### PR TITLE
fix: compact_context_window 在每次 LLM 调用前触发，修复自动压缩永远不生效的 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **compact 触发时机**：`compact_context_window` 从循环外移到 `agent_loop_stream` 的每次 LLM 调用前，确保每轮都能基于最新的 `current_context_tokens` 做决策（`a5692d7`）
+- **usage → ctx_tokens 数据流**：`record_usage` 返回 `ctx_tokens` 但不再直接写入 `current_context_tokens`；改由主循环在流结束后显式写入，compact 始终使用上一轮的完整上下文大小（`a5692d7`）
+
 ### Fixed
 
 - **summary `record_usage` 参数丢失**：`run_summary_call` 中 `record_usage "compact" 2>/dev/null` 缺少空格，`2>/dev/null` 被解析为 stderr 重定向而非传参 `2`（counter_idx），导致 stats 文件损坏、PlanClear/compact 失败（`d281c54`）
+- **Edit 工具 `unbound variable`**：`tool_edit` 合并 local 声明时 `label="${path#/}"` 引用了同语句中尚未赋值的 `path`，在 `set -u` 模式下报错；改用 `${1#/}` 直接引用位置参数（`968f5b3`）
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ---
 
-## [Unreleased]
+## [2.4.0] - 2026-05-10
+
+### Added
+
+- **OSC 标题栏缓存命中率**：终端标题 `I` 后显示缓存命中率百分比，格式 `I:12,345(72%)`，bash/Go/Rust 三端同步（`fc4164a`）
 
 ### Changed
 
@@ -327,8 +331,9 @@
 
 ---
 
-[Unreleased]: https://github.com/lloydzhou/bash-agent/compare/v2.3.0...HEAD
-[2.3.0]: https://github.com/lloydzhou/bash-agent/compare/v2.2.1...v2.3.0
+[Unreleased]: https://github.com/lloydzhou/bash-agent/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/lloydzhou/bash-agent/compare/v2.3.1...v2.4.0
+[2.3.1]: https://github.com/lloydzhou/bash-agent/compare/v2.3.0...v2.3.1
 [2.2.1]: https://github.com/lloydzhou/bash-agent/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/lloydzhou/bash-agent/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/lloydzhou/bash-agent/compare/v2.0.2...v2.1.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,7 +146,28 @@ session 数据按当前项目目录归档：
 
 ### 2. Context / compact
 
-compact 使用**缓存对齐摘要（Cache-Aligned Summarization）**和基于缓存经济学的动态规划算法，在每一步计算压缩的净收益，自动决定是否压缩和保留多少消息。
+compact 使用**缓存对齐摘要（Cache-Aligned Summarization）**和基于缓存经济学的动态规划算法，自动决定是否压缩和保留多少消息。
+
+#### 触发时机
+
+compact 在 `agent_loop_stream()` 的 **每次 LLM 调用前** 执行：
+
+```text
+while turn < MAX_TURNS:
+    ① compact_context_window auto     ← 使用上一轮 USAGE 记录的 ctx_tokens
+    ② llm_call()
+    ③ 流式处理：TEXT / THINKING / TOOL_CALL / USAGE / STOP
+    ④ 持久化 assistant + tool_results
+    ⑤ stats_set current_context_tokens = _ctx_tokens   ← 供下一轮 compact 使用
+```
+
+数据流时序：
+
+1. LLM 流中收到 `USAGE` 事件 → `record_usage()` 解析 input_tokens 并返回 → 赋值给 `_ctx_tokens`
+2. 流结束后，`_ctx_tokens > 0` 时写入 `stats.current_context_tokens`
+3. **下一轮循环迭代**开头的 `compact_context_window` 读取该值做 DP 决策和安全阀判断
+
+这意味着首次 LLM 调用前 `current_context_tokens` 为 0，compact 不会触发（DP 和安全阀都跳过）。这是正确行为——首轮没有历史需要压缩。
 
 #### 决策公式
 
@@ -167,14 +188,16 @@ $$
 
 Plan 相关的两个工具都会跳过 DP 决策，以 `DP_MIN_KEEP_RATIO`（默认 0.3）计算 turn-aligned 保留行数，执行缓存对齐摘要 + 裁切：
 
-- **`PlanConfirm`** — 用户确认 plan 时调用：将 `plan.draft` 移至 `plan.md`，触发 force compact
-- **`PlanClear`** — plan 执行完毕时调用：清空 `plan.md`，触发 force compact
+- **`PlanConfirm`** — 用户确认 plan 时调用：先 force compact（复用旧缓存前缀），再将 `plan.draft` 移至 `plan.md`（此时才触发缓存失效），总共只产生一次冷启动
+- **`PlanClear`** — plan 执行完毕时调用：先 force compact，再清空 `plan.md`
 
-三步：
+执行顺序（以 `PlanConfirm` 为例）：
 
 1. **`compact_turn_keep()`** — 扫描 conversation 中的 user 消息（匹配 `{"role":"user","content":"`），从末尾按 ratio 保留完整 turn
-2. **`compact_context_window(force=true)`** — 用 turn keep 结果执行缓存对齐摘要 + 裁切
-3. **`PlanConfirm`**：`mv plan.draft → plan.md` + 重建空 draft；**`PlanClear`**：`printf '' > plan.md`
+2. **`compact_context_window(plan_confirm)`** — 用 turn keep 结果执行缓存对齐摘要 + 裁切（此时 system prompt 前缀未变，cache 命中）
+3. **`mv plan.draft → plan.md`** + 重建空 draft（compact 后才移动，确保 compact 阶段前缀缓存命中）
+
+关键：compact 在 mv 之前执行。因为 compact 的 summary 调用需要前缀缓存命中来降低成本，如果先 mv 导致 `plan.md` 内容变化、system prompt 前缀改变，compact 就会失去缓存对齐的优势。
 
 Safety valve 也改用 `compact_turn_keep()` 实现 turn 对齐（替换原简单比例计算），确保 tool_result 不会被误算为 user turn。
 
@@ -277,7 +300,7 @@ system prompt 首尾都是语言约束，中间内容无论多长、是否变化
 
 `using-your-tools` 指导模型如何正确使用各内置 tool。
 
-`plan-lifecycle-guidance` 为复杂多步任务提供两阶段规划工作流：规划阶段写入 `plan.draft`（不进入 system prompt，不影响缓存）→ 用户确认后通过 `PlanConfirm` 工具将 draft 移至 `plan.md`（触发 compact，乘缓存失效之机回收上下文窗口）→ TodoWrite checklist → 执行 → `PlanClear` 清空 plan 并 compact。由 `PLAN_DRAFT_FILE` 和 `PLAN_FILE` 环境变量标识路径。`PlanClear` 后，system prompt 中的 plan section 会消失。
+`plan-lifecycle-guidance` 为复杂多步任务提供两阶段规划工作流：规划阶段写入 `plan.draft`（不进入 system prompt，不影响缓存）→ 用户确认后通过 `PlanConfirm` 工具先执行 force compact（复用旧前缀缓存）再将 draft 移至 `plan.md`（此时缓存才失效，正好 compact 已回收了上下文窗口）→ TodoWrite checklist → 执行 → `PlanClear` 清空 plan 并 compact。由 `PLAN_DRAFT_FILE` 和 `PLAN_FILE` 环境变量标识路径。`PlanClear` 后，system prompt 中的 plan section 会消失。
 
 ### 4. Skills
 
@@ -357,8 +380,8 @@ skills 当前优先读取：
 - `Glob`
 - `Grep`
 - `TodoWrite`
-- `PlanConfirm` — 确认 plan draft，将 draft 移至 plan.md 并触发 force compact（乘缓存失效之机回收上下文窗口）
-- `PlanClear` — 清空 plan 并触发 force compact（跳过 DP 决策，保留最后 `DP_MIN_KEEP_RATIO` 比例的完整 turn）
+- `PlanConfirm` — 确认 plan draft：先 force compact（复用旧缓存前缀），再 mv draft → plan.md（触发缓存失效），总共一次冷启动
+- `PlanClear` — 清空 plan：先 force compact（跳过 DP 决策，保留最后 `DP_MIN_KEEP_RATIO` 比例的完整 turn），再清空 plan.md
 - `Skill`
 - `WebSearch`
 - `WebFetch`
@@ -491,6 +514,18 @@ awk 端使用 `emit1()`/`emit()`/`emit_flush()` 三个函数构建消息；bash 
 - `input_tokens`
 - `output_tokens`
 - `cache_input_tokens`
+
+`record_usage(key, counter, verbose)` 内部处理流程：
+
+1. 从 RESP-like `USAGE` 事件中提取 `input_tokens`
+2. 计算 `ctx_tokens = input_tokens`（含 cache tokens 的原始值，直接反映当前请求的上下文窗口大小）
+3. 累加到 `total_input_tokens` / `total_output_tokens`
+4. 递增 `counter`（如 `agent_request_count` / `compact_request_count`）
+5. 返回 `ctx_tokens` 字符串（供调用方缓存到 `_ctx_tokens`，循环末尾写入 `stats.current_context_tokens`）
+
+注意：`record_usage` 只更新累加字段，不直接写入 `current_context_tokens`。该值由 `agent_loop_stream` 在流结束后显式设置，确保 compact 决策使用的是**上一轮**的完整上下文大小。
+
+`context_update` 事件：当 `compact_context_window` 实际执行压缩时，通过 `write_message "CONTEXT_UPDATE" "compact" "auto"` 发出，通知 display 层上下文已被压缩。
 
 ## 当前重要实现细节
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,6 +141,8 @@ session 数据按当前项目目录归档：
   - 规划阶段的工作草稿，确认后通过 `PlanConfirm` 工具移至 `plan.md`
 - `stats.json`
   - session 统计数据（LLM 调用次数、输入 token 总量、compact 次数、当前 turn 等）
+  - bash 版**不使用内存缓存**，每次 `stats_inc`/`stats_set`/`stats_get` 直接通过 `stats.awk action=update` 对文件做 read-modify-write。原因是 bash 的 `agent_loop_stream` 运行在 `<(…)` 子进程中，`$()` 命令替换会创建额外子 shell，bash 没有进程间共享变量的 IPC 机制——内存缓存在任何子进程场景下都无法同步，会导致数据丢失/归零。
+  - Go/Rust 版使用全局 `StatsCache` 结构体是合理的：它们运行在单进程多 goroutine/task 模型下，共享内存天然可用，配合读写锁即可安全并发。
 
 ### 2. Context / compact
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,16 +9,16 @@
 
 ### 1. 进程隔离输入与 Agent 循环
 
-**适用范围**：bash / go / rust
+**适用范围**：go / rust
 
 **现状**：`interactive_mode` 中读取输入和 `agent_loop` 在同一个主进程，agent 执行工具或等待 API 时整个进程阻塞，无法接收新输入。
 
 **方案**：
-- **bash**：用 `coproc` 将输入监听放到独立进程，通过管道与主循环通信。
+- ~~**bash**：用 `coproc` 将输入监听放到独立进程，通过管道与主循环通信。~~ 放弃 — bash 3.2 不支持 coproc；named pipe 替代方案在多行输入、scroll region 溢出、readline 兼容性等方面问题多，得不偿失。
 - **go**：独立 goroutine 读取 stdin，通过 channel 将输入发送到 agent 主循环。
 - **rust**：`tokio::spawn` 独立任务读取 stdin，通过 `mpsc` channel 通信。
 
-**状态**：⬚ 待开始
+**状态**：❌ bash 放弃；go/rust ⬚ 待开始
 
 ---
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -77,6 +77,7 @@ session 统计数据，JSON 格式，包含以下字段：
 
 用途：
 - DP compact 算法计算预期剩余步数和成本
+- `current_context_tokens` 在每次 LLM 调用结束后由主循环更新，供下一轮 compact 决策使用
 - 追踪 session 的 token 使用情况
 - 交互模式标题栏显示统计信息
 

--- a/go/internal/app/app.go
+++ b/go/internal/app/app.go
@@ -1327,9 +1327,14 @@ func (rt *runtime) updateTermTitle() {
 	ai := int(statsFloat64(stats, "total_input_tokens"))
 	ao := int(statsFloat64(stats, "total_output_tokens"))
 	ctx := int(statsFloat64(stats, "current_context_tokens"))
-	_, _ = fmt.Fprintf(rt.stderr, "\033]0;%s T:%s R:%s I:%s O:%s C:%s\007",
+	cr := int(statsFloat64(stats, "total_cache_read_tokens"))
+	cachePct := "—"
+	if ai > 0 {
+		cachePct = fmt.Sprintf("%d%%", cr*100/ai)
+	}
+	_, _ = fmt.Fprintf(rt.stderr, "\033]0;%s T:%s R:%s I:%s(%s) O:%s C:%s\007",
 		rt.cfg.Model,
-		fmtNum(tc), fmtNum(ar), fmtNum(ai), fmtNum(ao), fmtNum(ctx))
+		fmtNum(tc), fmtNum(ar), fmtNum(ai), cachePct, fmtNum(ao), fmtNum(ctx))
 }
 
 func (rt *runtime) buildAssistantEvent(text string, calls []protocol.ToolCallEvent) map[string]any {

--- a/go/internal/app/app.go
+++ b/go/internal/app/app.go
@@ -545,6 +545,10 @@ func (rt *runtime) agentLoopStream(userInput string) error {
 	state := displayState{lastChar: "\n"}
 	for turn < rt.cfg.MaxTurns {
 		turn++
+
+		// Compact before each LLM call: uses ctx_tokens from previous call's USAGE
+		rt.compactContextWindow("auto")
+
 		text := ""
 		thinking := ""
 		var calls []protocol.ToolCallEvent
@@ -602,7 +606,7 @@ func (rt *runtime) agentLoopStream(userInput string) error {
 				output = tools.FormatToolResult(output, rt.cfg.ToolResultMaxBytes)
 
 				if e.Name == "PlanClear" {
-					_, _ = rt.compactContextWindow("plan_clear")
+					rt.compactContextWindow("plan_clear")
 					_ = os.WriteFile(rt.paths.Plan, []byte{}, 0o644)
 					output = "Plan cleared."
 				}
@@ -611,7 +615,7 @@ func (rt *runtime) agentLoopStream(userInput string) error {
 					// 先 compact 再写 plan：compact 复用旧缓存前缀，写 plan 后才触发缓存失效——总共一次冷启动
 					draftData, err := os.ReadFile(rt.paths.PlanDraft)
 					if err == nil && len(draftData) > 0 {
-						_, _ = rt.compactContextWindow("plan_confirm")
+						rt.compactContextWindow("plan_confirm")
 						_ = os.WriteFile(rt.paths.Plan, draftData, 0o644)
 						_ = os.WriteFile(rt.paths.PlanDraft, []byte{}, 0o644) // Reset draft
 						output = "Plan confirmed and locked in."
@@ -704,11 +708,10 @@ func (rt *runtime) agentLoopStream(userInput string) error {
 				}
 				// Note: granular tool_result events already written by displayEvent inline
 			}
-			// Update stats with captured usage from this turn (matches bash agent_loop_stream)
+			// Update context tokens from USAGE (used by next turn's compact check)
 			if rt.lastInputTokens > 0 {
 				rt.updateStatsFromLastUsage()
 			}
-			_, _ = rt.compactContextWindow("auto")
 			// tool_use/tool_calls → loop continues; anything else → break
 			if stop != "tool_use" && stop != "tool_calls" {
 				return nil
@@ -932,6 +935,7 @@ func (rt *runtime) displayEvent(state *displayState, evt any) error {
 			"output_tokens":               e.OutputTokens,
 			"cache_read_input_tokens":     e.CacheReadInputTokens,
 			"cache_creation_input_tokens": e.CacheCreationInputTokens,
+			"kind":                        "agent",
 		}
 		if err := rt.emitAndAppendEvent(usageEvt); err != nil {
 			return err
@@ -1089,11 +1093,7 @@ func (rt *runtime) compactContextWindow(trigger string) (bool, error) {
 		stats["last_updated"] = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 		rt.writeStats(stats)
 	}
-	if rt.isStreamJSONMode() {
-		_ = rt.emitStream(map[string]any{"type": "context_update", "kind": "compact", "trigger": trigger})
-	} else {
-		rt.info("Context compacted automatically.")
-	}
+	_ = rt.emitContextUpdate(trigger)
 	return true, nil
 }
 
@@ -1350,6 +1350,17 @@ func (rt *runtime) buildAssistantEvent(text string, calls []protocol.ToolCallEve
 
 func (rt *runtime) isStreamJSONMode() bool {
 	return rt.cfg.OutputFormat == config.OutputStreamJSON
+}
+
+// emitContextUpdate emits a context_update event (stream-json) or prints info (human mode).
+func (rt *runtime) emitContextUpdate(trigger string) error {
+	evt := map[string]any{"type": "context_update", "kind": "compact", "trigger": trigger}
+	_ = rt.appendEvent(evt)
+	if rt.isStreamJSONMode() {
+		return rt.emitStream(evt)
+	}
+	rt.info("Context compacted (%s).", trigger)
+	return nil
 }
 
 func (rt *runtime) emitStream(v any) error {

--- a/go/internal/app/app.go
+++ b/go/internal/app/app.go
@@ -608,12 +608,12 @@ func (rt *runtime) agentLoopStream(userInput string) error {
 				}
 
 				if e.Name == "PlanConfirm" {
-					// Move draft → plan, trigger compact (plan in system prompt invalidates cache, so compact at same time)
+					// 先 compact 再写 plan：compact 复用旧缓存前缀，写 plan 后才触发缓存失效——总共一次冷启动
 					draftData, err := os.ReadFile(rt.paths.PlanDraft)
 					if err == nil && len(draftData) > 0 {
+						_, _ = rt.compactContextWindow("plan_confirm")
 						_ = os.WriteFile(rt.paths.Plan, draftData, 0o644)
 						_ = os.WriteFile(rt.paths.PlanDraft, []byte{}, 0o644) // Reset draft
-						_, _ = rt.compactContextWindow("plan_confirm")
 						output = "Plan confirmed and locked in."
 					} else {
 						output = "Error: no plan draft found to confirm."

--- a/go/internal/conversation/compact_dp.go
+++ b/go/internal/conversation/compact_dp.go
@@ -3,7 +3,6 @@ package conversation
 import (
 	"encoding/json"
 	"math"
-	"strings"
 )
 
 // DPCompactConfig holds the parameters for the DP compact decision.
@@ -49,14 +48,20 @@ func (s Store) CompactTurnKeep(minKeepRatio float64) (int, error) {
 		return 0, nil
 	}
 
-	// Detect user role: match {"role":"user","content":"... (excludes tool_result lines)
+	// Detect user role via JSON field access (map key order is not guaranteed by Go's json.Marshal).
+	// A "user turn" has role="user" and content is a plain string (excludes tool_result lines).
 	roleUser := make([]bool, len(lines))
 	totalTurns := 0
 	for i, line := range lines {
-		s := string(line)
-		if strings.HasPrefix(s, `{"role":"user","content":"`) {
-			roleUser[i] = true
-			totalTurns++
+		var msg struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(line, &msg); err == nil {
+			if msg.Role == "user" && len(msg.Content) > 0 && msg.Content[0] == '"' {
+				roleUser[i] = true
+				totalTurns++
+			}
 		}
 	}
 
@@ -76,8 +81,8 @@ func (s Store) CompactTurnKeep(minKeepRatio float64) (int, error) {
 			found++
 		}
 	}
-	if keep < 3 {
-		return len(lines), nil
+	if keep == 0 {
+		return 0, nil
 	}
 	return keep, nil
 }

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -307,6 +307,10 @@ impl Runtime {
 
             while turn < self.cfg.max_turns {
                 turn += 1;
+
+                // Compact before each LLM call: uses ctx_tokens from previous call's USAGE
+                let _ = self.compact_context_window("auto");
+
                 let mut text = String::new();
                 let mut thinking = String::new();
                 let mut calls: Vec<ToolCallEvent> = Vec::new();
@@ -472,11 +476,10 @@ impl Runtime {
                         self.conv.add_tool_results(&tool_results)?;
                         // Note: granular tool_result events already written by display_event via emit_and_append_event
                     }
-                    // Update stats with captured usage from this turn (matches bash)
+                    // Update context tokens from USAGE (used by next turn's compact check)
                     if self.last_input_tokens > 0 {
                         self.update_stats_from_usage();
                     }
-                    let _ = self.compact_context_window("auto");
                     // tool_use/tool_calls → loop continues; anything else → break
                     if stop.as_str() != "tool_use" && stop.as_str() != "tool_calls" {
                         return Ok(());
@@ -582,7 +585,8 @@ impl Runtime {
                     "input_tokens":input_tokens,
                     "output_tokens":output_tokens,
                     "cache_read_input_tokens":cache_read_input_tokens,
-                    "cache_creation_input_tokens":cache_creation_input_tokens
+                    "cache_creation_input_tokens":cache_creation_input_tokens,
+                    "kind":"agent"
                 }))?;
                 // No human display for usage events
                 // context = input + output + cache_read + cache_creation
@@ -771,6 +775,7 @@ impl Runtime {
         }
 
         let k = match keep_lines {
+            Some(0) => return Ok(false),
             Some(v) => v,
             None => return Ok(false),
         };
@@ -799,12 +804,7 @@ impl Runtime {
             self.write_stats(&stats);
         }
 
-        if self.is_stream_json_mode() {
-            let _ = self
-                .emit_stream(json!({"type":"context_update","kind":"compact","trigger": trigger}));
-        } else {
-            self.info("Context compacted automatically.");
-        }
+        self.emit_context_update(trigger)?;
         Ok(true)
     }
 
@@ -1091,6 +1091,18 @@ impl Runtime {
 
     fn is_stream_json_mode(&self) -> bool {
         self.cfg.output_format == OutputFormat::StreamJson
+    }
+
+    /// Emit a context_update event: write to events.jsonl + emit to stream-json or print info.
+    fn emit_context_update(&self, trigger: &str) -> Result<()> {
+        let evt = json!({"type":"context_update","kind":"compact","trigger":trigger});
+        self.append_event(evt.clone())?;
+        if self.is_stream_json_mode() {
+            self.emit_stream(evt)?;
+        } else {
+            self.info(&format!("Context compacted ({}).", trigger));
+        }
+        Ok(())
     }
 
     fn emit_stream(&self, value: Value) -> Result<()> {

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -1077,12 +1077,19 @@ impl Runtime {
         let ai = stats_get_f64(&stats, "total_input_tokens") as usize;
         let ao = stats_get_f64(&stats, "total_output_tokens") as usize;
         let ctx = stats_get_f64(&stats, "current_context_tokens") as usize;
+        let cr = stats_get_f64(&stats, "total_cache_read_tokens") as usize;
+        let cache_pct = if ai > 0 {
+            format!("{}%", cr * 100 / ai)
+        } else {
+            "—".to_string()
+        };
         eprint!(
-            "\x1b]0;{} T:{} R:{} I:{} O:{} C:{}\x07",
+            "\x1b]0;{} T:{} R:{} I:{}({}) O:{} C:{}\x07",
             self.cfg.model,
             Self::fmt_num(tc),
             Self::fmt_num(ar),
             Self::fmt_num(ai),
+            cache_pct,
             Self::fmt_num(ao),
             Self::fmt_num(ctx)
         );

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -378,12 +378,12 @@ impl Runtime {
                             }
 
                             if call.name == "PlanConfirm" {
-                                // Move draft → plan, trigger compact
+                                // 先 compact 再写 plan：compact 复用旧缓存前缀，写 plan 后才触发缓存失效——总共一次冷启动
                                 match fs::read(&self.paths.plan_draft) {
                                     Ok(data) if !data.is_empty() => {
+                                        let _ = self.compact_context_window("plan_confirm");
                                         let _ = fs::write(&self.paths.plan, &data);
                                         let _ = fs::write(&self.paths.plan_draft, "");
-                                        let _ = self.compact_context_window("plan_confirm");
                                         output = "Plan confirmed and locked in.".to_string();
                                     }
                                     _ => {

--- a/rust/src/compact_dp.rs
+++ b/rust/src/compact_dp.rs
@@ -42,19 +42,16 @@ pub fn compact_turn_keep(lines: &[Value], min_keep_ratio: f64) -> Option<usize> 
         return None;
     }
 
-    // Detect user role: match {"role":"user","content":"... (excludes tool_result lines)
+    // Detect user role via JSON object field access (field order is not guaranteed by serde).
+    // A "user turn" has role="user" and content is a plain string (excludes tool_result lines).
     let mut is_user = Vec::with_capacity(lines.len());
     let mut total_turns = 0usize;
     for line in lines {
-        if let Some(s) = line.as_str() {
-            if s.starts_with("{\"role\":\"user\",\"content\":\"") {
-                is_user.push(true);
-                total_turns += 1;
-            } else {
-                is_user.push(false);
-            }
-        } else {
-            is_user.push(false);
+        let user = line.get("role").and_then(Value::as_str) == Some("user")
+            && line.get("content").is_some_and(|c| c.is_string());
+        is_user.push(user);
+        if user {
+            total_turns += 1;
         }
     }
 
@@ -74,8 +71,8 @@ pub fn compact_turn_keep(lines: &[Value], min_keep_ratio: f64) -> Option<usize> 
             found += 1;
         }
     }
-    if keep < 3 {
-        return Some(lines.len());
+    if keep == 0 {
+        return None;
     }
     Some(keep)
 }
@@ -211,4 +208,8 @@ pub fn compact_dp_decision(
         adj = 1;
     }
     Some(adj)
+}
+
+#[cfg(test)]
+mod order_test {
 }

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -807,7 +807,7 @@ compact_dp_decision() {
 compact_turn_keep() {
     awk -v r="$DP_MIN_KEEP_RATIO" '
     BEGIN { target_turns = 0 }
-    { role[NR] = ($0 ~ /^\{"role":"user","content":"/) ? "user" : "other" }
+    { role[NR] = ($0 ~ /"role":"user"/ && $0 !~ /"content":\[/) ? "user" : "other" }
     END {
         if (NR == 0) { print 0; exit }
         for (i = 1; i <= NR; i++) if (role[i] == "user") total_turns++
@@ -816,7 +816,7 @@ compact_turn_keep() {
         if (target > total_turns) target = total_turns
         keep = 0; found = 0
         for (i = NR; i >= 1 && found < target; i--) { keep++; if (role[i] == "user") found++ }
-        if (keep < 3) { print NR; exit }
+        if (keep == 0) { print 0; exit }
         print keep
     }' "$CONV_FILE"
 }
@@ -840,8 +840,8 @@ compact_context_window() {
         fi
     fi
 
-    # 统一 guard：keep >= total 时只有 plan_clear/plan_confirm 继续
-    (( keep_lines < total_lines )) || [[ "$trigger" == "plan_clear" || "$trigger" == "plan_confirm" ]] || return 1
+    # 统一 guard：keep >= total 或 keep==0 时只有 plan_clear/plan_confirm 继续
+    (( keep_lines > 0 && keep_lines < total_lines )) || [[ "$trigger" == "plan_clear" || "$trigger" == "plan_confirm" ]] || return 1
     drop=$(( total_lines - keep_lines ))
 
     tmp_dropped=$(mktemp "${TMPDIR:-/tmp}/dropped.XXXXXX")
@@ -859,7 +859,7 @@ compact_context_window() {
 
     rm -f "$tmp_dropped"
     local remaining_turns
-    remaining_turns=$(grep -c '"role":"user","content":"' "$CONV_FILE" 2>/dev/null || echo 0)
+    remaining_turns=$(awk '/"role":"user"/ && ! /"content":\[/{n++} END{print n+0}' "$CONV_FILE" 2>/dev/null)
     stats_set current_turn_count=$remaining_turns
     return 0
 }
@@ -1085,11 +1085,11 @@ agent_loop_stream() {
     local user_input="$1" turn=0
     conv_add_user "$user_input"
 
-    # Compact before first LLM call: uses ctx_tokens from previous turn's USAGE
-    compact_context_window auto && write_message "CONTEXT_UPDATE" "compact" "auto"
-
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
+
+        # Compact before each LLM call: uses ctx_tokens from previous call's USAGE
+        compact_context_window auto && write_message "CONTEXT_UPDATE" "compact" "auto"
 
         local text="" thinking="" tool_calls="" stop="" loop_error="" tool_conv_results="" _ctx_tokens=""
         [[ "$VERBOSE" == true ]] && printf '[debug] messages: %.500s...\n' "$(conv_get_messages "$(<"$CONV_FILE")")" >&2

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -777,16 +777,18 @@ record_usage() {
 }
 
 stats_show_osc() {
-    local _dump t r i o c
+    local _dump t r i o c cr
     _dump=$(awk_run -v action=dump -f "$AWK_DIR/stats.awk" "$STATS_FILE" 2>/dev/null)
     t=$(echo "$_dump" | awk -F'\t' '$1=="current_turn_count"{print $2}')
     r=$(echo "$_dump" | awk -F'\t' '$1=="agent_request_count"{print $2}')
     i=$(echo "$_dump" | awk -F'\t' '$1=="total_input_tokens"{print $2}')
     o=$(echo "$_dump" | awk -F'\t' '$1=="total_output_tokens"{print $2}')
     c=$(echo "$_dump" | awk -F'\t' '$1=="current_context_tokens"{print $2}')
-    awk -v m="$MODEL" -v t="${t:-0}" -v r="${r:-0}" -v i="${i:-0}" -v o="${o:-0}" -v c="${c:-0}" '
+    cr=$(echo "$_dump" | awk -F'\t' '$1=="total_cache_read_tokens"{print $2}')
+    awk -v m="$MODEL" -v t="${t:-0}" -v r="${r:-0}" -v i="${i:-0}" -v o="${o:-0}" -v c="${c:-0}" -v cr="${cr:-0}" '
     function f(n,s,r){s=sprintf("%d",n);while(length(s)>3){r=","substr(s,length(s)-2)r;s=substr(s,1,length(s)-3)}return s r}
-    BEGIN{printf "\033]0;%s T:%s R:%s I:%s O:%s C:%s\007",m,f(t),f(r),f(i),f(o),f(c) > "/dev/stderr"}'
+    function pct(num,den){if(den+0>0)return sprintf("%.0f%%",num/den*100);return "—"}
+    BEGIN{printf "\033]0;%s T:%s R:%s I:%s(%s) O:%s C:%s\007",m,f(t),f(r),f(i),pct(cr,i),f(o),f(c) > "/dev/stderr"}'
 }
 
 # --- Dynamic Planning Compact Decision ---

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -292,9 +292,7 @@ tool_file_summary() {
     printf '%s(%s) [%s lines, %s bytes]' "$kind" "$path" "$lines" "$bytes"
 }
 
-is_stream_json_mode() {
-    [[ "$OUTPUT_FORMAT" == "stream-json" ]]
-}
+is_stream_json_mode() { [[ "$OUTPUT_FORMAT" == "stream-json" ]]; }
 
 wrap_section() {
     local tag="$1" content="$2" name="${3:-}"
@@ -357,8 +355,9 @@ msg_to_stream_event() {
                 "$(json_escape "${REPLY_MESSAGE[2]}")" \
                 "$(json_escape "${REPLY_MESSAGE[3]}")"
             ;;
-        USAGE)       printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s}' "${REPLY_MESSAGE[1]:-0}" "${REPLY_MESSAGE[2]:-0}" "${REPLY_MESSAGE[3]:-0}" "${REPLY_MESSAGE[4]:-0}" ;;
+        USAGE)       printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s,"kind":"agent"}' "${REPLY_MESSAGE[1]:-0}" "${REPLY_MESSAGE[2]:-0}" "${REPLY_MESSAGE[3]:-0}" "${REPLY_MESSAGE[4]:-0}" ;;
         STOP)        printf '{"type":"stop","reason":"%s"}' "$(json_escape "${REPLY_MESSAGE[1]}")" ;;
+        CONTEXT_UPDATE) printf '{"type":"context_update","kind":"%s","trigger":"%s"}' "$(json_escape "${REPLY_MESSAGE[1]}")" "$(json_escape "${REPLY_MESSAGE[2]}")" ;;
         ERROR)       printf '{"type":"error","message":"%s"}' "$(json_escape "${REPLY_MESSAGE[1]}")" ;;
         RETRY)       printf '{"type":"retry"}' ;;
         *)           return 1 ;;
@@ -430,6 +429,9 @@ display_event() {
             DISPLAY_LAST_CHAR=$'\n'
             ;;
         STOP)  display_ensure_newline ;;
+        CONTEXT_UPDATE)
+            display_ensure_newline; printf '\033[36mContext compacted (%s).\033[0m\n' "${REPLY_MESSAGE[2]}"; DISPLAY_LAST_CHAR=$'\n'
+            ;;
         ERROR) display_ensure_newline; printf '\033[31mError: %s\033[0m\n' "${REPLY_MESSAGE[1]}" >&2 ;;
         *)     return 0 ;;
     esac
@@ -773,17 +775,16 @@ stats_get() {
 }
 
 record_usage() {
-    # Args: kind counter_key
-    # Reads REPLY_MESSAGE[1..4], logs event, updates stats.
+    # Args: kind counter_key [write_event]
+    # Reads REPLY_MESSAGE[1..4], updates stats, optionally logs event.
     # Returns context token count (input+output+cache_read+cache_creation).
-    local kind="$1" counter_key="$2"
-    local _in="${REPLY_MESSAGE[1]:-0}" _out="${REPLY_MESSAGE[2]:-0}" _cr="${REPLY_MESSAGE[3]:-0}" _cc="${REPLY_MESSAGE[4]:-0}" _event
-    if [[ -n "$kind" ]]; then
+    local kind="$1" counter_key="$2" write_event="${3:-true}"
+    local _in="${REPLY_MESSAGE[1]:-0}" _out="${REPLY_MESSAGE[2]:-0}" _cr="${REPLY_MESSAGE[3]:-0}" _cc="${REPLY_MESSAGE[4]:-0}"
+    if [[ "$write_event" == "true" ]]; then
+        local _event
         _event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s,"kind":"%s"}' "$_in" "$_out" "$_cr" "$_cc" "$kind")
-    else
-        _event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s}' "$_in" "$_out" "$_cr" "$_cc")
+        [[ "$LOG_EVENTS" != "false" ]] && session_append_line "$_event"
     fi
-    [[ "$LOG_EVENTS" != "false" ]] && session_append_line "$_event"
     stats_inc ${counter_key}=1 total_input_tokens=${_in} total_output_tokens=${_out} total_cache_read_tokens=${_cr} total_cache_creation_tokens=${_cc}
     echo $(( _in + _out + _cr + _cc ))
 }
@@ -875,11 +876,6 @@ compact_context_window() {
     local remaining_turns
     remaining_turns=$(grep -c '"role":"user","content":"' "$CONV_FILE" 2>/dev/null || echo 0)
     stats_set current_turn_count=$remaining_turns
-    if is_stream_json_mode; then
-        printf '{"type":"context_update","kind":"compact","trigger":"%s"}\n' "$trigger"
-    else
-        printf '\033[36mContext compacted automatically.\033[0m\n'
-    fi
     return 0
 }
 
@@ -1109,6 +1105,9 @@ agent_loop_stream() {
     local user_input="$1"
     conv_add_user "$user_input"
 
+    # Compact before first LLM call: uses ctx_tokens from previous turn's USAGE
+    compact_context_window auto && write_message "CONTEXT_UPDATE" "compact" "auto"
+
     local turn=0
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
@@ -1175,7 +1174,7 @@ agent_loop_stream() {
                 STOP)  stop="${REPLY_MESSAGE[1]}" ;;
                 ERROR) loop_error="${REPLY_MESSAGE[1]}"; stop="error"; break ;;
                 USAGE)
-                    _ctx_tokens=$(record_usage "agent" agent_request_count)
+                    _ctx_tokens=$(record_usage "agent" agent_request_count false)
                     ;;
             esac
         done < <(llm_call "$(conv_get_messages "$(<"$CONV_FILE")")")
@@ -1194,13 +1193,9 @@ agent_loop_stream() {
             if [[ -n "$tool_conv_results" ]]; then
                 conv_add_tool_results "$tool_conv_results"
             fi
-            # Update context tokens and trigger compact if needed
+            # Update context tokens from USAGE (used by next turn's compact check)
             if [[ -n "$_ctx_tokens" && "$_ctx_tokens" -gt 0 ]]; then
                 stats_set current_context_tokens=${_ctx_tokens}
-                compact_context_window auto || true
-            else
-                # No usage data (e.g. retry) — skip compact
-                :
             fi
             # tool_use/tool_calls → loop continues; anything else → break
             [[ "$stop" == "tool_use" || "$stop" == "tool_calls" ]] || break

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -907,7 +907,7 @@ tool_write() {
 }
 
 tool_edit() {
-    local path="$1" old_string="$2" new_string="$3" tmp diff_output added removed label="${path#/}"
+    local path="$1" old_string="$2" new_string="$3" tmp diff_output added removed label="${1#/}"
     [[ -z "$path" ]] && { echo "Error: no path provided"; return 1; }
     [[ ! -f "$path" ]] && { echo "Error: file not found: $path"; return 1; }
     tmp=$(mktemp "${TMPDIR:-/tmp}/edit.XXXXXX")

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -54,10 +54,11 @@ INTERRUPT_REQUESTED=false
 DISPLAY_LAST_CHAR=$'\n'
 PREV_WAS_THINKING=false
 
-# --- Stats Cache (in-memory) --- Indexes match stats.awk _init_fields() order:
-#   0:current_turn_count  1:agent_request_count  2:compact_request_count 3:total_input_tokens  4:total_output_tokens
-#   5:total_cache_read_tokens 6:total_cache_creation_tokens  7:current_context_tokens  8:last_updated
-STATS_CACHE=(0 0 0 0 0 0 0 0 "")
+# --- Stats (file-based, no in-memory cache) ---
+# All stats operations go directly to stats.json via awk action=update.
+# Keys: current_turn_count agent_request_count compact_request_count
+#        total_input_tokens total_output_tokens total_cache_read_tokens
+#        total_cache_creation_tokens current_context_tokens
 
 # --- Environment Defaults ---
 : "${ANTHROPIC_API_KEY:=}"
@@ -698,7 +699,6 @@ conv_init() {
     if [[ "$new_session" == true ]]; then
         session_append_line "{\"type\":\"session_start\",\"session_id\":\"$(json_escape "$SESSION_ID")\"}"
     fi
-    stats_load
 }
 
 conv_add_user() {
@@ -744,45 +744,39 @@ context_append_summary() {
     printf '%s\n' "$text" > "$CONTEXT_SUMMARY_FILE"
 }
 
-stats_load() {
-    local idx=0
-    while IFS=$'\t' read -r key val; do
-        [[ -z "$key" ]] && continue
-        STATS_CACHE[idx]="$val"
-        idx=$(( idx + 1 ))
-    done < <(awk_run -v action=dump -f "$AWK_DIR/stats.awk" "$STATS_FILE" 2>/dev/null)
-}
-
-_stats_sync() {
-    printf '%s\n' "${STATS_CACHE[@]}" | awk_run -v action=sync -f "$AWK_DIR/stats.awk" "$STATS_FILE"
+stats_inc() {
+    # Args: key=delta ...  e.g. stats_inc agent_request_count=1 total_input_tokens=500
+    local entry key val line=""
+    for entry in "$@"; do
+        key="${entry%%=*}" val="${entry#*=}"
+        line+="${key}	+${val}"$'\n'
+    done
+    printf '%s' "$line" | awk_run -v action=update -f "$AWK_DIR/stats.awk" "$STATS_FILE"
     stats_show_osc
 }
 
-stats_inc() {
-    for entry in "$@"; do
-        local idx="${entry%%=*}" val="${entry#*=}"
-        STATS_CACHE[idx]=$(( STATS_CACHE[idx] + val ))
-    done
-    _stats_sync
-}
-
 stats_set() {
+    # Args: key=val ...  e.g. stats_set current_context_tokens=7794
+    local entry key val line=""
     for entry in "$@"; do
-        local idx="${entry%%=*}" val="${entry#*=}"
-        STATS_CACHE[idx]="$val"
+        key="${entry%%=*}" val="${entry#*=}"
+        line+="${key}	${val}"$'\n'
     done
-    _stats_sync
+    printf '%s' "$line" | awk_run -v action=update -f "$AWK_DIR/stats.awk" "$STATS_FILE"
+    stats_show_osc
 }
 
 stats_get() {
-    echo "${STATS_CACHE[$1]:-0}"
+    # Args: key  e.g. stats_get current_context_tokens
+    awk_run -v action=dump -f "$AWK_DIR/stats.awk" "$STATS_FILE" 2>/dev/null | \
+        awk -F'\t' -v k="$1" '$1 == k { print $2 }'
 }
 
 record_usage() {
-    # Args: kind counter_idx
+    # Args: kind counter_key
     # Reads REPLY_MESSAGE[1..4], logs event, updates stats.
     # Returns context token count (input+output+cache_read+cache_creation).
-    local kind="$1" counter_idx="$2"
+    local kind="$1" counter_key="$2"
     local _in="${REPLY_MESSAGE[1]:-0}" _out="${REPLY_MESSAGE[2]:-0}" _cr="${REPLY_MESSAGE[3]:-0}" _cc="${REPLY_MESSAGE[4]:-0}" _event
     if [[ -n "$kind" ]]; then
         _event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s,"kind":"%s"}' "$_in" "$_out" "$_cr" "$_cc" "$kind")
@@ -790,13 +784,20 @@ record_usage() {
         _event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s}' "$_in" "$_out" "$_cr" "$_cc")
     fi
     [[ "$LOG_EVENTS" != "false" ]] && session_append_line "$_event"
-    stats_inc ${counter_idx}=1 3=${_in} 4=${_out} 5=${_cr} 6=${_cc}
+    stats_inc ${counter_key}=1 total_input_tokens=${_in} total_output_tokens=${_out} total_cache_read_tokens=${_cr} total_cache_creation_tokens=${_cc}
     echo $(( _in + _out + _cr + _cc ))
 }
 
 stats_show_osc() {
-    awk -v m="$MODEL" -v t="${STATS_CACHE[0]:-0}" -v r="${STATS_CACHE[1]:-0}" \
-        -v i="${STATS_CACHE[3]:-0}" -v o="${STATS_CACHE[4]:-0}" -v c="${STATS_CACHE[7]:-0}" '
+    local _dump
+    _dump=$(awk_run -v action=dump -f "$AWK_DIR/stats.awk" "$STATS_FILE" 2>/dev/null)
+    local t r i o c
+    t=$(echo "$_dump" | awk -F'\t' '$1=="current_turn_count"{print $2}')
+    r=$(echo "$_dump" | awk -F'\t' '$1=="agent_request_count"{print $2}')
+    i=$(echo "$_dump" | awk -F'\t' '$1=="total_input_tokens"{print $2}')
+    o=$(echo "$_dump" | awk -F'\t' '$1=="total_output_tokens"{print $2}')
+    c=$(echo "$_dump" | awk -F'\t' '$1=="current_context_tokens"{print $2}')
+    awk -v m="$MODEL" -v t="${t:-0}" -v r="${r:-0}" -v i="${i:-0}" -v o="${o:-0}" -v c="${c:-0}" '
     function f(n,s,r){s=sprintf("%d",n);while(length(s)>3){r=","substr(s,length(s)-2)r;s=substr(s,1,length(s)-3)}return s r}
     BEGIN{printf "\033]0;%s T:%s R:%s I:%s O:%s C:%s\007",m,f(t),f(r),f(i),f(o),f(c) > "/dev/stderr"}'
 }
@@ -808,8 +809,8 @@ stats_show_osc() {
 # Formula: NetBenefit(k) = ①savings - ②cache_miss - ③compact_cost - ④info_loss
 # Returns: number of lines to keep (turn-aligned), or "0" if no compact beneficial.
 compact_dp_decision() {
-    awk_run -v t="$(stats_get 0)" -v total_requests="$(stats_get 1)" \
-            -v total_compact="$(stats_get 2)" -v total_input="$(stats_get 3)" \
+    awk_run -v t="$(stats_get current_turn_count)" -v total_requests="$(stats_get agent_request_count)" \
+            -v total_compact="$(stats_get compact_request_count)" -v total_input="$(stats_get total_input_tokens)" \
             -v baseline_e="${DP_BASELINE_E:-8}" -v e_fixed="${DP_E_FIXED:-0}" -v L_fixed="${DP_L:-0}" \
             -v V="$DP_V" -v p_input="$DP_P_INPUT" -v p_cache="$DP_P_CACHE" -v p_out="$DP_P_OUT" \
             -v S="$DP_S" -v min_keep_ratio="$DP_MIN_KEEP_RATIO" -v r="$DP_R" -v beta="$DP_BETA" \
@@ -845,7 +846,7 @@ compact_context_window() {
 
     # DP 返回 0（不值得）或 ≥ total_lines（全保留）→ 都算"不压缩"，进入 fallback
     if (( keep_lines == 0 )) || (( keep_lines >= total_lines && total_lines > 0 )); then
-        local ct=$(stats_get 7)
+        local ct=$(stats_get current_context_tokens)
         if [[ "$trigger" == "plan_clear" || "$trigger" == "plan_confirm" ]] || (( ct > 0 && ct > MAX_CONTEXT_TOKENS * 90 / 100 )); then
             keep_lines=$(compact_turn_keep)
         else
@@ -873,7 +874,7 @@ compact_context_window() {
     rm -f "$tmp_dropped"
     local remaining_turns
     remaining_turns=$(grep -c '"role":"user","content":"' "$CONV_FILE" 2>/dev/null || echo 0)
-    stats_set 0=$remaining_turns
+    stats_set current_turn_count=$remaining_turns
     if is_stream_json_mode; then
         printf '{"type":"context_update","kind":"compact","trigger":"%s"}\n' "$trigger"
     else
@@ -1092,7 +1093,7 @@ run_summary_call() {
         case "${REPLY_MESSAGE[0]}" in
             TEXT)  text+="${REPLY_MESSAGE[1]}" ;;
             THINKING) ;;
-            USAGE) record_usage "compact" 2 >/dev/null ;;
+            USAGE) record_usage "compact" compact_request_count >/dev/null ;;
             ERROR) last_error="${REPLY_MESSAGE[1]}" ;;
             STOP)  stop_reason="${REPLY_MESSAGE[1]}" ;;
         esac
@@ -1111,7 +1112,6 @@ agent_loop_stream() {
     local turn=0
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
-        stats_set 9=$turn
 
         local text="" thinking="" tool_calls="" stop="" loop_error="" tool_conv_results="" _ctx_tokens=""
         [[ "$VERBOSE" == true ]] && printf '[debug] messages: %.500s...\n' "$(conv_get_messages "$(<"$CONV_FILE")")" >&2
@@ -1175,7 +1175,7 @@ agent_loop_stream() {
                 STOP)  stop="${REPLY_MESSAGE[1]}" ;;
                 ERROR) loop_error="${REPLY_MESSAGE[1]}"; stop="error"; break ;;
                 USAGE)
-                    _ctx_tokens=$(record_usage "agent" 1)
+                    _ctx_tokens=$(record_usage "agent" agent_request_count)
                     ;;
             esac
         done < <(llm_call "$(conv_get_messages "$(<"$CONV_FILE")")")
@@ -1196,7 +1196,7 @@ agent_loop_stream() {
             fi
             # Update context tokens and trigger compact if needed
             if [[ -n "$_ctx_tokens" && "$_ctx_tokens" -gt 0 ]]; then
-                stats_set 7=${_ctx_tokens}
+                stats_set current_context_tokens=${_ctx_tokens}
                 compact_context_window auto || true
             else
                 # No usage data (e.g. retry) — skip compact
@@ -1228,7 +1228,7 @@ agent_loop() {
     [[ "$LOG_EVENTS" != "false" ]] && \
         session_append_line "{\"type\":\"user_input\",\"content\":\"$(json_escape "$user_input")\"}"
     # Increment turn count
-    stats_inc 0=1
+    stats_inc current_turn_count=1
 
     local _se=""
     while read_message; do

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1014,11 +1014,11 @@ tool_skill() {
 }
 
 tool_plan_confirm() {
-    # 将 draft 移至正式 plan，触发 compact（plan 写入 system prompt 会使缓存失效，趁机 compact）
+    # 先 compact 再 mv：compact 复用旧缓存前缀，mv 后才触发缓存失效——总共一次冷启动
     if [[ -n "$PLAN_DRAFT_FILE" && -s "$PLAN_DRAFT_FILE" ]]; then
+        compact_context_window plan_confirm
         mv "$PLAN_DRAFT_FILE" "$PLAN_FILE"
         : > "$PLAN_DRAFT_FILE"   # 重新创建空 draft，供下次规划使用
-        compact_context_window plan_confirm
         printf 'Plan confirmed and locked in.'
     else
         printf 'Error: no plan draft found to confirm.'

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -115,8 +115,7 @@ new_session_id() {
 }
 
 deny_bash_command_reason() {
-    local cmd="$1"
-    local device_write_re='(^|[[:space:]])(of=|>|1>|>>|1>>)[[:space:]]*/dev/(sd[a-z][0-9]*|disk[0-9]+|rdisk[0-9]+|nvme[0-9]+n[0-9]+(p[0-9]+)?|vd[a-z][0-9]*|xvd[a-z][0-9]*|hd[a-z][0-9]*)([[:space:]]|$)'
+    local cmd="$1" device_write_re='(^|[[:space:]])(of=|>|1>|>>|1>>)[[:space:]]*/dev/(sd[a-z][0-9]*|disk[0-9]+|rdisk[0-9]+|nvme[0-9]+n[0-9]+(p[0-9]+)?|vd[a-z][0-9]*|xvd[a-z][0-9]*|hd[a-z][0-9]*)([[:space:]]|$)'
 
     [[ -z "$cmd" ]] && return 1
 
@@ -164,17 +163,14 @@ tool_param_keys() {
 }
 
 tool_args_from_msg() {
-    local name="$1"
-    # Extract known params from flattened KV pairs at REPLY_MESSAGE[4..]
-    local param_key_string="" param_keys=() idx param_value=""
+    local name="$1" param_key_string="" param_keys=() idx param_value="" _n=${#REPLY_MESSAGE[@]} _pkey i
     local -a _outvars=("$2" "$3" "$4" "$5")
-    local _n=${#REPLY_MESSAGE[@]}
 
     param_key_string=$(tool_param_keys "$name")
     if [[ -n "$param_key_string" ]]; then
         IFS=' ' read -r -a param_keys <<< "$param_key_string"
         for idx in "${!param_keys[@]}"; do
-            local _pkey="${param_keys[idx]}" i
+            _pkey="${param_keys[idx]}"
             param_value=""
             for (( i = 4; i + 1 < _n; i += 2 )); do
                 if [[ "${REPLY_MESSAGE[i]}" == "$_pkey" ]]; then
@@ -188,7 +184,7 @@ tool_args_from_msg() {
 }
 
 tool_call_summary() {
-    local name="$1" label="" key=""
+    local name="$1" label="" key="" i value="" _vi
     shift
     case "$name" in
         Read|Write|Edit) key="path" ;;
@@ -200,10 +196,9 @@ tool_call_summary() {
         WebFetch) key="url" ;;
     esac
     if [[ -n "$key" && $# -gt 0 ]]; then
-        local i value=""
         for (( i = 1; i + 1 <= $#; i += 2 )); do
             if [[ "${!i}" == "$key" ]]; then
-                local _vi=$(( i + 1 ))
+                _vi=$(( i + 1 ))
                 value="${!_vi}"
                 break
             fi
@@ -261,20 +256,18 @@ json_escape() {
 }
 
 format_tool_result() {
-    local output="$1"
+    local output="$1" size marker marker_len tail_lines=5 tail_text tail_len head_len
     if (( ${#output} <= TOOL_RESULT_MAX_BYTES )); then
         printf '%s' "$output"
         return 0
     fi
 
-    local size=${#output}
-    local marker=$'\n\n[... truncated: showing first/last portions of %d bytes ...]\n\n'
-    local marker_len=$(( ${#marker} + 20 ))
-    local tail_lines=5
-    local tail_text
+    size=${#output}
+    marker=$'\n\n[... truncated: showing first/last portions of %d bytes ...]\n\n'
+    marker_len=$(( ${#marker} + 20 ))
     tail_text=$(printf '%s' "$output" | tail -n "$tail_lines")
-    local tail_len=${#tail_text}
-    local head_len=$(( TOOL_RESULT_MAX_BYTES - marker_len - tail_len ))
+    tail_len=${#tail_text}
+    head_len=$(( TOOL_RESULT_MAX_BYTES - marker_len - tail_len ))
     (( head_len > 0 )) || head_len=$(( TOOL_RESULT_MAX_BYTES / 2 ))
 
     printf '%s' "${output:0:$head_len}"
@@ -368,7 +361,7 @@ msg_to_stream_event() {
 display_event() {
     # REPLY_MESSAGE[0]=type, rest varies by type
     # Pure human-text rendering only. JSON event construction is in msg_to_stream_event().
-    local _type="${REPLY_MESSAGE[0]}"
+    local _type="${REPLY_MESSAGE[0]}" _tc_kv=() i _n _tc_summary="" _tr_name _tr_text="" _um_text
 
     case "$_type" in
         TEXT)
@@ -390,7 +383,7 @@ display_event() {
             PREV_WAS_THINKING=true
             ;;
         TOOL_CALL)
-            local _tc_kv=() i _n=${#REPLY_MESSAGE[@]} _tc_summary=""
+            _n=${#REPLY_MESSAGE[@]} _tc_kv=() _tc_summary=""
             for (( i = 4; i + 1 < _n; i += 2 )); do
                 _tc_kv+=("${REPLY_MESSAGE[i]}" "${REPLY_MESSAGE[i+1]}")
             done
@@ -404,7 +397,7 @@ display_event() {
             DISPLAY_LAST_CHAR=$'\n'
             ;;
         TOOL_RESULT)
-            local _tr_name="${REPLY_MESSAGE[2]}" _tr_text=""
+            _tr_name="${REPLY_MESSAGE[2]}" _tr_text=""
             if [[ "$_tr_name" == "Edit" ]]; then
                 _tr_text="${REPLY_MESSAGE[3]}"$'\n'
             elif [[ "$_tr_name" == "Read" || "$_tr_name" == "Write" ]]; then
@@ -423,7 +416,7 @@ display_event() {
             ;;
         USER_MESSAGE)
             display_ensure_newline
-            local _um_text="${REPLY_MESSAGE[1]%%$'\n'*}"
+            _um_text="${REPLY_MESSAGE[1]%%$'\n'*}"
             (( ${#_um_text} > 80 )) && _um_text="${_um_text:0:77}..."
             printf '\033[32m> %s\033[0m\n' "$_um_text"
             DISPLAY_LAST_CHAR=$'\n'
@@ -604,14 +597,12 @@ build_tool_result_json_object() {
 }
 
 build_assistant_content_json() {
-    local text="$1" thinking="$2" calls="$3"
-    local content="["
+    local text="$1" thinking="$2" calls="$3" content="[" name id input
     content+="{\"type\":\"thinking\",\"thinking\":\"$(json_escape "$thinking")\"}"
     content+=",{\"type\":\"text\",\"text\":\"$(json_escape "$text")\"}"
 
     while IFS= read -r tc; do
         [[ -z "$tc" ]] && continue
-        local name id input
         IFS=$'\t' read -r name id input _ <<< "$tc"
         content+=",$(build_tool_call_json_object "$name" "$id" "$input")"
     done <<< "$calls"
@@ -635,8 +626,7 @@ find_awk_dir() {
     die "Cannot find awk/ directory. Set AWK_DIR or ensure awk/ exists alongside agent.sh"
 }
 get_session_dir() {
-    local cwd="${PWD:-$(pwd)}"
-    local project_key base="${BASH_AGENT_HOME:-${HOME}}"
+    local cwd="${PWD:-$(pwd)}" project_key base="${BASH_AGENT_HOME:-${HOME}}"
     cwd="$(cd "$cwd" && pwd -P)"
     project_key="$(printf '%s' "$cwd" | awk_run '
     {
@@ -652,10 +642,9 @@ get_session_dir() {
 }
 
 get_latest_session_dir() {
-    local project_dir
+    local project_dir latest="" latest_ts=0 dir ts
     project_dir="$(get_session_dir)"
     [[ -d "$project_dir" ]] || return 1
-    local latest="" latest_ts=0 dir ts
     for dir in "$project_dir"/*/; do
         [[ -d "$dir" ]] || continue
         ts=$(stat -f "%m" "$dir/events.jsonl" 2>/dev/null || stat -f "%m" "$dir" 2>/dev/null || echo 0)
@@ -680,7 +669,7 @@ conv_init() {
     if [[ -z "$SESSION_ID" ]]; then
         SESSION_ID="$(new_session_id)"
     fi
-    local project_dir session_dir
+    local project_dir session_dir new_session=false
     project_dir="$(get_session_dir)"
     session_dir="${project_dir}/${SESSION_ID}"
     mkdir -p "$session_dir"
@@ -691,7 +680,6 @@ conv_init() {
     PLAN_FILE="${session_dir}/plan.md"
     PLAN_DRAFT_FILE="${session_dir}/plan.draft"
     STATS_FILE="${session_dir}/stats.json"
-    local new_session=false
     [[ ! -s "$SESSION_EVENT_FILE" ]] && new_session=true
     touch "$CONV_FILE"
     touch "$SESSION_EVENT_FILE"
@@ -775,24 +763,22 @@ stats_get() {
 }
 
 record_usage() {
-    # Args: kind counter_key [write_event]
+    # Args: kind counter_key [write_event=true]
     # Reads REPLY_MESSAGE[1..4], updates stats, optionally logs event.
     # Returns context token count (input+output+cache_read+cache_creation).
-    local kind="$1" counter_key="$2" write_event="${3:-true}"
-    local _in="${REPLY_MESSAGE[1]:-0}" _out="${REPLY_MESSAGE[2]:-0}" _cr="${REPLY_MESSAGE[3]:-0}" _cc="${REPLY_MESSAGE[4]:-0}"
+    local kind="$1" counter_key="$2" write_event="${3:-true}" _event \
+          _in="${REPLY_MESSAGE[1]:-0}" _out="${REPLY_MESSAGE[2]:-0}" _cr="${REPLY_MESSAGE[3]:-0}" _cc="${REPLY_MESSAGE[4]:-0}"
     if [[ "$write_event" == "true" ]]; then
-        local _event
         _event=$(printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s,"kind":"%s"}' "$_in" "$_out" "$_cr" "$_cc" "$kind")
-        [[ "$LOG_EVENTS" != "false" ]] && session_append_line "$_event"
+        session_append_line "$_event"
     fi
     stats_inc ${counter_key}=1 total_input_tokens=${_in} total_output_tokens=${_out} total_cache_read_tokens=${_cr} total_cache_creation_tokens=${_cc}
     echo $(( _in + _out + _cr + _cc ))
 }
 
 stats_show_osc() {
-    local _dump
+    local _dump t r i o c
     _dump=$(awk_run -v action=dump -f "$AWK_DIR/stats.awk" "$STATS_FILE" 2>/dev/null)
-    local t r i o c
     t=$(echo "$_dump" | awk -F'\t' '$1=="current_turn_count"{print $2}')
     r=$(echo "$_dump" | awk -F'\t' '$1=="agent_request_count"{print $2}')
     i=$(echo "$_dump" | awk -F'\t' '$1=="total_input_tokens"{print $2}')
@@ -836,8 +822,7 @@ compact_turn_keep() {
 }
 
 compact_context_window() {
-    local trigger=${1:-auto}
-    local total_lines keep_lines drop tmp_dropped dropped_messages summary_response
+    local trigger=${1:-auto} total_lines keep_lines drop tmp_dropped dropped_messages summary_response
 
     # 始终先算 DP 决策（经济最优）
     keep_lines=$(compact_dp_decision) || true
@@ -922,8 +907,7 @@ tool_write() {
 }
 
 tool_edit() {
-    local path="$1" old_string="$2" new_string="$3"
-    local tmp diff_output added removed
+    local path="$1" old_string="$2" new_string="$3" tmp diff_output added removed label="${path#/}"
     [[ -z "$path" ]] && { echo "Error: no path provided"; return 1; }
     [[ ! -f "$path" ]] && { echo "Error: file not found: $path"; return 1; }
     tmp=$(mktemp "${TMPDIR:-/tmp}/edit.XXXXXX")
@@ -933,7 +917,6 @@ tool_edit() {
         cat "$tmp"; rm -f "$tmp"; return 1
     fi
     (( $(wc -c < "$tmp") > 0 )) || { echo "Error: edit produced empty result"; rm -f "$tmp"; return 1; }
-    local label="${path#/}"
     diff_output=$(diff -u --color=always --label "a/$label" --label "b/$label" "$path" "$tmp" 2>&1) || true
     [[ "$diff_output" == *"unsupported --color"* || "$diff_output" == *"unrecognized option '--color'"* ]] \
         && diff_output=$(diff -u --label "a/$label" --label "b/$label" "$path" "$tmp" 2>&1) || true
@@ -946,8 +929,7 @@ tool_edit() {
 }
 
 tool_bash() {
-    local cmd="$1" timeout_secs="${2:-$TOOL_TIMEOUT_SECS}"
-    local reason output tool_rc
+    local cmd="$1" timeout_secs="${2:-$TOOL_TIMEOUT_SECS}" reason output tool_rc tmpout
 
     [[ -z "$cmd" ]] && { echo "Error: no command provided"; return 1; }
     reason=$(deny_bash_command_reason "$cmd") || reason=""
@@ -956,7 +938,6 @@ tool_bash() {
         return 1
     fi
 
-    local tmpout
     tmpout=$(mktemp)
 
     if [[ -n "$timeout_secs" && "$timeout_secs" =~ ^[0-9]+$ && "$timeout_secs" -gt 0 ]]; then
@@ -985,14 +966,13 @@ tool_glob() {
 }
 
 tool_grep() {
-    local pattern="$1" path="$2" glob="$3" context="$4"
+    local pattern="$1" path="$2" glob="$3" context="$4" args=(-n --color never --heading)
 
     [[ -z "$pattern" ]] && { echo "Error: no pattern provided"; return 1; }
     [[ -n "$path" ]] || path="."
     [[ -e "$path" ]] || { echo "Error: path not found: $path"; return 1; }
     command -v rg >/dev/null 2>&1 || { echo "Error: rg is required for grep"; return 1; }
 
-    local args=(-n --color never --heading)
     [[ -n "$context" && "$context" =~ ^[0-9]+$ ]] && args+=(-C "$context")
     [[ -n "$glob" ]] && args+=(--glob "$glob")
     args+=("--" "$pattern" "$path")
@@ -1102,13 +1082,12 @@ run_summary_call() {
 # --- Agent Loop ---
 
 agent_loop_stream() {
-    local user_input="$1"
+    local user_input="$1" turn=0
     conv_add_user "$user_input"
 
     # Compact before first LLM call: uses ctx_tokens from previous turn's USAGE
     compact_context_window auto && write_message "CONTEXT_UPDATE" "compact" "auto"
 
-    local turn=0
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
 
@@ -1128,7 +1107,7 @@ agent_loop_stream() {
                 TEXT)     text+="${REPLY_MESSAGE[1]}" ;;
                 THINKING) thinking+="${REPLY_MESSAGE[1]}" ;;
                 TOOL_CALL)
-                    local cur_tool_name cur_tool_id input
+                    local cur_tool_name cur_tool_id input arg1="" arg2="" arg3="" arg4="" output tool_rc=0 result_for_conv="" _tr_args=() i _n=${#REPLY_MESSAGE[@]}
                     cur_tool_name="${REPLY_MESSAGE[1]}"
                     cur_tool_id="${REPLY_MESSAGE[2]}"
                     input="${REPLY_MESSAGE[3]}"
@@ -1136,19 +1115,17 @@ agent_loop_stream() {
                     tool_calls+="${cur_tool_name}"$'\t'"${cur_tool_id}"$'\t'"${input}"$'\n'
 
                     # Execute tool immediately, output result
-                    local arg1="" arg2="" arg3="" arg4=""
                     tool_args_from_msg "$cur_tool_name" arg1 arg2 arg3 arg4
 
-                    local output
                     output=$(dispatch_tool "$cur_tool_name" "$arg1" "$arg2" "$arg3" "$arg4" 2>&1)
-                    local tool_rc=$?
+                    tool_rc=$?
 
                     if (( tool_rc != 0 )); then
                         output="Error: tool execution failed: $output"
                     fi
                     output=$(format_tool_result "$output")
 
-                    local result_for_conv="$output"
+                    result_for_conv="$output"
                     if [[ "$cur_tool_name" == "Edit" ]]; then
                         result_for_conv="$(printf '%s' "$output" | sed -n '1p')"
                     fi
@@ -1160,11 +1137,10 @@ agent_loop_stream() {
                     fi
 
                     # TOOL_RESULT: [0]=type [1]=id [2]=name [3]=output [4..]=checklist/summary
-                    local _tr_args=("TOOL_RESULT" "$cur_tool_id" "$cur_tool_name" "$output")
+                    _tr_args=("TOOL_RESULT" "$cur_tool_id" "$cur_tool_name" "$output")
                     [[ -n "$arg1" ]] && _tr_args+=("$arg1")
                     [[ -n "$arg2" ]] && _tr_args+=("$arg2")
                     # Search for checklist/summary in TOOL_CALL flattened KV pairs
-                    local i _n=${#REPLY_MESSAGE[@]}
                     for (( i = 4; i + 1 < _n; i += 2 )); do
                         if [[ "${REPLY_MESSAGE[i]}" == "checklist" ]]; then _tr_args+=("checklist" "${REPLY_MESSAGE[i+1]}"); fi
                         if [[ "${REPLY_MESSAGE[i]}" == "summary" ]]; then _tr_args+=("summary" "${REPLY_MESSAGE[i+1]}"); fi
@@ -1211,7 +1187,7 @@ agent_loop_stream() {
 }
 
 agent_loop() {
-    local user_input="$1" had_error=false
+    local user_input="$1" had_error=false _se=""
     DISPLAY_LAST_CHAR=$'\n'
     PREV_WAS_THINKING=false
     INTERRUPT_REQUESTED=false
@@ -1225,7 +1201,6 @@ agent_loop() {
     # Increment turn count
     stats_inc current_turn_count=1
 
-    local _se=""
     while read_message; do
         [[ "${REPLY_MESSAGE[0]}" == "ERROR" ]] && had_error=true
 
@@ -1352,14 +1327,13 @@ parse_args() {
 }
 
 list_sessions() {
-    local dir
+    local dir session_dir name mod preview summary_file
     dir="$(get_session_dir)"
     if [[ ! -d "$dir" ]]; then
         echo "No sessions found."
         return
     fi
     printf "%-40s %-16s %s\n" "NAME" "MODIFIED" "PREVIEW"
-    local session_dir name mod preview summary_file
     for session_dir in "$dir"/*/; do
         [[ -d "$session_dir" ]] || continue
         name=$(basename "$session_dir")
@@ -1421,7 +1395,7 @@ validate_config() {
 }
 
 interactive_mode() {
-    local history_file="${BASH_AGENT_HOME:-${HOME}}/.bash-agent/history"
+    local history_file="${BASH_AGENT_HOME:-${HOME}}/.bash-agent/history" _saved_log_events="${LOG_EVENTS:-true}" _efile="${SESSION_EVENT_FILE:-}" _match _from_line
 
     mkdir -p "$(dirname "$history_file")" 2>/dev/null || true
     touch "$history_file" 2>/dev/null || true
@@ -1431,9 +1405,7 @@ interactive_mode() {
     printf '\033[36mbash-agent interactive mode (type '\''exit'\'' or Ctrl+D to quit)\033[0m\n'
     # Replay recent 10 turns for resumed sessions (inlined turn-aware replay)
     if [[ -s "${SESSION_EVENT_FILE:-}" ]]; then
-        local _saved_log_events="${LOG_EVENTS:-true}"
         LOG_EVENTS=false
-        local _efile="${SESSION_EVENT_FILE:-}" _match _from_line
         _match=$(grep -n '"type":"user_input"' "$_efile" 2>/dev/null | tail -n 10 | head -n 1) || true
         _from_line="${_match%%:*}"
         [[ -n "$_from_line" && "$_from_line" -ge 1 ]] || _from_line=1

--- a/src/awk/compact_dp.awk
+++ b/src/awk/compact_dp.awk
@@ -26,7 +26,7 @@
 # Output: number of lines to keep (turn-aligned), or "0" if no compact
 {
     sizes[NR] = int((length($0) + 3) / 4) + 1
-    role[NR]  = ($0 ~ /^\{"role":"user","content":"/) ? "user" : "other"
+    role[NR]  = ($0 ~ /"role":"user"/ && $0 !~ /"content":\[/) ? "user" : "other"
 }
 END {
     if (NR == 0) { print "0"; exit }


### PR DESCRIPTION
## 问题

`compact_context_window` 始终无法自动触发，导致上下文无限增长。

**根因链：**
1. `compact_turn_keep` 中 `keep < 3` 时返回"全保留"（即 `keep = total_lines`）
2. 用户输入后立即触发 compact → 对话最后一行就是 user turn → `keep = 1`
3. `keep < 3` → 返回全保留 → 调用方 guard 拦住 → 永不压缩

## 修复

### 1. compact 位置调整（Bash/Rust/Go 统一）
从循环外部/末尾移到 `while` 循环内 `turn++` 之后、LLM 调用之前。每次调用前用上一轮 USAGE 的 `ctx_tokens` 检查是否需要压缩。

### 2. `keep < 3` → `keep == 0`
`compact_turn_keep` 仅在 `keep == 0` 时返回 None/0（放弃压缩），`keep < 3` 不再拦截。调用方 guard 增加 `Some(0) / keep == 0` 保护。

### 3. user turn 检测修复
旧方式依赖 JSON key 顺序（`starts_with '{"role":"user","content":"'`），现在改为结构化字段访问：
- **Rust**: `line.get("role")` + `content.is_string()`
- **Go**: `json.Unmarshal` 到 struct，检查 `Content[0] == '"'` 区分 string vs array
- **Bash/AWK**: `/"role":"user"/ && ! /"content":\[/`

### 4. 其他改进
- 提取 `emit_context_update` 统一方法，写入 `events.jsonl` 并输出到 stream-json/human
- USAGE event 增加 `"kind":"agent"` 字段
- 移除调试日志和临时测试代码

## 测试
- Rust: 6/6 passed
- Go: 全部 passed（app, httpclient, protocol, safety, session, sse, tools, transport）

## 文件变更
| 文件 | 说明 |
|------|------|
| `src/agent.sh` | compact 移入循环内、keep==0 修复、user turn 正则修复 |
| `src/awk/compact_dp.awk` | user turn 正则同步 |
| `rust/src/app.rs` | compact 移入循环内、guard 增加 Some(0)、emit_context_update |
| `rust/src/compact_dp.rs` | keep==0 修复、结构化检测、移除调试日志 |
| `go/internal/app/app.go` | compact 移入循环内、emit_context_update |
| `go/internal/conversation/compact_dp.go` | keep==0 修复、结构化 JSON 检测 |