### PR TITLE
feat: DEEPSEEK_API_KEY auto-detection + MODEL env var across all 3 versions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -35,6 +35,13 @@ bash-agent -i                    # interactive mode
 bash-agent --print "inspect"     # stream-json output
 ```
 
+### DeepSeek (Anthropic-compatible)
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+bash-agent "hello"   # auto-detected, uses deepseek-v4-flash
+```
+
 ### OpenAI-compatible APIs
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ bash-agent -i                    # 交互模式
 bash-agent --print "inspect"     # stream-json 输出
 ```
 
+### DeepSeek 兼容（Anthropic 协议）
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+bash-agent "hello"   # 自动检测，使用 deepseek-v4-flash
+```
+
 ### OpenAI 兼容接口
 
 ```bash

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -70,9 +70,11 @@ Options:
 Environment:
   ANTHROPIC_API_KEY       API key for Claude
   OPENAI_API_KEY          API key for OpenAI
+  DEEPSEEK_API_KEY        API key for DeepSeek (auto-configures provider)
   ANTHROPIC_BASE_URL      Claude API base URL
   OPENAI_BASE_URL         OpenAI API base URL
   BASH_AGENT_HOME         Override base directory for session storage
+  MODEL                   Default model name
   EFFORT                  Default thinking effort (default: high)
   THINKING                Default thinking mode (default: adaptive)
 
@@ -134,6 +136,17 @@ Examples:
 	case "claude":
 		if cfg.APIKey == "" {
 			cfg.APIKey = os.Getenv("ANTHROPIC_API_KEY")
+		}
+		// DeepSeek auto-detection: DEEPSEEK_API_KEY 且未显式配置其他 base URL
+		if cfg.APIKey == "" && cfg.BaseURL == "" &&
+			os.Getenv("DEEPSEEK_API_KEY") != "" &&
+			os.Getenv("ANTHROPIC_BASE_URL") == "" &&
+			os.Getenv("OPENAI_BASE_URL") == "" {
+			cfg.APIKey = os.Getenv("DEEPSEEK_API_KEY")
+			cfg.BaseURL = "https://api.deepseek.com/anthropic"
+			if cfg.Model == "" {
+				cfg.Model = "deepseek-v4-flash"
+			}
 		}
 		if cfg.BaseURL == "" {
 			cfg.BaseURL = os.Getenv("ANTHROPIC_BASE_URL")

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -70,9 +70,11 @@ Options:
 Environment:
   ANTHROPIC_API_KEY       API key for Claude
   OPENAI_API_KEY          API key for OpenAI
+  DEEPSEEK_API_KEY        Drop-in for ANTHROPIC_API_KEY (auto-configures DeepSeek endpoint + model)
   ANTHROPIC_BASE_URL      Claude API base URL
   OPENAI_BASE_URL         OpenAI API base URL
   BASH_AGENT_HOME         Override base directory for session storage
+  MODEL                   Default model name
   EFFORT                  Default thinking effort (default: high)
   THINKING                Default thinking mode (default: adaptive)
 
@@ -134,6 +136,17 @@ Examples:
 	case "claude":
 		if cfg.APIKey == "" {
 			cfg.APIKey = os.Getenv("ANTHROPIC_API_KEY")
+		}
+		// DeepSeek auto-detection: DEEPSEEK_API_KEY 且未显式配置其他 base URL
+		if cfg.APIKey == "" && cfg.BaseURL == "" &&
+			os.Getenv("DEEPSEEK_API_KEY") != "" &&
+			os.Getenv("ANTHROPIC_BASE_URL") == "" &&
+			os.Getenv("OPENAI_BASE_URL") == "" {
+			cfg.APIKey = os.Getenv("DEEPSEEK_API_KEY")
+			cfg.BaseURL = "https://api.deepseek.com/anthropic"
+			if cfg.Model == "" {
+				cfg.Model = "deepseek-v4-flash"
+			}
 		}
 		if cfg.BaseURL == "" {
 			cfg.BaseURL = os.Getenv("ANTHROPIC_BASE_URL")

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -200,6 +200,21 @@ pub mod config {
                 if cfg.api_key.is_empty() {
                     cfg.api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
                 }
+                // DeepSeek auto-detection
+                if cfg.api_key.is_empty()
+                    && cfg.base_url.is_empty()
+                    && std::env::var("DEEPSEEK_API_KEY")
+                        .map(|v| !v.is_empty())
+                        .unwrap_or(false)
+                    && std::env::var("ANTHROPIC_BASE_URL").is_err()
+                    && std::env::var("OPENAI_BASE_URL").is_err()
+                {
+                    cfg.api_key = std::env::var("DEEPSEEK_API_KEY").unwrap();
+                    cfg.base_url = "https://api.deepseek.com/anthropic".to_string();
+                    if cfg.model.is_empty() {
+                        cfg.model = "deepseek-v4-flash".to_string();
+                    }
+                }
                 if cfg.base_url.is_empty() {
                     cfg.base_url = std::env::var("ANTHROPIC_BASE_URL").unwrap_or_default();
                 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -182,6 +182,14 @@ fn print_usage() {
     println!("  -v, --verbose           Verbose mode");
     println!("  -i, --interactive       Interactive mode (REPL)");
     println!("  -h, --help              Show this help");
+    println!();
+    println!("Environment:");
+    println!("  ANTHROPIC_API_KEY       API key for Claude");
+    println!("  OPENAI_API_KEY          API key for OpenAI");
+    println!("  DEEPSEEK_API_KEY        Drop-in for ANTHROPIC_API_KEY (auto-configures DeepSeek endpoint + model)");
+    println!("  ANTHROPIC_BASE_URL      Claude API base URL");
+    println!("  OPENAI_BASE_URL         OpenAI API base URL");
+    println!("  MODEL                   Default model name");
 }
 
 fn list_sessions(home: &Path, cwd: &Path) -> Result<()> {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -182,6 +182,14 @@ fn print_usage() {
     println!("  -v, --verbose           Verbose mode");
     println!("  -i, --interactive       Interactive mode (REPL)");
     println!("  -h, --help              Show this help");
+    println!();
+    println!("Environment:");
+    println!("  ANTHROPIC_API_KEY       API key for Claude");
+    println!("  OPENAI_API_KEY          API key for OpenAI");
+    println!("  DEEPSEEK_API_KEY        API key for DeepSeek (auto-configures provider)");
+    println!("  ANTHROPIC_BASE_URL      Claude API base URL");
+    println!("  OPENAI_BASE_URL         OpenAI API base URL");
+    println!("  MODEL                   Default model name");
 }
 
 fn list_sessions(home: &Path, cwd: &Path) -> Result<()> {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1331,11 +1331,13 @@ Options:
 Environment:
   ANTHROPIC_API_KEY       API key for Claude
   OPENAI_API_KEY          API key for OpenAI
+  DEEPSEEK_API_KEY        API key for DeepSeek (auto-detected, uses Anthropic-compatible endpoint)
   ANTHROPIC_BASE_URL      Claude API base URL
   OPENAI_BASE_URL         OpenAI API base URL
   BASH_AGENT_HOME         Override base directory for session storage (default: $HOME)
   EFFORT                  Default thinking effort (default: high)
   THINKING                Default thinking mode (default: adaptive)
+  MODEL                   Default model name
 
 Examples:
   ./agent.sh "Read /etc/hostname and tell me what it says"
@@ -1450,6 +1452,14 @@ validate_config() {
             util_die "Unknown provider: $PROVIDER (use claude|openai)"
             ;;
     esac
+
+    # Auto-detect DeepSeek API key: if DEEPSEEK_API_KEY is set, use DeepSeek's Anthropic endpoint
+    if [[ -z "$API_KEY" && -z "$BASE_URL" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
+        PROVIDER="claude"
+        API_KEY="$DEEPSEEK_API_KEY"
+        BASE_URL="https://api.deepseek.com/anthropic"
+        : "${MODEL:=deepseek-v4-flash}"
+    fi
 
     if [[ -z "$API_KEY" && -z "$BASE_URL" ]]; then
         case "$PROVIDER" in

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1331,11 +1331,15 @@ Options:
 Environment:
   ANTHROPIC_API_KEY       API key for Claude
   OPENAI_API_KEY          API key for OpenAI
+  DEEPSEEK_API_KEY        Drop-in for ANTHROPIC_API_KEY (auto-configures DeepSeek endpoint + model)
   ANTHROPIC_BASE_URL      Claude API base URL
   OPENAI_BASE_URL         OpenAI API base URL
   BASH_AGENT_HOME         Override base directory for session storage (default: $HOME)
   EFFORT                  Default thinking effort (default: high)
   THINKING                Default thinking mode (default: adaptive)
+  MODEL                   Default model name
+
+Note: DEEPSEEK_API_KEY is a fallback when ANTHROPIC_API_KEY is not set — auto-configures the DeepSeek endpoint + model.
 
 Examples:
   ./agent.sh "Read /etc/hostname and tell me what it says"
@@ -1450,6 +1454,14 @@ validate_config() {
             util_die "Unknown provider: $PROVIDER (use claude|openai)"
             ;;
     esac
+
+    # Auto-detect DeepSeek API key: if DEEPSEEK_API_KEY is set, use DeepSeek's Anthropic endpoint
+    if [[ -z "$API_KEY" && -z "$BASE_URL" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
+        PROVIDER="claude"
+        API_KEY="$DEEPSEEK_API_KEY"
+        BASE_URL="https://api.deepseek.com/anthropic"
+        : "${MODEL:=deepseek-v4-flash}"
+    fi
 
     if [[ -z "$API_KEY" && -z "$BASE_URL" ]]; then
         case "$PROVIDER" in


### PR DESCRIPTION
为三个版本统一添加 `DEEPSEEK_API_KEY` 自动检测和 `MODEL` 环境变量支持。

### 改动内容

**Bash (`src/agent.sh`)**
- `validate_config` 中新增 DeepSeek 自动检测：当 `DEEPSEEK_API_KEY` 存在且未配置其他 key/URL 时，自动使用 `deepseek-v4-flash` + `https://api.deepseek.com/anthropic`
- Environment 区新增 `DEEPSEEK_API_KEY` 和 `MODEL` 文档

**Go (`go/cmd/goagent/main.go`)**
- `provider="claude"` case 中新增相同逻辑的 DeepSeek 检测
- Environment 区新增 `DEEPSEEK_API_KEY` 和 `MODEL`

**Rust**
- `rust/src/lib.rs`: `validate()` 函数的 `"claude"` case 中新增 DeepSeek 检测
- `rust/src/main.rs`: `print_usage()` 新增缺失的 Environment 区块

### 优先级

`-m` 参数 > `export MODEL` 环境变量 > DeepSeek 默认值 `deepseek-v4-flash` > Claude 默认值 `claude-sonnet-4-20250514`

### 验证

- 95 个测试全绿
- Go / Rust 编译通过