### PR TITLE
fix: 重构 Rust HTTP 架构——修复 Ctrl+C CPU 飙升、中断后无法恢复、三版不一致

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -49,3 +49,24 @@ make clean
 # 完整检查
 make build && make test
 ```
+
+## 版本一致性要求
+
+Bash / Go / Rust 三个版本的 **system prompt** 和 **tools.json** 必须完全一致。不一致会导致同一 session 切换版本时 LLM 缓存失效（system prompt 不同 → 请求体不同 → cache miss），浪费 token。
+
+### 关键文件
+
+| 文件 | 作用 | 同步说明 |
+|------|------|----------|
+| `src/tools.json` | 工具定义 JSON | **基准文件**，修改后必须同步到 `rust/src/tools.json` 和 `go/tools.json` |
+| `src/agent.sh` | Bash 版 system prompt (`agent_build_prompt`) | **基准**，Go/Rust 的 `BuildPrompt` 必须逐字对齐 |
+| `go/agent.go` | Go 版 system prompt (`BuildPrompt`) | 内容、顺序、格式必须与 bash 一致 |
+| `rust/src/lib.rs` | Rust 版 system prompt (`build_system_prompt`) | 同上 |
+
+### 检查清单（修改任一 prompt 区域时）
+
+- [ ] `rust/src/lib.rs` 的 `build_system_prompt` 是否同步？
+- [ ] `go/agent.go` 的 `BuildPrompt` 是否同步？
+- [ ] `go/`、`rust/src/`、`src/` 三处的 `tools.json` SHA256 是否一致？(`sha256sum src/tools.json rust/src/tools.json go/tools.json`)
+
+> **经验**: 同一 session 在三个版本间切换是正常的开发/调试流程。system prompt 不同直接导致缓存失效，每次切换都相当于冷启动。保持一致性就是省钱。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Go: `RunLoop` 中用 `context.WithCancel` 包装 ctx，Ctrl+C 立即取消 HTTP 请求（`b4a4d3e`）
   - Rust: `static CTRLC_FLAG` 全局标志 + handler 设在 `agent_run` 一次初始化，防止各 agent 相互覆盖 handler；`is_interrupted()` 同时检查 per-agent flag + 全局 flag；HTTP Client `.timeout(300s)` 防止 `spawn_reader` 线程无限阻塞（`448bec1`）
 - **SSE 解析兜底 (Go/Rust)**: 流异常中断（无 `message_stop`）时发射 `ERROR` + `STOP` 事件，对标 awk `END` 块。Go `parseSSEStream` 新增 `stopEmitted` 标志 + `defer` 兜底；Rust `claude::parse` / `openai::parse` 读流结束后 `pending_stop` 为空时发射 `ErrorEvent` + `StopEvent{reason:"error"}`（`ddce0c8`）
+- **usage `input_tokens` 被 `message_delta` 错误覆盖 (bash/Go/Rust)**: `message_start.usage.input_tokens` 为总 prompt token 数，但 `message_delta.usage.input_tokens` 为结算后计费值（远小于总数）。SSE 解析器中 `message_delta` 覆盖了 `message_start` 的值，导致 usage 事件记录的 `input_tokens` 异常偏小且波动（23~4204）。修复后 `input_tokens` 以 `message_start` 优先，`message_delta` 仅在未设置时补充（兼容 OpenAI 路径）（`ff72d76`）
 - **summary 调用 Ctrl+C 无保护 (Rust)**: `run_summary_call` 的 HTTP 响应包装 `CancelReader`，对标 bash trap 保护所有 LLM 调用（`448bec1`）
 - **构建脚本 FD 搜索模式未同步 (bash)**: `build.sh` 中 `http_stream.awk` 搜索模式写死 `<&6`，源码已改为 `<&9` 导致 `AWK_DIR` 未被替换为内联变量，`dist/agent.sh` 出现 `AWK_DIR: unbound variable` 错误（`193e0e3`）
 - **交互模式双提示符**: display_stream 子进程统一提示符控制，消除子 Agent 和主进程同时输出的重复提示符（`8827cc1`）

--- a/go/agent.go
+++ b/go/agent.go
@@ -108,9 +108,16 @@ func (a *Agent) BuildPrompt() string {
 	}
 	appendSection("agent-identity", identity, "")
 
-	// environment
+	// environment — platform 与 bash 的 uname -s 输出一致
+	platform := runtime.GOOS
+	switch platform {
+	case "darwin":
+		platform = "Darwin"
+	case "linux":
+		platform = "Linux"
+	}
 	env := fmt.Sprintf("lang: %s\npwd: %s\nhome: %s\nplatform: %s\nshell: %s",
-		locale, mustGetwd(), os.Getenv("HOME"), runtime.GOOS, os.Getenv("SHELL"))
+		locale, mustGetwd(), os.Getenv("HOME"), platform, os.Getenv("SHELL"))
 	appendSection("environment", env, "")
 
 	// rules
@@ -125,39 +132,70 @@ func (a *Agent) BuildPrompt() string {
 		"- Grep supports a context parameter to show surrounding lines — use it to get enough text for Edit directly from Grep output, avoiding a separate Read.\n" +
 		"- Use multiple tool calls in one response when they are independent.\n" +
 		"- Prefer dedicated tools over Bash when a dedicated tool fits the task.\n" +
-		"- For Edit: copy old_string exactly (including whitespace/indent/newlines).\n" +
+		"- For Edit: copy old_string exactly (including whitespace/indent/newlines). If you already know the location from prior context, use Read with offset/limit. If you need to locate the text first, use Grep with context — its output is often sufficient for Edit without an extra Read.\n" +
 		"- For skills, first check the skill-index section, then use Skill(name) for the matching skill.\n" +
-		"- SubAgent launches a background agent session. Results are injected back into your conversation when complete."
+		"- SubAgent launches a background agent session. Results are injected back into your conversation when complete. Use for parallelizable or independent sub-tasks. See sub-agent-guidance section for context inheritance rules."
 	appendSection("using-your-tools", toolGuidance, "")
 
 	// sub-agent guidance
-	subAgentGuidance := "- **When to use**: delegating independent sub-tasks that do NOT need your current conversation context.\n" +
-		"- **When NOT to use**: tasks that depend on your working context, conversation history, or intermediate state.\n" +
-		"- **Fork mode**: pass `fork=true` to inherit parent session context.\n" +
-		"- **Prompt design**: write a complete, self-contained prompt.\n" +
-		"- **Result handling**: results are injected as a user message.\n" +
-		"- **Parallelism**: multiple SubAgent calls run concurrently.\n" +
-		"- **Failure**: if the child fails, handle gracefully — do not retry automatically."
+	subAgentGuidance := "- **When to use**: delegating independent sub-tasks that do NOT need your current conversation context — e.g. investigating a separate file, running a focused search, testing a hypothesis in isolation.\n" +
+		"- **When NOT to use**: tasks that depend on your working context, conversation history, or intermediate state. The child agent starts with a blank slate.\n" +
+		"- **Fork mode**: pass `fork=true` to inherit parent session context (conversation history, plan, skills). Use when the child needs your working context.\n" +
+		"- **Prompt design**: write a complete, self-contained prompt. Include all file paths, function names, error messages, and constraints the child needs. Assume zero shared context.\n" +
+		"- **Result handling**: when the child completes, its result is injected as a user message: `[sub-agent <id>] <status> (in=<n>, out=<n>)\nThinking: ...\nText: ...`. You then get another LLM turn to interpret and act on it.\n" +
+		"- **Parallelism**: multiple SubAgent calls in one turn run concurrently. Use this to parallelize independent investigations. **IMPORTANT**: results return asynchronously as each sub-agent finishes — they do NOT return together. When you receive a result for one sub-agent, the others are still running. Simply wait for all results to arrive before acting. Do NOT re-launch a sub-agent just because another one finished first — match results by session_id.\n" +
+		"- **Failure**: if the child fails (status=failed), the result text may be partial or empty. Handle gracefully — do not retry automatically."
 	appendSection("sub-agent-guidance", subAgentGuidance, "")
 
 	// todo guidance
-	todoGuidance := "- Use TodoWrite proactively for complex multi-step tasks.\n" +
-		"- Do not use TodoWrite for trivial single-step requests.\n" +
+	todoGuidance := "- Use TodoWrite proactively for complex multi-step implementation, debugging, refactoring, review, or multi-file tasks.\n" +
+		"- Do not use TodoWrite for trivial single-step, single-command, or purely informational requests.\n" +
+		"- After receiving a non-trivial task, create an initial checklist before or as you begin work.\n" +
+		"- When you use TodoWrite, write the full updated checklist for the current session, not a partial diff.\n" +
 		"- Keep the checklist short, concrete, and actionable.\n" +
-		"- Prefer exactly one in_progress item when work is actively underway."
+		"- Prefer exactly one in_progress item when work is actively underway.\n" +
+		"- Mark items completed immediately after finishing them, and remove stale items that no longer matter."
 	appendSection("todo-guidance", todoGuidance, "")
 
 	// plan lifecycle
+	pdPath, pPath := a.store.PlanDraftPath(), a.store.PlanPath()
+	if pdPath == "" {
+		pdPath = "<not set>"
+	}
+	if pPath == "" {
+		pPath = "<not set>"
+	}
 	planGuidance := "- **PLANNING WORKFLOW** — For complex multi-step tasks (3+ steps OR multi-file OR user requests planning)\n" +
-		"- **Files**: PLAN_DRAFT_FILE and PLAN_FILE paths are session-specific.\n" +
-		"- **Why draft first?** Writing to PLAN_FILE immediately invalidates the system prompt cache.\n" +
-		"- **Drafting phase**: Every user reply MUST be classified as REVISE, CONFIRM, or CANCEL.\n" +
-		"- **Execution phase**: after PlanConfirm → TodoWrite checklist → execute tasks → PlanClear when all done."
+		"- **Files**: PLAN_DRAFT_FILE: " + pdPath + " | PLAN_FILE: " + pPath + "\n" +
+		"- **Why draft first?** Writing to PLAN_FILE immediately invalidates the system prompt cache. Use PLAN_DRAFT_FILE for all drafting iterations to avoid this cost.\n" +
+		"- **Drafting phase** (PLAN_DRAFT_FILE non-empty → you are drafting):\n" +
+		"  Every user reply MUST be classified as exactly ONE of:\n" +
+		"  ① REVISE (any feedback/question/change) → Edit PLAN_DRAFT_FILE → ask confirmation → stay in drafting\n" +
+		"  ② CONFIRM (explicit ok/go/confirmed) → call PlanConfirm IMMEDIATELY (before any other action) → TodoWrite checklist → execute\n" +
+		"  ③ CANCEL (explicit cancel/forget it) → Bash `: > PLAN_DRAFT_FILE` → exit to idle\n" +
+		"  ⚠ On CONFIRM you MUST call PlanConfirm first — no edits, no tool calls before it.\n" +
+		"- **Execution phase**: after PlanConfirm → TodoWrite checklist → execute tasks → PlanClear when all done\n" +
+		"- **Plan vs Todo**: PLAN_FILE=locked plan (only via PlanConfirm), PLAN_DRAFT_FILE=draft (edit freely), TodoWrite=progress tracker. Do NOT mix."
 	appendSection("plan-lifecycle-guidance", planGuidance, "")
 
-	// current plan
+	// instruction files
+	instructions := a.buildInstructionsSection()
+	appendSection("instruction-files", instructions, "")
+
+	// skill index
+	skillIndex := a.buildSkillIndex()
+	appendSection("skill-index", skillIndex, "")
+
+	// selected skills
+	for _, sn := range a.cfg.SkillNames {
+		if content, err := a.loadSkillContent(sn); err == nil {
+			appendSection("skill", content, sn)
+		}
+	}
+
+	// current plan (with plan file name as attribute)
 	if plan, err := a.store.GetPlan(); err == nil && plan != "" {
-		appendSection("current-plan", plan, "")
+		appendSection("current-plan", plan, pPath)
 	}
 
 	// context snapshot (summary)
@@ -165,29 +203,14 @@ func (a *Agent) BuildPrompt() string {
 		appendSection("context-snapshot", summary, "")
 	}
 
-	// output language
-	outputLang := fmt.Sprintf("MUST use \"%s\" for all output, including Chain of Thought/reasoning/thinking!", locale)
+	// output language — 必须放在最后
+	outputLang := "MUST use \"" + locale + "\" for all output, including your Chain of Thought/reasoning/thinking! Never mix languages! Code, commands, and file content remain as-is."
 	if strings.HasPrefix(locale, "zh") {
 		outputLang = "再次强调：必须使用中文进行所有输出，包括你的思考过程（Chain of Thought/推理/thinking）！严禁在思考或回答中出现任何英文内容！"
 	}
 	appendSection("output-language", outputLang, "")
 
-	// instruction files (AGENTS.md / AGENT.md / CLAUDE.md)
-	instructions := a.buildInstructionsSection()
-	appendSection("instruction-files", instructions, "")
-
-	// skill index (所有发现的 skill 的 name: summary 列表)
-	skillIndex := a.buildSkillIndex()
-	appendSection("skill-index", skillIndex, "")
-
-	// selected skills (--skill 指定的，完整内容)
-	for _, sn := range a.cfg.SkillNames {
-		if content, err := a.loadSkillContent(sn); err == nil {
-			appendSection("skill", content, sn)
-		}
-	}
-
-	return strings.Join(sections, "\n\n")
+	return strings.Join(sections, "\n")
 }
 
 // ─── agent_record_usage: 记录 token 用量 ───

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -174,12 +174,7 @@ Examples:
 	a := agent.NewAgent(cfg, store, llm, tools, display)
 
 	// 加载工具定义（编译时嵌入的 tools.json）
-	toolDefs, err := agent.UtilLoadToolDefs("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: load tools.json: %v\n", err)
-		os.Exit(1)
-	}
-	a.SetToolDefs(toolDefs)
+	a.SetToolDefs(agent.UtilLoadToolDefs())
 
 	// Session 管理
 	sessionID := session

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -173,10 +173,8 @@ Examples:
 	// 创建 agent
 	a := agent.NewAgent(cfg, store, llm, tools, display)
 
-	// 加载工具定义：优先使用同目录下的 tools.json，否则使用编译时嵌入的默认定义
-	execPath, _ := os.Executable()
-	scriptDir := filepath.Dir(execPath)
-	toolDefs, err := agent.UtilLoadToolDefs(scriptDir)
+	// 加载工具定义（编译时嵌入的 tools.json）
+	toolDefs, err := agent.UtilLoadToolDefs("")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: load tools.json: %v\n", err)
 		os.Exit(1)

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -173,17 +173,13 @@ Examples:
 	// 创建 agent
 	a := agent.NewAgent(cfg, store, llm, tools, display)
 
-	// 加载工具定义
+	// 加载工具定义：优先使用同目录下的 tools.json，否则使用编译时嵌入的默认定义
 	execPath, _ := os.Executable()
 	scriptDir := filepath.Dir(execPath)
 	toolDefs, err := agent.UtilLoadToolDefs(scriptDir)
 	if err != nil {
-		// 尝试源码目录
-		toolDefs, err = agent.UtilLoadToolDefs(".")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: load tools.json: %v\n", err)
-			os.Exit(1)
-		}
+		fmt.Fprintf(os.Stderr, "Error: load tools.json: %v\n", err)
+		os.Exit(1)
 	}
 	a.SetToolDefs(toolDefs)
 

--- a/go/store.go
+++ b/go/store.go
@@ -397,6 +397,12 @@ func (s *FileStore) SetSummary(text string) error {
 func (s *FileStore) GetPlan() (string, error) {
 	return UtilReadOptional(s.planFile)
 }
+func (s *FileStore) PlanPath() string {
+	return s.planFile
+}
+func (s *FileStore) PlanDraftPath() string {
+	return s.planDraftFile
+}
 
 func (s *FileStore) SetPlan(text string) error {
 	s.mu.Lock()

--- a/go/tools.json
+++ b/go/tools.json
@@ -1,0 +1,234 @@
+[
+  {
+    "name": "Read",
+    "description": "Read a file from the local filesystem. Use multiple Read calls if you need multiple files. Output includes line numbers (cat -n format). By default reads the whole file; use offset/limit to read specific line ranges.\n\nIMPORTANT - Prefer Grep over Read:\n- When searching for specific content, ALWAYS use Grep first — it returns only matching lines, never truncates, and keeps context small.\n- Read loads entire files into context, which rapidly inflates token usage. Use it ONLY when you already know exactly which lines you need (e.g. after a Grep located the target), or when you must understand the full file structure.\n- Grep with context provides enough surrounding lines for Edit in most cases, eliminating the need for a separate Read.\n- If a Read result is truncated (you see a truncation notice), do NOT re-read the same range — use Grep to search instead.\n- Use Read with offset/limit only when you already know the target line range (e.g. from a prior Grep).",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the file to read"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Line number to start reading from (1-indexed). Only provide when reading a specific portion of the file."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Number of lines to read. Only provide when reading a specific portion of the file."
+        }
+      },
+      "required": ["path"]
+    }
+  },
+  {
+    "name": "Write",
+    "description": "Write a file to the local filesystem.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the file to write"
+        },
+        "content": {
+          "type": "string",
+          "description": "Content to write to the file"
+        }
+      },
+      "required": ["path", "content"]
+    }
+  },
+  {
+    "name": "Edit",
+    "description": "Edit a file by replacing an exact string match with a new string. old_string must match byte-for-byte (including whitespace/indent/newlines). Before editing, locate the exact text — prefer Grep with context to capture the target in one step; use Read with offset/limit only if you already know the exact line range. Copy the exact text before calling Edit.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the file to edit"
+        },
+        "old_string": {
+          "type": "string",
+          "description": "The exact text to find and replace"
+        },
+        "new_string": {
+          "type": "string",
+          "description": "The replacement text"
+        }
+      },
+      "required": ["path", "old_string", "new_string"]
+    }
+  },
+  {
+    "name": "Bash",
+    "description": "Execute a bash command. Returns stdout and stderr.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "The bash command to execute"
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Timeout in seconds. If the command exceeds this duration, it will be killed. Only use for commands expected to take a long time (e.g. build, test, server start). Default: uses --tool-timeout setting."
+        }
+      },
+      "required": ["command"]
+    }
+  },
+  {
+    "name": "Glob",
+    "description": "Find files matching a single glob pattern. Use multiple Glob calls if you need multiple patterns.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Glob pattern, for example **/*.sh"
+        },
+        "path": {
+          "type": "string",
+          "description": "Optional directory to search from. Defaults to ."
+        }
+      },
+      "required": ["pattern"]
+    }
+  },
+  {
+    "name": "Grep",
+    "description": "Search file contents with ripgrep. Supports regex patterns.\n- Use context to show surrounding lines — often enough for Edit without a separate Read\n- Use multiple Grep calls if you need multiple patterns",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "The regular expression pattern to search for"
+        },
+        "path": {
+          "type": "string",
+          "description": "File or directory to search in. Defaults to ."
+        },
+        "glob": {
+          "type": "string",
+          "description": "Glob pattern to filter files (e.g. \"*.js\", \"*.{ts,tsx}\")"
+        },
+        "context": {
+          "type": "integer",
+          "description": "Number of lines before and after each match. Useful for getting enough context to Edit directly from Grep output."
+        }
+      },
+      "required": ["pattern"]
+    }
+  },
+  {
+    "name": "TodoWrite",
+    "description": "Create and manage a structured task list for the current coding session. Use proactively for complex multi-step implementation, debugging, refactoring, review, or multi-file work. Do not use for trivial single-step or purely informational requests.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "todos": {
+          "type": "array",
+          "description": "The full updated todo list for the current session. Send the complete list each time, not a partial diff.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "A short, concrete, actionable task description."
+              },
+              "status": {
+                "type": "string",
+                "description": "Task status: pending, in_progress, or completed. Prefer exactly one in_progress item while actively working."
+              }
+            },
+            "required": ["content", "status"]
+          }
+        }
+      },
+      "required": ["todos"]
+    }
+  },
+  {
+    "name": "PlanConfirm",
+    "description": "Confirm and lock in the current plan draft. Call this ONLY when the user explicitly confirms the plan. Do NOT call this during drafting or when the user requests changes — only on explicit confirmation.",
+    "input_schema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "PlanClear",
+    "description": "Clear the current plan. Call this when the current plan is fully completed and all tasks are done. After calling this, the system prompt will no longer include the plan section.",
+    "input_schema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "Skill",
+    "description": "First look in the skill-index section of the prompt to find the right skill name. Then use Skill(name) to read it. Use this instead of reading skill files directly with Read when the user asks to use a skill.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The skill name selected from the skill-index section of the prompt"
+        }
+      },
+      "required": ["name"]
+    }
+  },
+  {
+    "name": "WebSearch",
+    "description": "Search the web using a query and return search results with titles and URLs. Use this tool for accessing current information beyond your knowledge cutoff, such as recent events, latest documentation, or current data.\n\nCRITICAL REQUIREMENT - You MUST follow this:\n  - After answering the user's question, you MUST include a \"Sources:\" section at the end of your response\n  - In the Sources section, list all relevant URLs from the search results as markdown hyperlinks: [Title](URL)\n  - This is MANDATORY - never skip including sources in your response",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "The search query to use"
+        }
+      },
+      "required": ["query"]
+    }
+  },
+  {
+    "name": "WebFetch",
+    "description": "Fetches content from a specified URL and returns it as markdown. Use this tool when you need to retrieve and analyze web content.\n\nUsage notes:\n  - IMPORTANT: WebFetch WILL FAIL for authenticated or private URLs. Check if the URL points to an authenticated service (e.g. Google Docs, Confluence, Jira) before using.\n  - The URL must be a fully-formed valid URL\n  - HTTP URLs will be automatically upgraded to HTTPS\n  - This tool is read-only and does not modify any files\n  - Results may be summarized if the content is very large",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL to fetch content from"
+        }
+      },
+      "required": ["url"]
+    }
+  },
+  {
+    "name": "SubAgent",
+    "description": "Launches a sub-agent that runs asynchronously in the background. The sub-agent executes the given prompt as an independent agent session. Returns a start acknowledgement immediately; the actual result is injected into the parent session when complete. Use this for delegating sub-tasks that can run in parallel.\n\nFork mode: pass fork=true to inherit parent session context (conversation history, plan, skills). Default is a fresh independent session.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "description": "The prompt/task to delegate to the sub-agent"
+        },
+        "description": {
+          "type": "string",
+          "description": "Short description of the sub-agent task (for logging)"
+        },
+        "fork": {
+          "type": "boolean",
+          "description": "Set to true to fork parent session context (conversation history, plan, skills). Default is false for a fresh independent session."
+        }
+      },
+      "required": ["prompt"]
+    }
+  }
+]

--- a/go/transport.go
+++ b/go/transport.go
@@ -428,6 +428,8 @@ func (t *HTTPTransport) extractJSONValue(data, key string) string {
 }
 
 // extractUsageFromDelta 从 message_delta 提取 usage
+// output_tokens: 总是取。input_tokens/cache_*: 仅在 message_start 未提供时取
+// （OpenAI 路径无 message_start，通过 transport 合成 message_delta）
 func (t *HTTPTransport) extractUsageFromDelta(data string, inputTokens, outputTokens, cacheRead, cacheCreate *int) {
 	var d struct {
 		Usage struct {
@@ -444,13 +446,13 @@ func (t *HTTPTransport) extractUsageFromDelta(data string, inputTokens, outputTo
 		if d.Usage.OutputTokens > 0 {
 			*outputTokens = d.Usage.OutputTokens
 		}
-		if d.Usage.InputTokens > 0 {
+		if *inputTokens == 0 && d.Usage.InputTokens > 0 {
 			*inputTokens = d.Usage.InputTokens
 		}
-		if d.Usage.CacheReadInputTokens > 0 {
+		if *cacheRead == 0 && d.Usage.CacheReadInputTokens > 0 {
 			*cacheRead = d.Usage.CacheReadInputTokens
 		}
-		if d.Usage.CacheCreationInputTokens > 0 {
+		if *cacheCreate == 0 && d.Usage.CacheCreationInputTokens > 0 {
 			*cacheCreate = d.Usage.CacheCreationInputTokens
 		}
 	}

--- a/go/types.go
+++ b/go/types.go
@@ -180,6 +180,8 @@ type SessionStore interface {
 	IncrementCompact() error
 
 	// Plan
+	PlanPath() string
+	PlanDraftPath() string
 	GetPlan() (string, error)
 	SetPlan(text string) error
 	GetPlanDraft() (string, error)

--- a/go/util.go
+++ b/go/util.go
@@ -352,21 +352,12 @@ func UtilBuildAssistantJSON(text, thinking string, calls []ToolCallInfo) string 
 	return buf.String()
 }
 
-// UtilLoadToolDefs 从 tools.json 加载工具定义，文件不存在时返回嵌入的默认定义。
-func UtilLoadToolDefs(scriptDir string) (string, error) {
-	toolsFile := filepath.Join(scriptDir, "tools.json")
-	if fileExists(toolsFile) {
-		data, err := os.ReadFile(toolsFile)
-		if err != nil {
-			return "", err
-		}
-		return string(data), nil
-	}
-	// 文件不存在时使用编译时嵌入的默认 tools.json
+// UtilLoadToolDefs 返回编译时嵌入的 tools.json 工具定义。
+func UtilLoadToolDefs(_ string) (string, error) {
 	if embeddedToolsJSON != "" {
 		return embeddedToolsJSON, nil
 	}
-	return "", fmt.Errorf("cannot find tools.json: %s", toolsFile)
+	return "", fmt.Errorf("embedded tools.json is empty")
 }
 
 // ─── 内部辅助函数 ───

--- a/go/util.go
+++ b/go/util.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -13,6 +14,9 @@ import (
 	"strings"
 	"time"
 )
+
+//go:embed tools.json
+var embeddedToolsJSON string
 
 // ─── util_* 工具函数（23 个） ───
 
@@ -348,17 +352,21 @@ func UtilBuildAssistantJSON(text, thinking string, calls []ToolCallInfo) string 
 	return buf.String()
 }
 
-// UtilLoadToolDefs 从 tools.json 加载工具定义
+// UtilLoadToolDefs 从 tools.json 加载工具定义，文件不存在时返回嵌入的默认定义。
 func UtilLoadToolDefs(scriptDir string) (string, error) {
 	toolsFile := filepath.Join(scriptDir, "tools.json")
-	if !fileExists(toolsFile) {
-		return "", fmt.Errorf("cannot find tools.json: %s", toolsFile)
+	if fileExists(toolsFile) {
+		data, err := os.ReadFile(toolsFile)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
 	}
-	data, err := os.ReadFile(toolsFile)
-	if err != nil {
-		return "", err
+	// 文件不存在时使用编译时嵌入的默认 tools.json
+	if embeddedToolsJSON != "" {
+		return embeddedToolsJSON, nil
 	}
-	return string(data), nil
+	return "", fmt.Errorf("cannot find tools.json: %s", toolsFile)
 }
 
 // ─── 内部辅助函数 ───

--- a/go/util.go
+++ b/go/util.go
@@ -353,11 +353,8 @@ func UtilBuildAssistantJSON(text, thinking string, calls []ToolCallInfo) string 
 }
 
 // UtilLoadToolDefs 返回编译时嵌入的 tools.json 工具定义。
-func UtilLoadToolDefs(_ string) (string, error) {
-	if embeddedToolsJSON != "" {
-		return embeddedToolsJSON, nil
-	}
-	return "", fmt.Errorf("embedded tools.json is empty")
+func UtilLoadToolDefs() string {
+	return embeddedToolsJSON
 }
 
 // ─── 内部辅助函数 ───

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -216,7 +216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -230,6 +229,17 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -251,6 +261,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -876,7 +887,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -898,12 +908,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -929,6 +941,8 @@ dependencies = [
  "anyhow",
  "crossterm",
  "ctrlc",
+ "libc",
+ "nix 0.31.2",
  "once_cell",
  "regex",
  "reqwest",
@@ -936,6 +950,8 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1287,9 +1303,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1299,6 +1329,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1497,6 +1551,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,13 +7,17 @@ edition = "2024"
 anyhow = "1"
 once_cell = "1"
 regex = "1"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rustyline = "14"
 ctrlc = "3"
 crossterm = "0.28"
+nix = "0.31"
+libc = "0.2"
 time = { version = "0.3.47", features = ["formatting", "macros"] }
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
 
 [profile.release]
 opt-level = "s"

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -26,25 +26,21 @@ use serde_json::{Value, json};
 use std::cell::RefCell;
 use std::fs;
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::io::IntoRawFd;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::mpsc;
 
 type TransportRef = Arc<dyn crate::transport::Transport>;
 
 mod httpclient {
     use anyhow::{Result, anyhow};
-    use reqwest::blocking::{Client, Response};
+    use reqwest::Client;
     use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-    use std::collections::VecDeque;
     use std::fmt;
-    use std::io::{Read, Result as IoResult};
-    use std::sync::mpsc;
-    use std::sync::mpsc::{Receiver, RecvTimeoutError};
-    use std::thread;
-    use std::thread::sleep;
     use std::time::{Duration, Instant};
 
     #[derive(Debug)]
@@ -68,10 +64,7 @@ mod httpclient {
     impl HTTPError {
         pub fn format_detailed(&self) -> String {
             if self.status_code > 0 {
-                format!(
-                    "ERROR:{}\tHTTP {}: {}",
-                    self.status_code, self.status_code, self.body
-                )
+                format!("ERROR:{}\tHTTP {}: {}", self.status_code, self.status_code, self.body)
             } else {
                 format!("ERROR:0\t{}", self.body)
             }
@@ -86,21 +79,27 @@ mod httpclient {
     const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
     const DEFAULT_RETRY_MAX_TIME: Duration = Duration::from_secs(20);
     const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-    const DEFAULT_STREAM_LOW_SPEED_LIMIT: usize = 1;
-    const DEFAULT_STREAM_LOW_SPEED_TIME: Duration = Duration::from_secs(60);
-    const DEFAULT_STREAM_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
     impl StreamClient {
         pub fn new() -> Result<Self> {
             Ok(Self {
                 client: Client::builder()
-                    .timeout(Duration::from_secs(300)) // 总请求超时 5 分钟，防止 spawn_reader 线程无限阻塞
+                    .timeout(Duration::from_secs(300))
                     .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
                     .build()?,
             })
         }
 
-        pub fn post(&self, url: &str, headers: &[(String, String)], body: &[u8]) -> Result<StreamBody> {
+        /// 同步封装：内部使用 tokio runtime 执行 async HTTP 请求。
+        pub fn post(&self, url: &str, headers: &[(String, String)], body: &[u8]) -> Result<reqwest::Response> {
+            let client = self.client.clone();
+            let url = url.to_string();
+            let hdrs: Vec<(String, String)> = headers.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            let body = body.to_vec();
+            super::tokio_runtime().block_on(Self::async_post(client, &url, &hdrs, &body))
+        }
+
+        async fn async_post(client: Client, url: &str, headers: &[(String, String)], body: &[u8]) -> Result<reqwest::Response> {
             let mut h = HeaderMap::new();
             for (k, v) in headers {
                 h.insert(
@@ -108,335 +107,33 @@ mod httpclient {
                     HeaderValue::from_str(v).map_err(|e| anyhow!(e.to_string()))?,
                 );
             }
-
             let start = Instant::now();
-            let mut attempt: u32 = 0;
+            let mut attempt = 0u32;
             loop {
-                let resp = self
-                    .client
-                    .post(url)
-                    .headers(h.clone())
-                    .body(body.to_vec())
-                    .send();
-
+                attempt += 1;
+                let resp = client.post(url).headers(h.clone()).body(body.to_vec()).send().await;
                 match resp {
                     Ok(resp) => {
                         let code = resp.status().as_u16();
                         if code >= 400 {
-                            let text = resp.text().unwrap_or_default();
-                            let retryable =
-                                should_retry_status(code) && should_retry_attempt(attempt, start);
-                            if retryable {
-                                sleep(DEFAULT_RETRY_DELAY);
-                                attempt += 1;
+                            let text = resp.text().await.unwrap_or_default();
+                            if code >= 500 && attempt < DEFAULT_RETRY_COUNT && start.elapsed() < DEFAULT_RETRY_MAX_TIME {
+                                tokio::time::sleep(DEFAULT_RETRY_DELAY).await;
                                 continue;
                             }
-                            return Err(HTTPError {
-                                status_code: code,
-                                body: text.trim().to_string(),
-                            }
-                            .into());
+                            return Err(HTTPError { status_code: code, body: text.trim().to_string() }.into());
                         }
-                        return StreamBody::new(
-                            self.client.clone(),
-                            url.to_string(),
-                            h.clone(),
-                            body.to_vec(),
-                            resp,
-                            DEFAULT_STREAM_LOW_SPEED_LIMIT,
-                            DEFAULT_STREAM_LOW_SPEED_TIME,
-                            DEFAULT_STREAM_CHECK_INTERVAL,
-                            DEFAULT_RETRY_COUNT,
-                            DEFAULT_RETRY_DELAY,
-                            start,
-                        );
+                        return Ok(resp);
                     }
-                    Err(err) => {
-                        if should_retry_attempt(attempt, start) {
-                            sleep(DEFAULT_RETRY_DELAY);
-                            attempt += 1;
+                    Err(e) => {
+                        if attempt < DEFAULT_RETRY_COUNT && start.elapsed() < DEFAULT_RETRY_MAX_TIME {
+                            tokio::time::sleep(DEFAULT_RETRY_DELAY).await;
                             continue;
                         }
-                        return Err(HTTPError {
-                            status_code: 0,
-                            body: err.to_string(),
-                        }
-                        .into());
+                        return Err(HTTPError { status_code: 0, body: e.to_string() }.into());
                     }
                 }
             }
-        }
-    }
-
-    pub struct StreamBody {
-        client: Client,
-        url: String,
-        headers: HeaderMap,
-        request_body: Vec<u8>,
-        max_retries: u32,
-        retry_delay: Duration,
-        start: Instant,
-        attempt: u32,
-        rx: Receiver<StreamChunk>,
-        buf: std::io::Cursor<Vec<u8>>,
-        done: bool,
-        low_speed_limit: usize,
-        low_speed_time: Duration,
-        check_interval: Duration,
-        samples: VecDeque<StreamSample>,
-        window_bytes: usize,
-    }
-
-    #[derive(Clone)]
-    struct StreamChunk {
-        at: Instant,
-        data: Vec<u8>,
-    }
-
-    #[derive(Clone)]
-    struct StreamSample {
-        at: Instant,
-        bytes: usize,
-    }
-
-    impl StreamBody {
-        fn new(
-            client: Client,
-            url: String,
-            headers: HeaderMap,
-            request_body: Vec<u8>,
-            resp: Response,
-            low_speed_limit: usize,
-            low_speed_time: Duration,
-            check_interval: Duration,
-            max_retries: u32,
-            retry_delay: Duration,
-            start: Instant,
-        ) -> Result<Self> {
-            let rx = spawn_reader(resp);
-            Ok(Self {
-                client,
-                url,
-                headers,
-                request_body,
-                max_retries,
-                retry_delay,
-                start,
-                attempt: 0,
-                rx,
-                buf: std::io::Cursor::new(Vec::new()),
-                done: false,
-                low_speed_limit,
-                low_speed_time,
-                check_interval,
-                samples: VecDeque::new(),
-                window_bytes: 0,
-            })
-        }
-
-        fn try_retry(&mut self) -> std::io::Result<()> {
-            sleep(self.retry_delay);
-            let resp = self
-                .client
-                .post(&self.url)
-                .headers(self.headers.clone())
-                .body(self.request_body.clone())
-                .send()
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-            let code = resp.status().as_u16();
-            if code >= 400 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("HTTP {} on retry", code),
-                ));
-            }
-            self.rx = spawn_reader(resp);
-            self.done = false;
-            Ok(())
-        }
-    }
-
-    fn spawn_reader(mut resp: Response) -> Receiver<StreamChunk> {
-        let (tx, rx) = mpsc::channel();
-        let _ = thread::spawn(move || {
-            let mut buf = [0u8; 8192];
-            loop {
-                match resp.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if tx
-                            .send(StreamChunk {
-                                at: Instant::now(),
-                                data: buf[..n].to_vec(),
-                            })
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-        rx
-    }
-
-    impl Read for StreamBody {
-        fn read(&mut self, out: &mut [u8]) -> IoResult<usize> {
-            if self.done {
-                return Ok(0);
-            }
-            loop {
-                if (self.buf.position() as usize) < self.buf.get_ref().len() {
-                    return self.buf.read(out);
-                }
-                match self.rx.recv_timeout(self.check_interval) {
-                    Ok(chunk) => {
-                        self.record_chunk(chunk.at, chunk.data.len());
-                        self.buf = std::io::Cursor::new(chunk.data);
-                    }
-                    Err(RecvTimeoutError::Timeout) => {
-                        if self.low_speed_exceeded(Instant::now()) {
-                            if self.attempt < self.max_retries
-                                && should_retry_attempt(self.attempt, self.start)
-                            {
-                                self.attempt += 1;
-                                match self.try_retry() {
-                                    Ok(()) => {
-                                        self.buf = std::io::Cursor::new(b"RETRY:\n".to_vec());
-                                        continue;
-                                    }
-                                    Err(_) => {
-                                        self.done = true;
-                                        return Err(std::io::Error::new(
-                                            std::io::ErrorKind::TimedOut,
-                                            "stream low speed timeout",
-                                        ));
-                                    }
-                                }
-                            }
-                            self.done = true;
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::TimedOut,
-                                "stream low speed timeout",
-                            ));
-                        }
-                    }
-                    Err(RecvTimeoutError::Disconnected) => {
-                        self.done = true;
-                        return Ok(0);
-                    }
-                }
-            }
-        }
-    }
-
-    impl Drop for StreamBody {
-        fn drop(&mut self) {
-            self.done = true;
-        }
-    }
-
-    impl StreamBody {
-        fn record_chunk(&mut self, at: Instant, bytes: usize) {
-            self.samples.push_back(StreamSample { at, bytes });
-            self.window_bytes = self.window_bytes.saturating_add(bytes);
-            self.prune_window(at);
-        }
-
-        fn prune_window(&mut self, now: Instant) {
-            while let Some(sample) = self.samples.front() {
-                if now.saturating_duration_since(sample.at) <= self.low_speed_time {
-                    break;
-                }
-                self.window_bytes = self.window_bytes.saturating_sub(sample.bytes);
-                self.samples.pop_front();
-            }
-        }
-
-        fn low_speed_exceeded(&mut self, now: Instant) -> bool {
-            self.prune_window(now);
-            if now.duration_since(self.start) < self.low_speed_time {
-                return false;
-            }
-            self.window_bytes
-                < self
-                    .low_speed_limit
-                    .saturating_mul(self.low_speed_time.as_secs() as usize)
-        }
-    }
-
-    fn should_retry_attempt(attempt: u32, start: Instant) -> bool {
-        if attempt >= DEFAULT_RETRY_COUNT {
-            return false;
-        }
-        start.elapsed() + DEFAULT_RETRY_DELAY <= DEFAULT_RETRY_MAX_TIME
-    }
-
-    fn should_retry_status(code: u16) -> bool {
-        matches!(code, 408 | 409 | 425 | 429 | 500 | 502 | 503 | 504)
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::{StreamBody, StreamChunk};
-        use reqwest::blocking::Client;
-        use reqwest::header::HeaderMap;
-        use std::collections::VecDeque;
-        use std::sync::mpsc;
-        use std::time::{Duration, Instant};
-
-        #[test]
-        fn low_speed_window_expires_without_bytes() {
-            let start = Instant::now();
-            let mut body = StreamBody {
-                client: Client::new(),
-                url: String::new(),
-                headers: HeaderMap::new(),
-                request_body: Vec::new(),
-                max_retries: 0,
-                retry_delay: Duration::from_secs(1),
-                start,
-                attempt: 0,
-                rx: mpsc::channel::<StreamChunk>().1,
-                buf: std::io::Cursor::new(Vec::new()),
-                done: false,
-                low_speed_limit: 1,
-                low_speed_time: Duration::from_secs(60),
-                check_interval: Duration::from_secs(1),
-                samples: VecDeque::new(),
-                window_bytes: 0,
-            };
-
-            assert!(!body.low_speed_exceeded(start + Duration::from_secs(59)));
-            assert!(body.low_speed_exceeded(start + Duration::from_secs(60)));
-        }
-
-        #[test]
-        fn low_speed_window_uses_recent_bytes_only() {
-            let start = Instant::now();
-            let mut body = StreamBody {
-                client: Client::new(),
-                url: String::new(),
-                headers: HeaderMap::new(),
-                request_body: Vec::new(),
-                max_retries: 0,
-                retry_delay: Duration::from_secs(1),
-                start,
-                attempt: 0,
-                rx: mpsc::channel::<StreamChunk>().1,
-                buf: std::io::Cursor::new(Vec::new()),
-                done: false,
-                low_speed_limit: 1,
-                low_speed_time: Duration::from_secs(60),
-                check_interval: Duration::from_secs(1),
-                samples: VecDeque::new(),
-                window_bytes: 0,
-            };
-
-            body.record_chunk(start + Duration::from_secs(30), 100);
-            assert!(!body.low_speed_exceeded(start + Duration::from_secs(60)));
-            assert!(body.low_speed_exceeded(start + Duration::from_secs(91)));
         }
     }
 }
@@ -446,14 +143,59 @@ use httpclient::{HTTPError, StreamClient};
 /// 全局 SIGINT 标志，防止多个 agent 相互覆盖 ctrlc handler。
 /// 只在 agent_run / interactive_mode 中设一次。
 static CTRLC_FLAG: AtomicBool = AtomicBool::new(false);
+/// 全局 cancel pipe 写端 FD，ctrlc handler 通过写入此 pipe 传播中断信号。
+static CANCEL_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+
+/// 全局 tokio 运行时，嵌入在 sync 应用中使用 async HTTP。
+pub fn tokio_runtime() -> &'static tokio::runtime::Runtime {
+    use std::sync::OnceLock;
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| tokio::runtime::Runtime::new().expect("tokio runtime"))
+}
+
+/// 基于 std::sync::mpsc channel 的 Read 实现。
+/// async 数据流发送端写入 channel，parse_sse 通过这里读取。
+struct ChannelReader {
+    rx: std::sync::mpsc::Receiver<Vec<u8>>,
+    buf: Vec<u8>,
+    pos: usize,
+}
+
+impl Read for ChannelReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.buf.len() {
+            match self.rx.recv() {
+                Ok(data) => {
+                    self.buf = data;
+                    self.pos = 0;
+                }
+                Err(_) => return Ok(0), // channel closed = EOF
+            }
+        }
+        let n = std::cmp::min(buf.len(), self.buf.len() - self.pos);
+        buf[..n].copy_from_slice(&self.buf[self.pos..self.pos + n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
 
 pub fn agent_run(cfg: Config, cwd: PathBuf, home: PathBuf) -> Result<()> {
-    // 全局 ctrlc handler：只在第一次调用时注册
+    // 创建全局 cancel pipe：ctrlc handler 写入，tool 执行通过 kqueue 等待读取
+    let (cancel_r, cancel_w) = nix::unistd::pipe()?;
+    CANCEL_WRITE_FD.store(cancel_w.as_raw_fd(), Ordering::SeqCst);
+    let cancel_read_fd = cancel_r.into_raw_fd();
+
+    // 全局 ctrlc handler：写入 cancel pipe（kqueue）+ 设置 CTRLC_FLAG（interrupted 轮询）
     ctrlc::set_handler(move || {
         CTRLC_FLAG.store(true, Ordering::SeqCst);
+        let fd = CANCEL_WRITE_FD.load(Ordering::SeqCst);
+        if fd >= 0 {
+            let _ = unsafe { libc::write(fd, b"x" as *const u8 as *const libc::c_void, 1) };
+        }
     }).ok();
 
     let mut rt = Agent::new(cfg, cwd, home)?;
+    rt.cancel_read_fd = cancel_read_fd;
 
     if rt.cfg.interactive || (rt.cfg.prompt.is_empty() && io::stdin().is_terminal()) {
         rt.cfg.interactive = true;
@@ -531,6 +273,7 @@ pub(crate) struct Agent {
     sub_agent_request_count: usize,          // SubAgent 请求计数
     stdout: RefCell<Box<dyn Write + Send>>,  // 可替换的输出目标（子 agent 时为 sink）
     stderr: RefCell<Box<dyn Write + Send>>,  // 可替换的错误输出目标（子 agent 时为 sink）
+    cancel_read_fd: i32,                      // cancel pipe 读端 FD，传给 Runner 做 kqueue wait
 }
 
 struct DisplayState {
@@ -550,30 +293,8 @@ struct LlmStream {
     interrupted: Arc<AtomicBool>,
 }
 
-struct CancelReader<R> {
-    inner: R,
-    cancel: Arc<AtomicBool>,
-    interrupted: Arc<AtomicBool>,
-}
 
-impl<R: Read> Read for CancelReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if self.cancel.load(Ordering::SeqCst) || self.interrupted.load(Ordering::SeqCst) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Interrupted,
-                "cancelled",
-            ));
-        }
-        let n = self.inner.read(buf)?;
-        if self.cancel.load(Ordering::SeqCst) || self.interrupted.load(Ordering::SeqCst) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Interrupted,
-                "cancelled",
-            ));
-        }
-        Ok(n)
-    }
-}
+
 
 impl LlmStream {
     fn next_event(&mut self) -> Result<Option<Event>> {
@@ -682,6 +403,7 @@ impl Agent {
             sub_agent_request_count: 0,
             stdout: RefCell::new(Box::new(io::stdout())),
             stderr: RefCell::new(Box::new(io::stderr())),
+            cancel_read_fd: 0, // 占位，稍后由 agent_run 设置
         };
 
         if new_session {
@@ -788,6 +510,7 @@ impl Agent {
                 sub_agent_request_count: 0,
                 stdout: RefCell::new(Box::new(io::empty())),  // 子 agent 输出全部丢弃（与 Go 的 io.Discard、Bash 的 >/dev/null 对应）
                 stderr: RefCell::new(Box::new(io::empty())),  // 子 agent 错误输出全部丢弃
+                cancel_read_fd: -1,
             };
 
             // 4. 执行 agent_loop
@@ -1009,8 +732,11 @@ impl Agent {
                     }
                     if let Err(e) = self.agent_loop(input) {
                         let msg = e.to_string();
-                        // 不打印 interrupted 错误
-                        if msg != "interrupted" {
+                        // 不打印中断相关的错误（包括 SSE 流被 Ctrl+C 断开的情况）
+                        let is_interrupt = msg == "interrupted"
+                            || msg == "sse_parse: cancelled"
+                            || msg.contains("ConnectionAborted");
+                        if !is_interrupt {
                             self.error(&msg);
                         }
                     }
@@ -1177,6 +903,8 @@ impl Agent {
         if CTRLC_FLAG.swap(false, Ordering::SeqCst) {
             self.interrupted.store(true, Ordering::SeqCst);
         }
+        // drain cancel pipe：清理上次可能残留的 Ctrl+C 数据，防止 PollReader 误判
+        crate::tools::drain_fd(self.cancel_read_fd);
 
         let result = (|| -> Result<()> {
             self.conv.add_user(&user_input)?;
@@ -1209,6 +937,8 @@ impl Agent {
                     config: self.cfg.clone(),
                     cwd: self.cwd.clone(),
                     home: self.home.clone(),
+                    interrupted: self.interrupted.clone(),
+                    cancel_fd: self.cancel_read_fd,
                 };
 
                 let mut stream = match self.llm_stream() {
@@ -1225,7 +955,25 @@ impl Agent {
                         return Err(e);
                     }
                 };
-                while let Some(evt) = stream.next_event()? {
+                loop {
+                    let evt = match stream.next_event() {
+                        Ok(Some(e)) => e,
+                        Ok(None) => break,
+                        Err(e) => {
+                            // SSE 解析错误：如果是中断导致的，走正常 interrupted 分支
+                            let msg = e.to_string();
+                            if self.is_interrupted()
+                                || msg.contains("cancelled")
+                                || msg.contains("ConnectionAborted")
+                            {
+                                stop = "interrupted".to_string();
+                            } else {
+                                // 非中断的解析错误，直接返回
+                                return Err(e);
+                            }
+                            break;
+                        }
+                    };
                     if self.is_interrupted() {
                         stop = "interrupted".to_string();
                         break;
@@ -1374,6 +1122,7 @@ impl Agent {
                     }
                     // tool_use/tool_calls → loop continues; anything else → break
                     if stop.as_str() != "tool_use" && stop.as_str() != "tool_calls" {
+                        CTRLC_FLAG.store(false, Ordering::SeqCst);
                         return Ok(());
                     }
                 } else {
@@ -1389,6 +1138,7 @@ impl Agent {
                         }
                         self.info("Interrupted.");
                     }
+                    CTRLC_FLAG.store(false, Ordering::SeqCst);
                     return Ok(());
                 }
             }
@@ -1598,16 +1348,11 @@ impl Agent {
         };
 
         let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        let cancel_thread = cancel.clone();
-        let interrupted_thread = self.interrupted.clone();
         let transport = self.transport.clone();
+
+        // 同步线程：http_stream → ChannelReader → BufReader → parse_sse → events
+        let (reader, cancel) = self.http_stream(resp);
         let _reader_thread = std::thread::spawn(move || {
-            let reader = CancelReader {
-                inner: resp,
-                cancel: cancel_thread,
-                interrupted: interrupted_thread,
-            };
             let mut send = |evt: Event| -> Result<()> {
                 tx.send(StreamMsg::Event(evt))
                     .map_err(|e| anyhow!(e.to_string()))
@@ -1735,6 +1480,7 @@ impl Agent {
                 return Err(e);
             }
         };
+        let (channel_reader, _cancel) = self.http_stream(resp);
         let mut out = String::new();
         let mut last_error = String::new();
         let mut stop_reason = String::new();
@@ -1742,7 +1488,6 @@ impl Agent {
             match evt {
                 Event::Text(TextEvent { content }) => out.push_str(&content),
                 Event::Usage(usage) => {
-                    // Record compact usage to events and stats (matches bash run_summary_call)
                     let compact_evt = json!({
                         "type":"usage",
                         "input_tokens":usage.input_tokens,
@@ -1754,26 +1499,10 @@ impl Agent {
                     let _ = self.append_event(compact_evt);
                     store::store_stats_update(&self.paths.stats, |stats| {
                         Self::add_stat_usize(stats, "compact_request_count", 1);
-                        Self::add_stat_usize(
-                            stats,
-                            "total_input_tokens",
-                            usage.input_tokens as usize,
-                        );
-                        Self::add_stat_usize(
-                            stats,
-                            "total_output_tokens",
-                            usage.output_tokens as usize,
-                        );
-                        Self::add_stat_usize(
-                            stats,
-                            "total_cache_read_tokens",
-                            usage.cache_read_input_tokens as usize,
-                        );
-                        Self::add_stat_usize(
-                            stats,
-                            "total_cache_creation_tokens",
-                            usage.cache_creation_input_tokens as usize,
-                        );
+                        Self::add_stat_usize(stats, "total_input_tokens", usage.input_tokens as usize);
+                        Self::add_stat_usize(stats, "total_output_tokens", usage.output_tokens as usize);
+                        Self::add_stat_usize(stats, "total_cache_read_tokens", usage.cache_read_input_tokens as usize);
+                        Self::add_stat_usize(stats, "total_cache_creation_tokens", usage.cache_creation_input_tokens as usize);
                     })?;
                     self.update_term_title();
                 }
@@ -1783,12 +1512,7 @@ impl Agent {
             }
             Ok(())
         };
-        let cancel_reader = CancelReader {
-            inner: resp,
-            cancel: self.interrupted.clone(),
-            interrupted: self.interrupted.clone(),
-        };
-        self.transport.parse_sse(Box::new(cancel_reader), &mut parse_emit)?;
+        self.transport.parse_sse(Box::new(channel_reader), &mut parse_emit)?;
         if out.is_empty() {
             bail!(
                 "failed to generate context summary: empty text response (stop_reason={}, error={})",
@@ -1797,6 +1521,35 @@ impl Agent {
             );
         }
         Ok(out)
+    }
+
+    /// 通过 mpsc channel 流式传输 HTTP 响应体，100ms 轮询 interrupted + CTRLC_FLAG 实现可中断。
+    /// 返回 (ChannelReader, Arc<AtomicBool>)，后者用于 LlmStream::drop 时取消流。
+    /// 同时检查 per-agent 的 interrupted 和全局的 CTRLC_FLAG，确保 Ctrl+C 能立即中断当前流。
+    fn http_stream(&self, resp: reqwest::Response) -> (ChannelReader, Arc<AtomicBool>) {
+        let (chunk_tx, chunk_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+        let interrupted = self.interrupted.clone();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_clone = cancel.clone();
+        tokio_runtime().spawn(async move {
+            use tokio_stream::StreamExt;
+            let stream = resp.bytes_stream();
+            tokio::pin!(stream);
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                        if interrupted.load(Ordering::SeqCst) || CTRLC_FLAG.load(Ordering::SeqCst) || cancel_clone.load(Ordering::SeqCst) { break; }
+                    }
+                    chunk = stream.next() => {
+                        match chunk {
+                            Some(Ok(bytes)) => { if chunk_tx.send(bytes.to_vec()).is_err() { break; } }
+                            _ => break,
+                        }
+                    }
+                }
+            }
+        });
+        (ChannelReader { rx: chunk_rx, buf: Vec::new(), pos: 0 }, cancel)
     }
 
     fn headers(&self) -> Vec<(String, String)> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -961,7 +961,11 @@ pub mod prompt {
             };
             sections.push(wrap_section("agent-identity", &identity, None));
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "unknown".to_string());
-            let platform = std::env::consts::OS;
+            let platform = match std::env::consts::OS {
+                "macos" => "Darwin",
+                "linux" => "Linux",
+                other => other,
+            };
             let environment = format!(
                 "lang: {}\npwd: {}\nhome: {}\nplatform: {}\nshell: {}",
                 locale,
@@ -975,7 +979,7 @@ pub mod prompt {
             sections.push(wrap_section("rules", &rules_str, None));
             sections.push(wrap_section(
                 "using-your-tools",
-                "- Use Read for a single file. If you need multiple files, call Read multiple times.\n- Read supports optional offset and limit parameters to read specific line ranges (saves tokens for large files). Output includes line numbers.\n- Use Glob and Grep for one pattern at a time.\n- Grep supports a context parameter to show surrounding lines — use it to get enough text for Edit directly from Grep output, avoiding a separate Read.\n- Use multiple tool calls in one response when they are independent.\n- Prefer dedicated tools over Bash when a dedicated tool fits the task.\n- For Edit: copy old_string exactly (including whitespace/indent/newlines). If you already know the location from prior context, use Read with offset/limit. If you need to locate the text first, use Grep with context — its output is often sufficient for Edit without an extra Read.\n- For skills, first check the skill-index section, then use Skill(name) for the matching skill.",
+                "- Use Read for a single file. If you need multiple files, call Read multiple times.\n- Read supports optional offset and limit parameters to read specific line ranges (saves tokens for large files). Output includes line numbers.\n- Use Glob and Grep for one pattern at a time.\n- Grep supports a context parameter to show surrounding lines — use it to get enough text for Edit directly from Grep output, avoiding a separate Read.\n- Use multiple tool calls in one response when they are independent.\n- Prefer dedicated tools over Bash when a dedicated tool fits the task.\n- For Edit: copy old_string exactly (including whitespace/indent/newlines). If you already know the location from prior context, use Read with offset/limit. If you need to locate the text first, use Grep with context — its output is often sufficient for Edit without an extra Read.\n- For skills, first check the skill-index section, then use Skill(name) for the matching skill.\n- SubAgent launches a background agent session. Results are injected back into your conversation when complete. Use for parallelizable or independent sub-tasks. See sub-agent-guidance section for context inheritance rules.",
                 None,
             ));
             sections.push(wrap_section(
@@ -1000,24 +1004,16 @@ pub mod prompt {
             };
             let plan_lifecycle_guidance = format!(
                 "- **PLANNING WORKFLOW** — For complex multi-step tasks (3+ steps OR multi-file OR user requests planning)\n\
+                 - **Files**: PLAN_DRAFT_FILE: {} | PLAN_FILE: {}\n\
                  - **Why draft first?** Writing to PLAN_FILE immediately invalidates the system prompt cache. Use PLAN_DRAFT_FILE for all drafting iterations to avoid this cost.\n\
-                 - **Step-by-step**:\n\
-                   1. Write draft to PLAN_DRAFT_FILE using Edit (markdown: goal, analysis, steps, notes)\n\
-                   2. Ask user to confirm the plan before execution\n\
-                   3. **Draft revision loop**: while PLAN_DRAFT_FILE is non-empty and user has NOT said \"confirmed\"/\"ok\"/\"go ahead\" (or equivalent), ANY user reply (questions, suggestions, objections, or implicit change requests) MUST be treated as revision feedback. ALWAYS update PLAN_DRAFT_FILE to reflect the discussion, then ask for confirmation again. NEVER just answer without updating the draft.\n\
-                   4. If user explicitly cancels/abandons: use Bash to clear PLAN_DRAFT_FILE (e.g. `: > PLAN_DRAFT_FILE`). Do NOT use PlanClear.\n\
-                   5. When user confirms: call PlanConfirm tool — this moves draft → PLAN_FILE and triggers a context compaction (cache invalidation is already happening, so we reclaim space at the same time).\n\
-                   6. After PlanConfirm, create TodoWrite checklist based on plan\n\
-                   7. Execute tasks following todo checklist (update progress in TodoWrite)\n\
-                   8. When all tasks complete, use PlanClear tool to clear plan and compact context\n\
-                 - **Plan vs Todo separation**:\n\
-                   - PLAN_FILE: locked-in plan (only written via PlanConfirm)\n\
-                   - PLAN_DRAFT_FILE: working draft during planning (safe to edit freely)\n\
-                   - TodoWrite: execution checklist for real-time progress tracking\n\
-                   - Do NOT mix todo checkboxes into plan files\n\
-                 - **Files**:\n\
-                   - PLAN_DRAFT_FILE: {}\n\
-                   - PLAN_FILE: {}",
+                 - **Drafting phase** (PLAN_DRAFT_FILE non-empty → you are drafting):\n\
+                   Every user reply MUST be classified as exactly ONE of:\n\
+                   ① REVISE (any feedback/question/change) → Edit PLAN_DRAFT_FILE → ask confirmation → stay in drafting\n\
+                   ② CONFIRM (explicit ok/go/confirmed) → call PlanConfirm IMMEDIATELY (before any other action) → TodoWrite checklist → execute\n\
+                   ③ CANCEL (explicit cancel/forget it) → Bash `: > PLAN_DRAFT_FILE` → exit to idle\n\
+                   ⚠ On CONFIRM you MUST call PlanConfirm first — no edits, no tool calls before it.\n\
+                 - **Execution phase**: after PlanConfirm → TodoWrite checklist → execute tasks → PlanClear when all done\n\
+                 - **Plan vs Todo**: PLAN_FILE=locked plan (only via PlanConfirm), PLAN_DRAFT_FILE=draft (edit freely), TodoWrite=progress tracker. Do NOT mix.",
                 plan_draft_file_display, plan_file_display
             );
             sections.push(wrap_section(

--- a/rust/src/sse.rs
+++ b/rust/src/sse.rs
@@ -230,20 +230,26 @@ pub mod claude {
                         }
                     }
                     let usage = body.get("usage").cloned().unwrap_or(Value::Null);
-                    if let Some(v) = usage.get("input_tokens").and_then(Value::as_i64) {
-                        input_tokens = v;
-                    }
+                    // message_delta.usage.output_tokens: 总是取
+                    // message_delta.usage.input_tokens/cache_*: 仅在 message_start 未提供时取
+                    // （OpenAI 路径无 message_start，通过 transport 合成 message_delta）
                     if let Some(v) = usage.get("output_tokens").and_then(Value::as_i64) {
                         output_tokens = v;
                     }
-                    if let Some(v) = usage.get("cache_read_input_tokens").and_then(Value::as_i64) {
-                        cache_read_input_tokens = v;
+                    if input_tokens == 0 {
+                        if let Some(v) = usage.get("input_tokens").and_then(Value::as_i64) {
+                            input_tokens = v;
+                        }
                     }
-                    if let Some(v) = usage
-                        .get("cache_creation_input_tokens")
-                        .and_then(Value::as_i64)
-                    {
-                        cache_creation_input_tokens = v;
+                    if cache_read_input_tokens == 0 {
+                        if let Some(v) = usage.get("cache_read_input_tokens").and_then(Value::as_i64) {
+                            cache_read_input_tokens = v;
+                        }
+                    }
+                    if cache_creation_input_tokens == 0 {
+                        if let Some(v) = usage.get("cache_creation_input_tokens").and_then(Value::as_i64) {
+                            cache_creation_input_tokens = v;
+                        }
                     }
                 }
                 "message_start" => {

--- a/rust/src/tools.json
+++ b/rust/src/tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Read",
-    "description": "Read a file from the local filesystem. Use multiple Read calls if you need multiple files. Output includes line numbers (cat -n format). By default reads the whole file; use offset/limit to read specific line ranges.\n\nIMPORTANT - Prefer Grep over Read:\n- When searching for specific content, ALWAYS use Grep first \u2014 it returns only matching lines, never truncates, and keeps context small.\n- Read loads entire files into context, which rapidly inflates token usage. Use it ONLY when you already know exactly which lines you need (e.g. after a Grep located the target), or when you must understand the full file structure.\n- Grep with context provides enough surrounding lines for Edit in most cases, eliminating the need for a separate Read.\n- If a Read result is truncated (you see a truncation notice), do NOT re-read the same range \u2014 use Grep to search instead.\n- Use Read with offset/limit only when you already know the target line range (e.g. from a prior Grep).",
+    "description": "Read a file from the local filesystem. Use multiple Read calls if you need multiple files. Output includes line numbers (cat -n format). By default reads the whole file; use offset/limit to read specific line ranges.\n\nIMPORTANT - Prefer Grep over Read:\n- When searching for specific content, ALWAYS use Grep first — it returns only matching lines, never truncates, and keeps context small.\n- Read loads entire files into context, which rapidly inflates token usage. Use it ONLY when you already know exactly which lines you need (e.g. after a Grep located the target), or when you must understand the full file structure.\n- Grep with context provides enough surrounding lines for Edit in most cases, eliminating the need for a separate Read.\n- If a Read result is truncated (you see a truncation notice), do NOT re-read the same range — use Grep to search instead.\n- Use Read with offset/limit only when you already know the target line range (e.g. from a prior Grep).",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -18,9 +18,7 @@
           "description": "Number of lines to read. Only provide when reading a specific portion of the file."
         }
       },
-      "required": [
-        "path"
-      ]
+      "required": ["path"]
     }
   },
   {
@@ -38,15 +36,12 @@
           "description": "Content to write to the file"
         }
       },
-      "required": [
-        "path",
-        "content"
-      ]
+      "required": ["path", "content"]
     }
   },
   {
     "name": "Edit",
-    "description": "Edit a file by replacing an exact string match with a new string. old_string must match byte-for-byte (including whitespace/indent/newlines). Before editing, locate the exact text \u2014 prefer Grep with context to capture the target in one step; use Read with offset/limit only if you already know the exact line range. Copy the exact text before calling Edit.",
+    "description": "Edit a file by replacing an exact string match with a new string. old_string must match byte-for-byte (including whitespace/indent/newlines). Before editing, locate the exact text — prefer Grep with context to capture the target in one step; use Read with offset/limit only if you already know the exact line range. Copy the exact text before calling Edit.",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -63,11 +58,7 @@
           "description": "The replacement text"
         }
       },
-      "required": [
-        "path",
-        "old_string",
-        "new_string"
-      ]
+      "required": ["path", "old_string", "new_string"]
     }
   },
   {
@@ -82,12 +73,10 @@
         },
         "timeout": {
           "type": "integer",
-          "description": "Timeout in seconds. If the command exceeds this duration, it will be killed. Only use for commands expected to take a long time (e.g. build, test, server start). Default: no timeout."
+          "description": "Timeout in seconds. If the command exceeds this duration, it will be killed. Only use for commands expected to take a long time (e.g. build, test, server start). Default: uses --tool-timeout setting."
         }
       },
-      "required": [
-        "command"
-      ]
+      "required": ["command"]
     }
   },
   {
@@ -105,14 +94,12 @@
           "description": "Optional directory to search from. Defaults to ."
         }
       },
-      "required": [
-        "pattern"
-      ]
+      "required": ["pattern"]
     }
   },
   {
     "name": "Grep",
-    "description": "Search file contents with ripgrep. Supports regex patterns.\n- Use context to show surrounding lines \u2014 often enough for Edit without a separate Read\n- Use multiple Grep calls if you need multiple patterns",
+    "description": "Search file contents with ripgrep. Supports regex patterns.\n- Use context to show surrounding lines — often enough for Edit without a separate Read\n- Use multiple Grep calls if you need multiple patterns",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -133,9 +120,7 @@
           "description": "Number of lines before and after each match. Useful for getting enough context to Edit directly from Grep output."
         }
       },
-      "required": [
-        "pattern"
-      ]
+      "required": ["pattern"]
     }
   },
   {
@@ -159,21 +144,16 @@
                 "description": "Task status: pending, in_progress, or completed. Prefer exactly one in_progress item while actively working."
               }
             },
-            "required": [
-              "content",
-              "status"
-            ]
+            "required": ["content", "status"]
           }
         }
       },
-      "required": [
-        "todos"
-      ]
+      "required": ["todos"]
     }
   },
   {
     "name": "PlanConfirm",
-    "description": "Confirm and lock in the current plan draft. Call this ONLY when the user explicitly confirms the plan. Do NOT call this during drafting or when the user requests changes \u2014 only on explicit confirmation.",
+    "description": "Confirm and lock in the current plan draft. Call this ONLY when the user explicitly confirms the plan. Do NOT call this during drafting or when the user requests changes — only on explicit confirmation.",
     "input_schema": {
       "type": "object",
       "properties": {}
@@ -198,9 +178,7 @@
           "description": "The skill name selected from the skill-index section of the prompt"
         }
       },
-      "required": [
-        "name"
-      ]
+      "required": ["name"]
     }
   },
   {
@@ -214,9 +192,7 @@
           "description": "The search query to use"
         }
       },
-      "required": [
-        "query"
-      ]
+      "required": ["query"]
     }
   },
   {
@@ -230,9 +206,7 @@
           "description": "The URL to fetch content from"
         }
       },
-      "required": [
-        "url"
-      ]
+      "required": ["url"]
     }
   },
   {
@@ -251,7 +225,7 @@
         },
         "fork": {
           "type": "boolean",
-          "description": "Set to true to inherit parent session context (conversation history, plan, skills). Default is false for a fresh independent session."
+          "description": "Set to true to fork parent session context (conversation history, plan, skills). Default is false for a fresh independent session."
         }
       },
       "required": ["prompt"]

--- a/rust/src/tools.rs
+++ b/rust/src/tools.rs
@@ -5,13 +5,15 @@ use crate::config::Config;
     use regex::Regex;
     use serde::Deserialize;
     use serde_json::Value;
+    use nix::unistd::pipe;
     use std::fs;
-    use std::io::{BufRead, BufReader, Read as IoRead};
+    use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
     use std::path::Path;
     use std::process::{Command, Stdio};
+    use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
     use std::thread;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     static RE_FIND_DELETE: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"(?i)(^|[;&|])\s*find\b.*\bdelete\b").expect("regex"));
@@ -26,6 +28,8 @@ use crate::config::Config;
         pub config: Config,
         pub cwd: std::path::PathBuf,
         pub home: std::path::PathBuf,
+        pub interrupted: Arc<AtomicBool>,
+        pub cancel_fd: i32, // cancel pipe 读端 FD，-1 表示不可用
     }
 
     #[derive(Debug, Clone, Deserialize)]
@@ -265,46 +269,90 @@ use crate::config::Config;
                 }),
             };
 
+            // 创建手动 pipe：写端给子进程，读端由 reader 线程读取
+            // 通过关闭读端 FD 来传播中断信号（chain 模式）
+            let (stdout_r, stdout_w): (OwnedFd, OwnedFd) = pipe()?;
+            let (stderr_r, stderr_w): (OwnedFd, OwnedFd) = pipe()?;
+
+            let stdout_fd = stdout_r.into_raw_fd(); // 消费 OwnedFd，由我们手动管理 FD 生命周期
+            let stderr_fd = stderr_r.into_raw_fd();
+
             let mut child = Command::new("bash")
                 .arg("-lc")
                 .arg(command)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
+                .stdout(unsafe { Stdio::from_raw_fd(stdout_w.into_raw_fd()) })
+                .stderr(unsafe { Stdio::from_raw_fd(stderr_w.into_raw_fd()) })
                 .spawn()?;
 
             let stdout_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
             let stderr_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
 
-            if let Some(stdout) = child.stdout.take() {
-                let buf = stdout_buf.clone();
-                thread::spawn(move || stream_reader(stdout, buf));
-            }
-            if let Some(stderr) = child.stderr.take() {
-                let buf = stderr_buf.clone();
-                thread::spawn(move || stream_reader(stderr, buf));
-            }
+            // Reader 线程：读取 stdout FD，FD 被外部关闭时 read 返回 EBADF 自动退出
+            let sbuf = stdout_buf.clone();
+            let stdout_fd_reader = stdout_fd;
+            thread::spawn(move || {
+                let mut tmp = Vec::new();
+                let mut buf = [0u8; 8192];
+                loop {
+                    match unsafe { libc::read(stdout_fd_reader, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) } {
+                        0 => break,
+                        n if n > 0 => tmp.extend_from_slice(&buf[..n as usize]),
+                        _ => break, // EBADF（FD 被关）/ 其他错误
+                    }
+                }
+                if let Ok(s) = String::from_utf8(tmp) {
+                    *sbuf.lock().unwrap() = s;
+                }
+            });
 
-            let start = Instant::now();
+            let ebuf = stderr_buf.clone();
+            let stderr_fd_reader = stderr_fd;
+            thread::spawn(move || {
+                let mut tmp = Vec::new();
+                let mut buf = [0u8; 8192];
+                loop {
+                    match unsafe { libc::read(stderr_fd_reader, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) } {
+                        0 => break,
+                        n if n > 0 => tmp.extend_from_slice(&buf[..n as usize]),
+                        _ => break,
+                    }
+                }
+                if let Ok(s) = String::from_utf8(tmp) {
+                    *ebuf.lock().unwrap() = s;
+                }
+            });
+
+            // 使用 kqueue 事件驱动等待子进程退出 / cancel 信号 / 超时 — 零轮询
             let mut timed_out = false;
-            loop {
-                match child.try_wait() {
-                    Ok(Some(_status)) => break,
-                    Ok(None) => {
-                        if start.elapsed() >= timeout {
-                            let _ = child.kill();
-                            let _ = child.wait();
-                            timed_out = true;
-                            break;
-                        }
-                        thread::sleep(Duration::from_millis(50));
-                    }
-                    Err(e) => {
-                        bail!("Error: failed to wait on child process: {e}");
-                    }
+            match wait_child_or_cancel(child.id(), self.cancel_fd, timeout) {
+                Ok(WaitResult::Exited) => {
+                    let _ = child.try_wait(); // reap
+                }
+                Ok(WaitResult::Cancel) => {
+                    timed_out = true; // 标记为截断
+                    // drain cancel pipe 防止后续 tool 调用立即收到 Cancel
+                    drain_fd(self.cancel_fd);
+                }
+                Ok(WaitResult::Timeout) => {
+                    timed_out = true;
+                    // SIGTERM 子进程
+                    let _ = Command::new("kill")
+                        .arg("--")
+                        .arg(format!("-{}", child.id()))
+                        .output();
+                    let _ = child.try_wait();
+                }
+                Err(e) => {
+                    // 先关闭 FD 再返回错误
+                    unsafe { libc::close(stdout_fd); }
+                    unsafe { libc::close(stderr_fd); }
+                    bail!("Error: wait failed: {e}");
                 }
             }
 
-            thread::sleep(Duration::from_millis(30));
+            // 给 reader 线程 1ms 处理剩余数据。FD 链机制下 reader 在子进程退出 / FD 关闭后
+            // 立即得到 EOF / EBADF，1ms 足够处理常规输出。大输出场景靠多轮 8KB read 完成。
+            thread::sleep(Duration::from_millis(1));
 
             let mut out = stdout_buf.lock().unwrap().clone();
             let stderr = stderr_buf.lock().unwrap().clone();
@@ -416,40 +464,244 @@ use crate::config::Config;
             if query.is_empty() {
                 bail!("Error: no query provided");
             }
-            let client = reqwest::blocking::Client::new();
-            let mut req = client
-                .get("https://s.jina.ai/")
-                .query(&[("q", query)])
-                .header("X-Respond-With", "no-content")
-                .timeout(std::time::Duration::from_secs(30));
-            if let Ok(key) = std::env::var("JINA_API_KEY") {
-                if !key.is_empty() {
-                    req = req.header("Authorization", format!("Bearer {key}"));
+            let rt = crate::agent::tokio_runtime();
+            let client = reqwest::Client::new();
+            let query = query.to_string();
+            let result: Result<String> = rt.block_on(async move {
+                let mut req = client
+                    .get("https://s.jina.ai/")
+                    .query(&[("q", &query)])
+                    .header("X-Respond-With", "no-content")
+                    .timeout(std::time::Duration::from_secs(30));
+                if let Ok(key) = std::env::var("JINA_API_KEY") {
+                    if !key.is_empty() {
+                        req = req.header("Authorization", format!("Bearer {key}"));
+                    }
                 }
-            }
-            let resp = req.send()?;
-            let body = resp.text()?;
-            Ok(body)
+                let resp = req.send().await.map_err(|e| anyhow!(e.to_string()))?;
+                let body = resp.text().await.map_err(|e| anyhow!(e.to_string()))?;
+                Ok(body)
+            });
+            result
         }
 
         fn web_fetch(&self, url: &str) -> Result<String> {
             if url.is_empty() {
                 bail!("Error: no url provided");
             }
-            let client = reqwest::blocking::Client::new();
-            let mut req = client
-                .get("https://r.jina.ai/")
-                .query(&[("url", url)])
-                .timeout(std::time::Duration::from_secs(60));
-            if let Ok(key) = std::env::var("JINA_API_KEY") {
-                if !key.is_empty() {
-                    req = req.header("Authorization", format!("Bearer {key}"));
+            let rt = crate::agent::tokio_runtime();
+            let client = reqwest::Client::new();
+            let url = url.to_string();
+            let result: Result<String> = rt.block_on(async move {
+                let mut req = client
+                    .get("https://r.jina.ai/")
+                    .query(&[("url", &url)])
+                    .timeout(std::time::Duration::from_secs(60));
+                if let Ok(key) = std::env::var("JINA_API_KEY") {
+                    if !key.is_empty() {
+                        req = req.header("Authorization", format!("Bearer {key}"));
+                    }
+                }
+                let resp = req.send().await.map_err(|e| anyhow!(e.to_string()))?;
+                let body = resp.text().await.map_err(|e| anyhow!(e.to_string()))?;
+                Ok(body)
+            });
+            result
+        }
+    }
+
+    /// 等待结果：子进程退出 / cancel 信号 / 超时
+    enum WaitResult {
+        Exited,
+        Cancel,
+        Timeout,
+    }
+
+    /// 使用 kqueue (macOS) 事件驱动等待，零轮询。
+    /// 同时监视子进程退出 (EVFILT_PROC + NOTE_EXIT) 和 cancel pipe (EVFILT_READ)。
+    #[cfg(target_os = "macos")]
+    fn wait_child_or_cancel(child_pid: u32, cancel_fd: i32, timeout: Duration) -> Result<WaitResult> {
+        let kq = unsafe { libc::kqueue() };
+        if kq < 0 {
+            bail!("kqueue() failed: {}", std::io::Error::last_os_error());
+        }
+
+        let mut events = Vec::with_capacity(2);
+        events.push(libc::kevent {
+            ident: child_pid as usize,
+            filter: libc::EVFILT_PROC as i16,
+            flags: libc::EV_ADD as u16,
+            fflags: libc::NOTE_EXIT as u32,
+            data: 0,
+            udata: std::ptr::null_mut(),
+        });
+        if cancel_fd >= 0 {
+            events.push(libc::kevent {
+                ident: cancel_fd as usize,
+                filter: libc::EVFILT_READ as i16,
+                flags: libc::EV_ADD as u16,
+                fflags: 0,
+                data: 0,
+                udata: std::ptr::null_mut(),
+            });
+        }
+
+        let mut event: libc::kevent = unsafe { std::mem::zeroed() };
+        let timeout_nanos = timeout.as_secs().saturating_mul(1_000_000_000) as i64
+            + timeout.subsec_nanos() as i64;
+        let ts = libc::timespec {
+            tv_sec: (timeout_nanos / 1_000_000_000) as libc::time_t,
+            tv_nsec: (timeout_nanos % 1_000_000_000) as _,
+        };
+
+        let ret = unsafe {
+            libc::kevent(
+                kq,
+                events.as_ptr(),
+                events.len() as i32,
+                &mut event,
+                1,
+                &ts as *const libc::timespec,
+            )
+        };
+
+        unsafe { libc::close(kq); }
+
+        if ret < 0 {
+            bail!("kevent() failed: {}", std::io::Error::last_os_error());
+        }
+        if ret == 0 {
+            return Ok(WaitResult::Timeout);
+        }
+
+        // kevent 返回了一个事件
+        if event.filter == libc::EVFILT_READ as i16 {
+            Ok(WaitResult::Cancel)
+        } else {
+            // EVFILT_PROC — 子进程退出
+            Ok(WaitResult::Exited)
+        }
+    }
+
+    /// 使用 pidfd_open + poll (Linux 5.3+) 事件驱动等待。
+    /// 同时监视子进程退出 (pidfd) 和 cancel pipe (poll)。
+    #[cfg(target_os = "linux")]
+    fn wait_child_or_cancel(child_pid: u32, cancel_fd: i32, timeout: Duration) -> Result<WaitResult> {
+        let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, child_pid as libc::c_int, 0) };
+        if pidfd < 0 {
+            bail!("pidfd_open({}) failed: {}", child_pid, std::io::Error::last_os_error());
+        }
+
+        let mut poll_fds = vec![
+            libc::pollfd {
+                fd: pidfd as libc::c_int,
+                events: libc::POLLIN as i16,
+                revents: 0,
+            },
+        ];
+        if cancel_fd >= 0 {
+            poll_fds.push(libc::pollfd {
+                fd: cancel_fd,
+                events: libc::POLLIN as i16,
+                revents: 0,
+            });
+        }
+
+        let timeout_ms = if timeout == Duration::MAX {
+            -1i32
+        } else {
+            let ms = timeout.as_millis();
+            if ms > i32::MAX as u128 { i32::MAX } else { ms as i32 }
+        };
+
+        let ret = unsafe {
+            libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as libc::nfds_t, timeout_ms)
+        };
+
+        unsafe { libc::close(pidfd as libc::c_int); }
+
+        if ret < 0 {
+            bail!("poll() failed: {}", std::io::Error::last_os_error());
+        }
+        if ret == 0 {
+            return Ok(WaitResult::Timeout);
+        }
+
+        let exited = (poll_fds[0].revents as i16 & libc::POLLIN as i16) != 0;
+        let cancelled = poll_fds.len() > 1
+            && (poll_fds[1].revents as i16 & libc::POLLIN as i16) != 0;
+
+        if exited {
+            Ok(WaitResult::Exited)
+        } else if cancelled {
+            Ok(WaitResult::Cancel)
+        } else {
+            bail!("unexpected poll result: revents={:?}",
+                poll_fds.iter().map(|p| p.revents).collect::<Vec<_>>());
+        }
+    }
+
+    /// 跨平台备选：waitpid(WNOHANG) + 50ms 轮询
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    fn wait_child_or_cancel(child_pid: u32, cancel_fd: i32, timeout: Duration) -> Result<WaitResult> {
+        let start = std::time::Instant::now();
+        loop {
+            // waitpid WNOHANG 非阻塞检查子进程状态
+            let mut status = 0;
+            let ret = unsafe { libc::waitpid(child_pid as libc::pid_t, &mut status, libc::WNOHANG) };
+            if ret == child_pid as libc::pid_t {
+                return Ok(WaitResult::Exited);
+            }
+            if ret < 0 {
+                if let Some(libc::ECHILD) = std::io::Error::last_os_error().raw_os_error() {
+                    return Ok(WaitResult::Exited);
                 }
             }
-            let resp = req.send()?;
-            let body = resp.text()?;
-            Ok(body)
+
+            // 非阻塞检查 cancel pipe
+            if cancel_fd >= 0 {
+                let mut pfd = libc::pollfd {
+                    fd: cancel_fd,
+                    events: libc::POLLIN as i16,
+                    revents: 0,
+                };
+                let pret = unsafe { libc::poll(&mut pfd, 1, 0) };
+                if pret > 0 && (pfd.revents as i16 & libc::POLLIN as i16) != 0 {
+                    return Ok(WaitResult::Cancel);
+                }
+            }
+
+            if start.elapsed() >= timeout {
+                return Ok(WaitResult::Timeout);
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
         }
+    }
+
+    /// 非阻塞地 drain 一个 FD 的所有待读数据。
+    /// 用于 cancel pipe：Cancel 后清空管道，避免后续 tool 调用错误地立即收到 Cancel。
+    pub fn drain_fd(fd: i32) {
+        if fd < 0 {
+            return;
+        }
+        // 临时设为非阻塞
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL, 0) };
+        if flags < 0 {
+            return;
+        }
+        let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+        let mut buf = [0u8; 64];
+        loop {
+            let ret = unsafe {
+                libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len())
+            };
+            if ret <= 0 {
+                break;
+            }
+        }
+        // 恢复阻塞模式
+        let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
     }
 
     fn deny_bash_command_reason(command: &str) -> Option<&'static str> {
@@ -535,29 +787,6 @@ use crate::config::Config;
 
     pub fn tool_format_result(s: &str, max: usize) -> String {
         format_tool_result(s, max)
-    }
-
-    fn stream_reader<R: std::io::Read>(pipe: R, buf: Arc<Mutex<String>>) {
-        let mut reader = BufReader::new(pipe);
-        let mut line = String::new();
-        loop {
-            line.clear();
-            match reader.read_line(&mut line) {
-                Ok(0) => break,
-                Ok(_) => {
-                    if let Ok(mut guard) = buf.lock() {
-                        guard.push_str(&line);
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-        let mut tail = String::new();
-        if reader.read_to_string(&mut tail).is_ok() && !tail.is_empty() {
-            if let Ok(mut guard) = buf.lock() {
-                guard.push_str(&tail);
-            }
-        }
     }
 
     fn unified_diff_color(path: &str, old_content: &str, new_content: &str) -> Result<String> {
@@ -714,11 +943,16 @@ use crate::config::Config;
 
     #[cfg(test)]
     mod tests {
-        use super::Runner;
+        use super::{Runner, WaitResult, drain_fd, wait_child_or_cancel};
         use crate::config::Config;
+        use nix::unistd::pipe;
         use serde_json::json;
         use std::fs;
-        use std::time::{SystemTime, UNIX_EPOCH};
+        use std::os::fd::AsRawFd;
+        use std::os::unix::io::IntoRawFd;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Arc;
+        use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
         #[test]
         fn dispatch_skill_reads_content() {
@@ -739,6 +973,8 @@ use crate::config::Config;
                 config: Config::default(),
                 cwd: root.clone(),
                 home: root.join("home"),
+                interrupted: Arc::new(AtomicBool::new(false)),
+                cancel_fd: -1,
             };
             let result = runner
                 .dispatch("Skill", &json!({ "name": "test-skill" }))
@@ -748,5 +984,63 @@ use crate::config::Config;
             assert!(result.contains("/helper.sh"));
 
             let _ = fs::remove_dir_all(root);
+        }
+
+        #[test]
+        fn wait_cancel_pipe_aborts_sleep() {
+            // 验证 wait_child_or_cancel 在 cancel pipe 写入后立即返回 Cancel
+            let (r, w) = pipe().unwrap();
+            let cancel_fd = r.as_raw_fd();
+
+            let mut child = std::process::Command::new("bash")
+                .arg("-lc")
+                .arg("sleep 30")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .unwrap();
+
+            let start = std::time::Instant::now();
+            let handle = std::thread::spawn(move || {
+                // 稍后写入 cancel pipe
+                std::thread::sleep(Duration::from_millis(200));
+                let _ = drain_fd(cancel_fd); // 先确保空
+                let data = b"x";
+                unsafe {
+                    libc::write(
+                        w.into_raw_fd(),
+                        data.as_ptr() as *const libc::c_void,
+                        data.len(),
+                    );
+                }
+            });
+
+            let result = wait_child_or_cancel(child.id(), cancel_fd, Duration::from_secs(10));
+            let elapsed = start.elapsed();
+
+            handle.join().unwrap();
+            let _ = child.try_wait();
+
+            match result {
+                Ok(WaitResult::Cancel) => {
+                    // 应在 1 秒内返回 Cancel
+                    assert!(
+                        elapsed < Duration::from_secs(2),
+                        "took too long: {elapsed:?}"
+                    );
+                }
+                Ok(WaitResult::Exited) => {
+                    // child 意外退出了
+                    drain_fd(cancel_fd);
+                    panic!("child exited instead of being cancelled");
+                }
+                Ok(WaitResult::Timeout) => {
+                    drain_fd(cancel_fd);
+                    panic!("timed out before cancel");
+                }
+                Err(e) => {
+                    panic!("wait_child_or_cancel failed: {e}");
+                }
+            }
         }
     }

--- a/src/awk/claude_sse.awk
+++ b/src/awk/claude_sse.awk
@@ -88,14 +88,22 @@ BEGIN {
     else if (event == "message_delta") {
         sr = extract_str(json, "stop_reason", 1)
         if (sr != "") stop_reason = sr
-        it = extract_num(json, "input_tokens", 1)
-        if (it != "") input_tokens = it
         ot = extract_num(json, "output_tokens", 1)
         if (ot != "") output_tokens = ot
-        crt = extract_num(json, "cache_read_input_tokens", 1)
-        if (crt != "") cache_read_input_tokens = crt
-        cct = extract_num(json, "cache_creation_input_tokens", 1)
-        if (cct != "") cache_creation_input_tokens = cct
+        # input_tokens/cache_*: 优先从 message_start 获取。
+        # OpenAI 路径无 message_start，需从合成的 message_delta 读取。
+        if (input_tokens == 0) {
+            it = extract_num(json, "input_tokens", 1)
+            if (it != "") input_tokens = it
+        }
+        if (cache_read_input_tokens == 0) {
+            crt = extract_num(json, "cache_read_input_tokens", 1)
+            if (crt != "") cache_read_input_tokens = crt
+        }
+        if (cache_creation_input_tokens == 0) {
+            cct = extract_num(json, "cache_creation_input_tokens", 1)
+            if (cct != "") cache_creation_input_tokens = cct
+        }
     }
     else if (event == "message_start") {
         it = extract_num(json, "input_tokens", 1)


### PR DESCRIPTION
## 背景

Rust 版本的 HTTP 架构有根本性问题：

1. **Ctrl+C 后 CPU 飙高**：使用 `reqwest::blocking` 同步客户端 + 独立
   `spawn_reader` 线程接收响应体。Ctrl+C 后 SSE 解析层虽然退出了，但
   spawn_reader 线程仍在全速读取 HTTP 响应写入无界 channel，导致 CPU 100%。

2. **Ctrl+C 后不能恢复**：`CancellationToken` 是单次信号，第一次取消后
   永久失效，后续所有 HTTP 请求立即被中断。

3. **三份 tools.json 不一致**：JSON 格式、Unicode 转义、描述文本各有差异。

4. **Go 版 system prompt 严重不一致**：多个 section 截断、顺序错乱、platform
   三个版本三种值。

5. **Go 二进制不能独立运行**：tools.json 未内置。

## 改动

### 1. Rust HTTP 架构重构（核心修复）

| 维度 | 旧架构 | 新架构 |
|------|--------|--------|
| HTTP 客户端 | `reqwest::blocking` | `reqwest` async |
| 响应体读取 | 独立 `spawn_reader` 线程 | async `bytes_stream()` |
| 中断机制 | `CancellationToken` + 桥接 pipe + 线程 | `AtomicBool`（cancel + interrupted + CTRLC_FLAG）轮询 |
| CPU 行为 | 中断后 reader 线程空跑 100% | 协作式中断，select! 退出即停 |

- 移除 `tokio-util` 依赖（不再需要 CancellationToken）
- 移除阻塞 HTTP 客户端，全部改用 `tokio::runtime.block_on`
- 中断检测从外部强杀改为 async 任务内协作式轮询，一次修复两个问题

### 2. tools.json 统一

- `rust/src/tools.json` 覆盖为 `src/tools.json` 副本
- `go/tools.json` 新增，`//go:embed` 内置到二进制

### 3. system prompt 统一（以 bash 为基准）

| 版本 | 改动 |
|------|------|
| Rust | `using-your-tools` 补 SubAgent 段落；`plan-lifecycle-guidance` 对齐 bash |
| Go   | 所有 section 补全到与 bash 一致；顺序改为 output-language 最后；分隔符 `\n\n`→`\n`；current-plan 加 name 属性 |
| 三版 | platform 统一为 `uname -s` 格式 |

### 4. 相关补充

- Go: SessionStore 新增 `PlanPath()` / `PlanDraftPath()` 方法
- AGENT.md: 新增「版本一致性要求」章节

## 验证

- 三版均编译通过（bash / go / rust）
- Go 单元测试通过
- 集成测试 91 passed（3 failed 为测试环境问题，与改动无关）
- Go 二进制复制到独立目录运行正常