### PR TITLE
fix: WebFetch 改用 Jina Reader 路径拼接 & Go stream-json 输出修正

### DIFF
--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -167,6 +167,9 @@ Examples:
 	cwd, _ := os.Getwd()
 	store := agent.NewFileStore(home, cwd)
 	display := agent.NewTermDisplay()
+	if cfg.OutputFormat == "stream-json" {
+		display.SetSilent(true)
+	}
 	llm := agent.NewHTTPTransport(cfg)
 	tools := agent.NewToolDispatcher(cfg)
 

--- a/go/display.go
+++ b/go/display.go
@@ -15,6 +15,7 @@ type TermDisplay struct {
 	writer         io.Writer // 输出目标（默认 os.Stdout）
 	lastChar       byte      // 上次输出的最后一个字符
 	prevThinking   bool      // 上一个事件是否为 THINKING
+	silent         bool      // stream-json 模式下抑制人类可读输出
 	titleFormatter func(model string) string
 }
 
@@ -60,8 +61,16 @@ func (d *TermDisplay) HumanText(s string) {
 	}
 }
 
+// SetSilent 设置静默模式（stream-json 时抑制人类可读输出）
+func (d *TermDisplay) SetSilent(s bool) {
+	d.silent = s
+}
+
 // SetTitle 设置终端标题
 func (d *TermDisplay) SetTitle(title string) {
+	if d.silent {
+		return
+	}
 	if d.titleFormatter != nil {
 		title = d.titleFormatter(title)
 	}
@@ -71,6 +80,9 @@ func (d *TermDisplay) SetTitle(title string) {
 
 // ShowEvent 显示一个 Event
 func (d *TermDisplay) ShowEvent(ev Event) {
+	if d.silent {
+		return
+	}
 	switch ev.Type {
 	case EventText:
 		// thinking → text 转换时补换行

--- a/go/tools.go
+++ b/go/tools.go
@@ -500,13 +500,10 @@ func (td *ToolDispatcher) toolWebFetch(ctx context.Context, url string) (string,
 		return "", fmt.Errorf("no url provided")
 	}
 	client := &http.Client{Timeout: 60 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://r.jina.ai/", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://r.jina.ai/"+url, nil)
 	if err != nil {
 		return "", err
 	}
-	q := req.URL.Query()
-	q.Set("url", url)
-	req.URL.RawQuery = q.Encode()
 	if td.cfg.JinaAPIKey != "" {
 		req.Header.Set("Authorization", "Bearer "+td.cfg.JinaAPIKey)
 	}

--- a/rust/src/tools.rs
+++ b/rust/src/tools.rs
@@ -494,8 +494,7 @@ use crate::config::Config;
             let url = url.to_string();
             let result: Result<String> = rt.block_on(async move {
                 let mut req = client
-                    .get("https://r.jina.ai/")
-                    .query(&[("url", &url)])
+                    .get(format!("https://r.jina.ai/{url}"))
                     .timeout(std::time::Duration::from_secs(60));
                 if let Ok(key) = std::env::var("JINA_API_KEY") {
                     if !key.is_empty() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -864,7 +864,7 @@ tool_plan_clear() {
 
 tool_web_search() { curl -sS --connect-timeout 10 --max-time 30 -G --data-urlencode "q=$1" -H "Authorization: Bearer ${JINA_API_KEY:-}" -H "X-Respond-With: no-content" "https://s.jina.ai/" 2>&1; }
 
-tool_web_fetch() { curl -sS --connect-timeout 10 --max-time 60 -G --data-urlencode "url=$1" -H "Authorization: Bearer ${JINA_API_KEY:-}" "https://r.jina.ai/" 2>&1; }
+tool_web_fetch() { curl -sS --connect-timeout 10 --max-time 60 -H "Authorization: Bearer ${JINA_API_KEY:-}" "https://r.jina.ai/$1" 2>&1; }
 
 # 启动异步子 agent：后台执行 agent_loop，完成后通过 INPUT_FIFO 发回 AGENT_RESULT
 # 消息格式：AGENT_RESULT <session_id> <status:ok|failed> <result_text> <in> <out> <cr> <cc> <reqs>


### PR DESCRIPTION
## 修复内容

### 1. WebFetch 调用方式修正（Bash/Go/Rust 三版本）

Jina Reader API (`r.jina.ai`) 不再支持 `?url=` 查询参数方式，需改用路径拼接：

```
# 旧（400 错误）
curl "https://r.jina.ai/?url=https://example.com"

# 新（200 正常）
curl "https://r.jina.ai/https://example.com"
```

- `src/agent.sh` — `tool_web_fetch` 改为路径拼接
- `go/tools.go` — `toolWebFetch` 改为路径拼接
- `rust/src/tools.rs` — `web_fetch` 改为路径拼接

### 2. Go 版 stream-json 输出污染修复

`--output-format stream-json` / `--print` 模式下，`TermDisplay.ShowEvent()` 无条件输出 ANSI 颜色码和人类可读文本，与 JSON 行混在一起。

修复：`TermDisplay` 新增 `silent` 标志，stream-json 模式下 `ShowEvent()` 和 `SetTitle()` 直接 return，仅输出纯 JSON 行。

## 变更文件

| 文件 | 说明 |
|------|------|
| `src/agent.sh` | WebFetch 路径拼接 |
| `go/tools.go` | WebFetch 路径拼接 |
| `rust/src/tools.rs` | WebFetch 路径拼接 |
| `go/display.go` | 新增 silent 模式 |
| `go/cmd/goagent/main.go` | stream-json 时启用 silent |