### PR TITLE
Summary 调用的缓存复用

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,6 +165,24 @@ compact 现在按 **context 实际大小** 触发，而不是按消息条数：
 - 自动 compact 不应重复做 provider/API 初始化检查
 - 手动 compact 入口已移除，compact 仅在主循环内自动触发
 
+#### Summary 调用的缓存复用
+
+summary 调用（`run_summary_call`）采用与正常请求完全相同的前缀结构，以最大化 API 缓存命中：
+
+- **正常请求**：`system_prompt + tools + [全部消息]`
+- **summary 请求**：`system_prompt + tools + [dropped 消息] + [summary 指令消息]`
+
+由于 dropped 消息是 CONV_FILE 开头的行（通过 `head -n` 提取），它们与之前请求中的前缀完全一致。summary 请求只追加了一条 user 消息作为总结指令，不影响前缀匹配。thinking 参数也保持一致（使用 `THINKING_BUDGET`），确保 messages 层级缓存不被破坏。
+
+与旧方案（使用独立 system prompt 的单独请求，前缀完全不同，缓存命中率为零）相比，新方案利用已缓存的 `system + tools + dropped_messages` 前缀，仅末尾的 summary 指令消息产生少量 cache_creation，大幅降低 compact 成本。
+
+以 Claude Sonnet 为例（无缓存 $3.00/MTok，缓存命中 $0.30/MTok），典型场景：system+tools 20k tokens，dropped messages 30k tokens，summary 输出 500 tokens：
+
+- **旧方案**：50k tokens 全部无缓存 → 输入 $0.15 + 输出 $0.0075 = **$0.1575**
+- **新方案**：50k tokens 全部缓存命中 → 输入 $0.015 + 输出 $0.0075 = **$0.0225**
+
+单次 compact 节省约 **85.7%**，复杂任务中多次触发时累积效应显著。
+
 ### 3. Session Replay
 
 当恢复已有 session（`--continue` 或 `--session`）时，交互模式会回放最近 10 轮对话。
@@ -322,7 +340,7 @@ skills 当前优先读取：
 
 - `claude`：发送 `thinking.type=enabled, budget_tokens=N`
 - `openai`：发送 `reasoning_effort=high`（统一值，不按模型名分支）
-- summary 调用传 `0` 禁用 thinking，节省 token
+- summary 调用复用 `THINKING_BUDGET` 以保持 API 缓存前缀一致性
 
 消息转换时，assistant 的 `thinking` content block 会被跳过（OpenAI 格式不支持 thinking block）。
 

--- a/go/internal/app/app.go
+++ b/go/internal/app/app.go
@@ -1134,16 +1134,12 @@ func (rt *runtime) compactContextWindow(trigger string, force bool) (bool, error
 		dropped.Write(line)
 		dropped.WriteByte('\n')
 	}
-	currentSummary, err := os.ReadFile(rt.paths.Summary)
-	if err != nil && !os.IsNotExist(err) {
-		return false, err
-	}
 	if trigger == "manual" && rt.apiURL == "" {
 		if err := rt.applyProviderDefaults(); err != nil {
 			return false, err
 		}
 	}
-	summary, err := rt.runSummaryCall(string(currentSummary), strings.TrimRight(dropped.String(), "\n"))
+	summary, err := rt.runSummaryCall(allLines[:drop])
 	if err != nil {
 		return false, err
 	}
@@ -1169,19 +1165,33 @@ func (rt *runtime) compactContextWindow(trigger string, force bool) (bool, error
 	return true, nil
 }
 
-func (rt *runtime) runSummaryCall(currentSummary, droppedMessages string) (string, error) {
-	lines := []json.RawMessage{}
-	userPrompt := prompt.BuildCompactSummaryUserPrompt(currentSummary, droppedMessages)
+func (rt *runtime) runSummaryCall(droppedLines []json.RawMessage) (string, error) {
+	// Build messages: dropped conversation lines + summary instruction
+	// Uses same system prompt + tools + thinking as normal requests for cache reuse
+	summaryInstruction := "The conversation context above needs to be compacted. Summarize the key information from the messages above into a concise context summary. Update the existing summary snapshot using the messages above. Use exactly these fields:\nTask focus:\nLatest request:\nProgress:\nTool evidence:"
 	msg, err := json.Marshal(map[string]any{
 		"role":    "user",
-		"content": userPrompt,
+		"content": summaryInstruction,
 	})
 	if err != nil {
 		return "", err
 	}
+	lines := make([]json.RawMessage, 0, len(droppedLines)+1)
+	lines = append(lines, droppedLines...)
 	lines = append(lines, msg)
-	// Disable thinking for summary calls (not needed, saves tokens)
-	claudeBody, err := provider.BuildClaudeRequest(rt.cfg, lines, nil, prompt.BuildCompactSummarySystemPrompt(), rt.cfg.SummaryMaxTokens, 0)
+
+	systemPrompt, err := prompt.Builder{
+		Cwd:         rt.cwd,
+		Home:        rt.home,
+		Skills:      rt.cfg.Skills,
+		SummaryFile: rt.paths.Summary,
+		TodoFile:    rt.paths.Todo,
+		PlanFile:    rt.paths.Plan,
+	}.BuildSystemPrompt()
+	if err != nil {
+		return "", fmt.Errorf("build_system_prompt: %w", err)
+	}
+	claudeBody, err := provider.BuildClaudeRequest(rt.cfg, lines, rt.toolsJSON, systemPrompt, rt.cfg.SummaryMaxTokens, rt.cfg.ThinkingBudget)
 	if err != nil {
 		return "", fmt.Errorf("build_summary_request: %w", err)
 	}
@@ -1207,24 +1217,7 @@ func (rt *runtime) runSummaryCall(currentSummary, droppedMessages string) (strin
 		case protocol.TextEvent:
 			b.WriteString(e.Content)
 		case protocol.UsageEvent:
-			// Record compact usage to events and stats (matches bash run_summary_call)
-			compactEvt := map[string]any{
-				"type":                     "usage",
-				"input_tokens":             e.InputTokens,
-				"output_tokens":            e.OutputTokens,
-				"cache_read_input_tokens":  e.CacheReadInputTokens,
-				"cache_creation_input_tokens": e.CacheCreationInputTokens,
-				"kind":                     "compact",
-			}
-			_ = rt.appendEvent(compactEvt)
-			// Update stats for compact call
-			stats := rt.readStats()
-			stats["compact_request_count"] = statsFloat64(stats, "compact_request_count") + 1
-			stats["total_input_tokens"] = statsFloat64(stats, "total_input_tokens") + float64(e.InputTokens)
-			stats["total_output_tokens"] = statsFloat64(stats, "total_output_tokens") + float64(e.OutputTokens)
-			stats["total_cache_read_tokens"] = statsFloat64(stats, "total_cache_read_tokens") + float64(e.CacheReadInputTokens)
-			stats["total_cache_creation_tokens"] = statsFloat64(stats, "total_cache_creation_tokens") + float64(e.CacheCreationInputTokens)
-			rt.writeStats(stats)
+			_ = rt.recordUsage("compact", "compact_request_count", e)
 		case protocol.ErrorEvent:
 			return fmt.Errorf("%s", e.Message)
 		}
@@ -1278,6 +1271,27 @@ func (rt *runtime) incrementTurnCount() {
 	stats["current_turn_count"] = statsFloat64(stats, "current_turn_count") + 1
 	stats["last_updated"] = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 	rt.writeStats(stats)
+}
+
+// recordUsage logs a usage event and updates stats. Returns context token count.
+func (rt *runtime) recordUsage(kind, counterKey string, e protocol.UsageEvent) int {
+	evt := map[string]any{
+		"type":                        "usage",
+		"input_tokens":                e.InputTokens,
+		"output_tokens":               e.OutputTokens,
+		"cache_read_input_tokens":     e.CacheReadInputTokens,
+		"cache_creation_input_tokens": e.CacheCreationInputTokens,
+		"kind":                        kind,
+	}
+	_ = rt.appendEvent(evt)
+	stats := rt.readStats()
+	stats[counterKey] = statsFloat64(stats, counterKey) + 1
+	stats["total_input_tokens"] = statsFloat64(stats, "total_input_tokens") + float64(e.InputTokens)
+	stats["total_output_tokens"] = statsFloat64(stats, "total_output_tokens") + float64(e.OutputTokens)
+	stats["total_cache_read_tokens"] = statsFloat64(stats, "total_cache_read_tokens") + float64(e.CacheReadInputTokens)
+	stats["total_cache_creation_tokens"] = statsFloat64(stats, "total_cache_creation_tokens") + float64(e.CacheCreationInputTokens)
+	rt.writeStats(stats)
+	return e.InputTokens + e.OutputTokens + e.CacheReadInputTokens + e.CacheCreationInputTokens
 }
 
 // updateStatsFromLastUsage updates stats.json with last turn's usage (matches bash).

--- a/go/internal/app/app.go
+++ b/go/internal/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1128,11 +1127,6 @@ func (rt *runtime) compactContextWindow(trigger string, force bool) (bool, error
 	allLines, err := rt.conv.Lines()
 	if err != nil {
 		return false, err
-	}
-	var dropped bytes.Buffer
-	for _, line := range allLines[:drop] {
-		dropped.Write(line)
-		dropped.WriteByte('\n')
 	}
 	if trigger == "manual" && rt.apiURL == "" {
 		if err := rt.applyProviderDefaults(); err != nil {

--- a/go/internal/prompt/prompt.go
+++ b/go/internal/prompt/prompt.go
@@ -72,27 +72,6 @@ func (b Builder) BuildSystemPrompt() (string, error) {
 	return strings.Join(sections, "\n"), nil
 }
 
-func BuildCompactSummarySystemPrompt() string {
-	return strings.Join([]string{
-		"You are compressing conversation context for a lightweight coding agent.",
-		"",
-		"Return only plain text.",
-		"Do not include analysis, markdown fences, or extra commentary.",
-		"Update the existing summary snapshot using the dropped messages.",
-		"Keep the output concise and specific.",
-		"",
-		"Use exactly these fields:",
-		"Task focus:",
-		"Latest request:",
-		"Progress:",
-		"Tool evidence:",
-	}, "\n")
-}
-
-func BuildCompactSummaryUserPrompt(currentSummary, droppedMessages string) string {
-	return wrapSection("current-summary", currentSummary, "") + "\n\n" + wrapSection("dropped-messages", droppedMessages, "")
-}
-
 func appendSection(sections []string, tag, content, name string) []string {
 	if strings.TrimSpace(content) == "" {
 		return sections

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -788,20 +788,14 @@ impl Runtime {
         }
 
         let all = self.conv.lines()?;
-        let mut dropped = String::new();
-        for line in &all[..drop] {
-            dropped.push_str(&serde_json::to_string(line)?);
-            dropped.push('\n');
-        }
-
-        let current_summary = fs::read_to_string(&self.paths.summary).unwrap_or_default();
+        let dropped_lines = &all[..drop];
 
         if trigger == "manual" && self.api_url.is_empty() {
             apply_provider_defaults(&mut self.cfg)?;
             self.api_url = api_url(&self.cfg);
         }
 
-        let summary = self.run_summary_call(&current_summary, dropped.trim_end())?;
+        let summary = self.run_summary_call(dropped_lines)?;
         fs::write(&self.paths.summary, format!("{summary}\n"))?;
         self.conv.trim_keep_last(keep_lines)?;
 
@@ -822,22 +816,30 @@ impl Runtime {
         Ok(true)
     }
 
-    fn run_summary_call(
-        &mut self,
-        current_summary: &str,
-        dropped_messages: &str,
-    ) -> Result<String> {
-        let user_prompt =
-            prompt::build_compact_summary_user_prompt(current_summary, dropped_messages);
-        let messages = vec![json!({"role":"user","content":user_prompt})];
-        // Disable thinking for summary calls (not needed, saves tokens)
+    fn run_summary_call(&mut self, dropped_lines: &[Value]) -> Result<String> {
+        // Build messages: dropped conversation lines + summary instruction
+        // Uses same system prompt + tools + thinking as normal requests for cache reuse
+        let summary_instruction = "The conversation context above needs to be compacted. Summarize the key information from the messages above into a concise context summary. Update the existing summary snapshot using the messages above. Use exactly these fields:\nTask focus:\nLatest request:\nProgress:\nTool evidence:";
+        let mut messages: Vec<Value> = dropped_lines.to_vec();
+        messages.push(json!({"role":"user","content":summary_instruction}));
+
+        let system_prompt = prompt::Builder {
+            cwd: self.cwd.clone(),
+            home: self.home.clone(),
+            skills: self.cfg.skills.clone(),
+            summary_file: self.paths.summary.clone(),
+            todo_file: self.paths.todo.clone(),
+            plan_file: self.paths.plan.clone(),
+        }
+        .build_system_prompt()?;
+
         let claude_body = provider::build_claude_request(
             &self.cfg,
             &messages,
-            &[],
-            &prompt::build_compact_summary_system_prompt(),
+            &self.tools_json,
+            &system_prompt,
             self.cfg.summary_max_tokens,
-            0,
+            self.cfg.thinking_budget,
         )?;
         let body = self.transport.convert_body(&claude_body)?;
         let resp = match self.http.post(&self.api_url, &self.headers(), &body) {
@@ -853,34 +855,28 @@ impl Runtime {
         let mut parse_emit = |evt: Event| -> Result<()> {
             match evt {
                 Event::Text(TextEvent { content }) => out.push_str(&content),
-                Event::Usage(UsageEvent {
-                    input_tokens,
-                    output_tokens,
-                    cache_read_input_tokens,
-                    cache_creation_input_tokens,
-                }) => {
+                Event::Usage(usage) => {
                     // Record compact usage to events and stats (matches bash run_summary_call)
                     let compact_evt = json!({
                         "type":"usage",
-                        "input_tokens":input_tokens,
-                        "output_tokens":output_tokens,
-                        "cache_read_input_tokens":cache_read_input_tokens,
-                        "cache_creation_input_tokens":cache_creation_input_tokens,
+                        "input_tokens":usage.input_tokens,
+                        "output_tokens":usage.output_tokens,
+                        "cache_read_input_tokens":usage.cache_read_input_tokens,
+                        "cache_creation_input_tokens":usage.cache_creation_input_tokens,
                         "kind":"compact"
                     });
                     let _ = self.append_event(compact_evt);
-                    // Update stats for compact call
                     let mut stats = self.read_stats();
                     *stats.entry("compact_request_count".to_string()).or_insert(Value::Number(0.into())) =
                         Value::Number((stats_get_f64(&stats, "compact_request_count") as usize + 1).into());
                     *stats.entry("total_input_tokens".to_string()).or_insert(Value::Number(0.into())) =
-                        Value::Number((stats_get_f64(&stats, "total_input_tokens") as usize + input_tokens as usize).into());
+                        Value::Number((stats_get_f64(&stats, "total_input_tokens") as usize + usage.input_tokens as usize).into());
                     *stats.entry("total_output_tokens".to_string()).or_insert(Value::Number(0.into())) =
-                        Value::Number((stats_get_f64(&stats, "total_output_tokens") as usize + output_tokens as usize).into());
+                        Value::Number((stats_get_f64(&stats, "total_output_tokens") as usize + usage.output_tokens as usize).into());
                     *stats.entry("total_cache_read_tokens".to_string()).or_insert(Value::Number(0.into())) =
-                        Value::Number((stats_get_f64(&stats, "total_cache_read_tokens") as usize + cache_read_input_tokens as usize).into());
+                        Value::Number((stats_get_f64(&stats, "total_cache_read_tokens") as usize + usage.cache_read_input_tokens as usize).into());
                     *stats.entry("total_cache_creation_tokens".to_string()).or_insert(Value::Number(0.into())) =
-                        Value::Number((stats_get_f64(&stats, "total_cache_creation_tokens") as usize + cache_creation_input_tokens as usize).into());
+                        Value::Number((stats_get_f64(&stats, "total_cache_creation_tokens") as usize + usage.cache_creation_input_tokens as usize).into());
                     self.write_stats(&stats);
                 }
                 Event::Error(ErrorEvent { message }) => return Err(anyhow!(message)),

--- a/rust/src/prompt.rs
+++ b/rust/src/prompt.rs
@@ -181,31 +181,7 @@ impl Builder {
     }
 }
 
-pub fn build_compact_summary_system_prompt() -> String {
-    [
-        "You are compressing conversation context for a lightweight coding agent.",
-        "",
-        "Return only plain text.",
-        "Do not include analysis, markdown fences, or extra commentary.",
-        "Update the existing summary snapshot using the dropped messages.",
-        "Keep the output concise and specific.",
-        "",
-        "Use exactly these fields:",
-        "Task focus:",
-        "Latest request:",
-        "Progress:",
-        "Tool evidence:",
-    ]
-    .join("\n")
-}
 
-pub fn build_compact_summary_user_prompt(current_summary: &str, dropped_messages: &str) -> String {
-    format!(
-        "{}\n\n{}",
-        wrap_section("current-summary", current_summary, None),
-        wrap_section("dropped-messages", dropped_messages, None)
-    )
-}
 
 fn wrap_section(tag: &str, content: &str, name: Option<&str>) -> String {
     if content.trim().is_empty() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -580,23 +580,6 @@ build_instruction_files_section() {
     printf '%s' "${output%$'\n'}"
 }
 
-build_compact_summary_system_prompt() {
-    cat <<'EOF'
-You are compressing conversation context for a lightweight coding agent.
-
-Return only plain text.
-Do not include analysis, markdown fences, or extra commentary.
-Update the existing summary snapshot using the dropped messages.
-Keep the output concise and specific.
-
-Use exactly these fields:
-Task focus:
-Latest request:
-Progress:
-Tool evidence:
-EOF
-}
-
 build_tool_call_json_object() {
     local name="$1" id="$2" input="$3" type="${4:-tool_use}"
     if [[ "$type" == "tool_use" ]]; then
@@ -741,8 +724,7 @@ conv_add_user() {
 }
 
 conv_add_assistant() {
-    local text="$1" thinking="$2" calls="$3"
-    local content
+    local text="$1" thinking="$2" calls="$3" content
     content=$(build_assistant_content_json "$text" "$thinking" "$calls")
     printf '{"role":"assistant","content":%s}\n' "$content" >> "$CONV_FILE"
 }
@@ -767,7 +749,7 @@ conv_get_messages() {
         $first || result+=","
         first=false
         result+="$msg"
-    done < "$CONV_FILE"
+    done <<< "$1"
     printf '%s]' "$result"
 }
 
@@ -776,17 +758,6 @@ context_append_summary() {
     [[ -n "${CONTEXT_SUMMARY_FILE:-}" ]] || return 0
     [[ -n "$text" ]] || return 0
     printf '%s\n' "$text" > "$CONTEXT_SUMMARY_FILE"
-}
-
-build_compact_summary_user_prompt() {
-    local current_summary="$1" dropped_messages="$2" summary_section dropped_section
-    summary_section=$(wrap_section "current-summary" "$current_summary")
-    dropped_section=$(wrap_section "dropped-messages" "$dropped_messages")
-    cat <<EOF
-${summary_section}
-
-${dropped_section}
-EOF
 }
 
 compact_keep_lines() {
@@ -858,6 +829,22 @@ stats_get() {
     echo "${STATS_CACHE[$1]:-0}"
 }
 
+record_usage() {
+    # Args: kind counter_idx
+    # Reads REPLY_MESSAGE[1..4], logs event, updates stats.
+    # Returns context token count (input+output+cache_read+cache_creation).
+    local kind="$1" counter_idx="$2"
+    local _in="${REPLY_MESSAGE[1]:-0}" _out="${REPLY_MESSAGE[2]:-0}" _cr="${REPLY_MESSAGE[3]:-0}" _cc="${REPLY_MESSAGE[4]:-0}" _event
+    if [[ -n "$kind" ]]; then
+        _event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s,"kind":"%s"}' "$_in" "$_out" "$_cr" "$_cc" "$kind")
+    else
+        _event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s}' "$_in" "$_out" "$_cr" "$_cc")
+    fi
+    [[ "$LOG_EVENTS" != "false" ]] && session_append_line "$_event"
+    stats_inc ${counter_idx}=1 3=${_in} 4=${_out} 5=${_cr} 6=${_cc}
+    echo $(( _in + _out + _cr + _cc ))
+}
+
 stats_show_osc() {
     printf '\033]0;T:%s R:%s I:%s O:%s C:%s\007' \
         "${STATS_CACHE[0]:-0}" "${STATS_CACHE[1]:-0}" \
@@ -865,9 +852,8 @@ stats_show_osc() {
 }
 
 compact_context_window() {
-    local trigger="$1" force="${2:-false}"
-    local total_bytes total_lines keep_lines drop tmp_dropped dropped_messages current_summary prompt
-    local turn_triggered=false
+    local trigger="$1" force="${2:-false}" turn_triggered=false
+    local total_bytes total_lines keep_lines drop tmp_dropped dropped_messages summary_response
 
     if ! $force; then
         local ct=$(stats_get 7) tc=$(stats_get 0)
@@ -894,17 +880,13 @@ compact_context_window() {
     tmp_dropped=$(mktemp "${TMPDIR:-/tmp}/dropped.XXXXXX")
     head -n "$drop" "$CONV_FILE" > "$tmp_dropped"
     dropped_messages=$(<"$tmp_dropped")
-    current_summary=""
-    if [[ -n "${CONTEXT_SUMMARY_FILE:-}" && -s "$CONTEXT_SUMMARY_FILE" ]]; then
-        current_summary=$(<"$CONTEXT_SUMMARY_FILE")
-    fi
 
-    prompt=$(build_compact_summary_user_prompt "$current_summary" "$dropped_messages")
     if [[ "$trigger" == "manual" && -z "${API_URL:-}" ]]; then
         validate_config
     fi
-    summary_request="[{\"role\":\"user\",\"content\":\"$(json_escape "$prompt")\"}]"
-    summary_response=$(run_summary_call "$summary_request")
+    # Pass raw dropped messages to run_summary_call
+    # which builds a cache-friendly request (system+tools prefix reused)
+    summary_response=$(run_summary_call "$dropped_messages")
     context_append_summary "$summary_response"
 
     if (( keep_lines < total_lines )); then
@@ -1085,28 +1067,6 @@ dispatch_tool() {
     esac
 }
 
-# --- API Request Builders ---
-
-build_claude_request() {
-    local messages="$1" tools="$2" system_prompt="${3:-}" max_tokens="${4:-$MAX_TOKENS}" thinking_budget="${5:-0}"
-    local body
-    if [[ -z "$system_prompt" ]]; then
-        system_prompt=$(build_system_prompt)
-    fi
-
-    body="{\"model\":\"${MODEL}\",\"max_tokens\":${max_tokens},\"stream\":true"
-
-    if (( thinking_budget > 0 )); then
-        body+=",\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":${thinking_budget}}"
-    fi
-
-    [[ -n "$system_prompt" ]] && body+=",\"system\":\"$(json_escape "$system_prompt")\""
-    [[ -n "$tools" ]] && body+=",\"tools\":${tools}"
-
-    body+=",\"messages\":${messages}}"
-    printf '%s' "$body"
-}
-
 # --- API Calls (curl) ---
 
 _stream_curl() {
@@ -1116,39 +1076,37 @@ _stream_curl() {
 # --- LLM Call (internal) ---
 
 llm_call() {
-    local messages="$1"
-    local tools="$TOOL_DEF_JSON"
+    local messages="$1" max_tokens="${2:-$MAX_TOKENS}" thinking_budget="${3:-$THINKING_BUDGET}" body system_prompt
+    system_prompt=$(build_system_prompt)
 
-    local body
-    body=$(build_claude_request "$messages" "$tools")
+    body="{\"model\":\"${MODEL}\",\"max_tokens\":${max_tokens},\"stream\":true"
+
+    if (( thinking_budget > 0 )); then
+        body+=",\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":${thinking_budget}}"
+    fi
+
+    [[ -n "$system_prompt" ]] && body+=",\"system\":\"$(json_escape "$system_prompt")\""
+    [[ -n "$TOOL_DEF_JSON" ]] && body+=",\"tools\":${TOOL_DEF_JSON}"
+
+    body+=",\"messages\":${messages}}"
+
     $VERBOSE && printf '\033[90m[verbose] Request body (%dKB): %.200s...\033[0m\n' "$((${#body} / 1024))" "$body" >&2
 
     printf '%s' "$body" | body_convert | _stream_curl | sse_convert | sse_parse
 }
 
 run_summary_call() {
-    local messages="$1"
-    local body text
-    body=$(build_claude_request "$messages" "" "$(build_compact_summary_system_prompt)" "$SUMMARY_MAX_TOKENS" 0)
-    $VERBOSE && printf '\033[90m[verbose] Summary request body (%dKB): %.200s...\033[0m\n' "$((${#body} / 1024))" "$body" >&2
+    local dropped_messages="$1" text="" messages summary_instruction=$'The conversation context above needs to be compacted. Summarize the key information from the messages above into a concise context summary. Update the existing summary snapshot using the messages above. Use exactly these fields:\nTask focus:\nLatest request:\nProgress:\nTool evidence:'
+    messages=$(conv_get_messages "${dropped_messages}"$'\n'"{\"role\":\"user\",\"content\":\"$(json_escape "$summary_instruction")\"}")
 
-    text=""
     while read_message; do
         case "${REPLY_MESSAGE[0]}" in
             TEXT)  text+="${REPLY_MESSAGE[1]}" ;;
-            USAGE)
-                local _cu_in="${REPLY_MESSAGE[1]:-0}" _cu_out="${REPLY_MESSAGE[2]:-0}" _cu_cr="${REPLY_MESSAGE[3]:-0}" _cu_cc="${REPLY_MESSAGE[4]:-0}"
-                # Record compact usage to events and stats
-                if [[ -n "$_cu_in" ]]; then
-                    local _cu_event
-                    _cu_event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s,"kind":"compact"}' "$_cu_in" "$_cu_out" "$_cu_cr" "$_cu_cc")
-                    [[ "$LOG_EVENTS" != "false" ]] && session_append_line "$_cu_event"
-                    stats_inc 2=1 3=${_cu_in} 4=${_cu_out} 5=${_cu_cr} 6=${_cu_cc}
-                fi
-                ;;
+            THINKING) ;;
+            USAGE) record_usage "compact" 2 >/dev/null ;;
             ERROR) die "${REPLY_MESSAGE[1]}" ;;
         esac
-    done < <(printf '%s' "$body" | body_convert | _stream_curl | sse_convert | sse_parse)
+    done < <(llm_call "$messages" "$SUMMARY_MAX_TOKENS" "$THINKING_BUDGET")
 
     [[ -n "$text" ]] || die "Failed to generate context summary"
     printf '%s' "$text"
@@ -1164,10 +1122,8 @@ agent_loop_stream() {
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
 
-        local text="" thinking="" tool_calls="" stop="" loop_error=""
-        local tool_conv_results=""  # collected: id<TAB>json_escaped_result per line
-        local _usage_in="" _usage_out="" _usage_cr="" _usage_cc=""
-        [[ "$VERBOSE" == true ]] && printf '[debug] messages: %.500s...\n' "$(conv_get_messages)" >&2
+        local text="" thinking="" tool_calls="" stop="" loop_error="" tool_conv_results="" _ctx_tokens=""
+        [[ "$VERBOSE" == true ]] && printf '[debug] messages: %.500s...\n' "$(conv_get_messages "$(<"$CONV_FILE")")" >&2
         while read_message; do
             if interrupt_requested; then
                 stop="interrupted"
@@ -1178,7 +1134,7 @@ agent_loop_stream() {
             write_message "${REPLY_MESSAGE[@]}"
 
             case "${REPLY_MESSAGE[0]}" in
-                RETRY)    text="" thinking="" tool_calls="" tool_conv_results="" ;;
+                RETRY)    text="" thinking="" tool_calls="" tool_conv_results="" _ctx_tokens="" ;;
                 TEXT)     text+="${REPLY_MESSAGE[1]}" ;;
                 THINKING) thinking+="${REPLY_MESSAGE[1]}" ;;
                 TOOL_CALL)
@@ -1231,14 +1187,10 @@ agent_loop_stream() {
                 STOP)  stop="${REPLY_MESSAGE[1]}" ;;
                 ERROR) loop_error="${REPLY_MESSAGE[1]}"; stop="error"; break ;;
                 USAGE)
-                    # Capture usage data for stats and compact decisions
-                    _usage_in="${REPLY_MESSAGE[1]:-0}"
-                    _usage_out="${REPLY_MESSAGE[2]:-0}"
-                    _usage_cr="${REPLY_MESSAGE[3]:-0}"
-                    _usage_cc="${REPLY_MESSAGE[4]:-0}"
+                    _ctx_tokens=$(record_usage "agent" 1)
                     ;;
             esac
-        done < <(llm_call "$(conv_get_messages)")
+        done < <(llm_call "$(conv_get_messages "$(<"$CONV_FILE")")")
 
         # Fatal stop reasons exit immediately
         case "$stop" in
@@ -1254,16 +1206,8 @@ agent_loop_stream() {
             if [[ -n "$tool_conv_results" ]]; then
                 conv_add_tool_results "$tool_conv_results"
             fi
-            # Update stats with captured usage from this turn
-            if [[ -n "$_usage_in" ]]; then
-                # context = input + output + cache_read + cache_creation
-                local _ctx_tokens=$(( _usage_in + _usage_out + ${_usage_cr:-0} + ${_usage_cc:-0} ))
-                stats_inc \
-                    1=1 \
-                    3=${_usage_in} \
-                    4=${_usage_out} \
-                    5=${_usage_cr:-0} \
-                    6=${_usage_cc:-0}
+            # Update context tokens and trigger compact if needed
+            if [[ -n "$_ctx_tokens" && "$_ctx_tokens" -gt 0 ]]; then
                 stats_set 7=${_ctx_tokens}
                 compact_context_window "auto" false || true
             else
@@ -1284,8 +1228,7 @@ agent_loop_stream() {
 }
 
 agent_loop() {
-    local user_input="$1"
-    local had_error=false
+    local user_input="$1" had_error=false
     DISPLAY_LAST_CHAR=$'\n'
     PREV_WAS_THINKING=false
     start_esc_interrupt_listener  # stop/clear before start


### PR DESCRIPTION
summary 调用（`run_summary_call`）采用与正常请求完全相同的前缀结构，以最大化 API 缓存命中：

- **正常请求**：`system_prompt + tools + [全部消息]`
- **summary 请求**：`system_prompt + tools + [dropped 消息] + [summary 指令消息]`

由于 dropped 消息是 CONV_FILE 开头的行（通过 `head -n` 提取），它们与之前请求中的前缀完全一致。summary 请求只追加了一条 user 消息作为总结指令，不影响前缀匹配。thinking 参数也保持一致（使用 `THINKING_BUDGET`），确保 messages 层级缓存不被破坏。

与旧方案（使用独立 system prompt 的单独请求，前缀完全不同，缓存命中率为零）相比，新方案利用已缓存的 `system + tools + dropped_messages` 前缀，仅末尾的 summary 指令消息产生少量 cache_creation，大幅降低 compact 成本。

以 Claude Sonnet 为例（无缓存 $3.00/MTok，缓存命中 $0.30/MTok），典型场景：system+tools 20k tokens，dropped messages 30k tokens，summary 输出 500 tokens：

- **旧方案**：50k tokens 全部无缓存 → 输入 $0.15 + 输出 $0.0075 = **$0.1575**
- **新方案**：50k tokens 全部缓存命中 → 输入 $0.015 + 输出 $0.0075 = **$0.0225**

单次 compact 节省约 **85.7%**，复杂任务中多次触发时累积效应显著。