### PR TITLE
feat: tcode — tmux chat UI 包装器

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,9 +155,27 @@ jobs:
           name: rustagent-${{ matrix.suffix }}
           path: dist/rustagent-${{ matrix.suffix }}${{ matrix.ext }}
 
+  tcode:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Copy tcode
+        run: |
+          mkdir -p dist
+          cp scripts/tcode dist/tcode
+          chmod +x dist/tcode
+
+      - name: Upload tcode
+        uses: actions/upload-artifact@v4
+        with:
+          name: tcode
+          path: dist/tcode
+
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [bash-agent, goagent, rustagent]
+    needs: [bash-agent, goagent, rustagent, tcode]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -184,3 +202,4 @@ jobs:
             dist/rustagent-linux-arm64
             dist/rustagent-darwin-amd64
             dist/rustagent-darwin-arm64
+            dist/tcode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -621,6 +621,17 @@
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **tcode — tmux Chat UI 包装器**：三栏 TMUX 界面（watch sidebar + agent + 输入框），支持
+  bash-agent/goagent/rustagent。第一个参数可选（默认 rustagent），支持透传参数。创建 session
+  时同步终端尺寸并使用百分比分割消除闪烁。退出打印 resume 信息，支持 Ctrl+C 中断/Ctrl+D 干净
+  退出。CI 发布时自动包含 `dist/tcode`。Makefile 新增 `build-tcode` target（`feat/tmux-chat-ui`）
+
+---
+
 [Unreleased]: https://github.com/lloydzhou/bash-agent/compare/v3.0.4...HEAD
 [3.0.4]: https://github.com/lloydzhou/bash-agent/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/lloydzhou/bash-agent/compare/v3.0.2...v3.0.3

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL := /bin/bash
 
-.PHONY: build build-bash build-go build-rust test test-bash test-go test-rust test-go-e2e test-rust-e2e clean
+.PHONY: build build-bash build-go build-rust build-tcode test test-bash test-go test-rust test-go-e2e test-rust-e2e clean
 
-build: build-bash build-go build-rust
+build: build-bash build-go build-rust build-tcode
 
 build-bash:
 	bash scripts/build.sh dist/agent.sh
@@ -23,6 +23,10 @@ build-rust2:
 	cd rust2 && cargo build --release -j 10
 	cp rust2/target/release/rust2agent dist/rust2agent
 	strip -x dist/rust2agent
+
+build-tcode:
+	cp scripts/tcode dist/tcode
+	chmod +x dist/tcode
 
 test: test-bash test-go test-rust
 

--- a/README.en.md
+++ b/README.en.md
@@ -113,6 +113,9 @@ Pre-built binaries (Go / Rust) are available on [Releases](https://github.com/ll
 
 ## tcode — tmux Chat UI Wrapper
 
+<details>
+<summary>tmux 3-pane wrapper for the agent, click to expand</summary>
+
 `tcode` is a tmux 3-pane wrapper for the agent, with watch sidebar, agent chat, and input pane.
 
 ```bash
@@ -129,6 +132,8 @@ tcode goagent -p openai -m gpt-4o
 ```
 
 Supports readline input, resume info on exit, Ctrl+C to interrupt, Ctrl+D to cleanly exit.
+
+</details>
 
 ## Environment Variables
 

--- a/README.en.md
+++ b/README.en.md
@@ -91,25 +91,6 @@ cd rust && cargo build --release && cp target/release/rustagent ~/.local/bin/rus
 
 Pre-built binaries (Go / Rust) are available on [Releases](https://github.com/lloydzhou/bash-agent/releases).
 
-## tcode — tmux Chat UI Wrapper
-
-`tcode` is a tmux 3-pane wrapper for the agent, with watch sidebar, agent chat, and input pane.
-
-```bash
-# Start (defaults to rustagent)
-tcode
-
-# Specify agent and passthrough args
-tcode goagent
-tcode rustagent --session my-session
-tcode goagent -p openai -m gpt-4o
-
-# Run directly from release download
-./tcode
-```
-
-Supports readline input, resume info on exit, Ctrl+C to interrupt, Ctrl+D to cleanly exit.
-
 ## CLI
 
 | Flag | Description | Default |
@@ -129,6 +110,25 @@ Supports readline input, resume info on exit, Ctrl+C to interrupt, Ctrl+D to cle
 | `-i` | interactive mode | - |
 | `--print` | stream-json output | - |
 | `-v` | verbose logging | - |
+
+## tcode — tmux Chat UI Wrapper
+
+`tcode` is a tmux 3-pane wrapper for the agent, with watch sidebar, agent chat, and input pane.
+
+```bash
+# Start (defaults to rustagent)
+tcode
+
+# Specify agent and passthrough args
+tcode goagent
+tcode rustagent --session my-session
+tcode goagent -p openai -m gpt-4o
+
+# Run directly from release download
+./tcode
+```
+
+Supports readline input, resume info on exit, Ctrl+C to interrupt, Ctrl+D to cleanly exit.
 
 ## Environment Variables
 

--- a/README.en.md
+++ b/README.en.md
@@ -91,6 +91,25 @@ cd rust && cargo build --release && cp target/release/rustagent ~/.local/bin/rus
 
 Pre-built binaries (Go / Rust) are available on [Releases](https://github.com/lloydzhou/bash-agent/releases).
 
+## tcode — tmux Chat UI Wrapper
+
+`tcode` is a tmux 3-pane wrapper for the agent, with watch sidebar, agent chat, and input pane.
+
+```bash
+# Start (defaults to rustagent)
+tcode
+
+# Specify agent and passthrough args
+tcode goagent
+tcode rustagent --session my-session
+tcode goagent -p openai -m gpt-4o
+
+# Run directly from release download
+./tcode
+```
+
+Supports readline input, resume info on exit, Ctrl+C to interrupt, Ctrl+D to cleanly exit.
+
 ## CLI
 
 | Flag | Description | Default |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ cd rust && cargo build --release && cp target/release/rustagent ~/.local/bin/rus
 
 预构建产物下载（Go / Rust）见 [Releases](https://github.com/lloydzhou/bash-agent/releases)。
 
+## tcode — tmux Chat UI 包装器
+
+`tcode` 是 agent 的 tmux 三栏界面包装器，提供 watch sidebar + agent 对话 + 输入框的布局。
+
+```bash
+# 启动（默认 rustagent）
+tcode
+
+# 指定 agent 并透传参数
+tcode goagent
+tcode rustagent --session my-session
+tcode goagent -p openai -m gpt-4o
+
+# 从 release 下载后直接运行
+./tcode
+```
+
+支持 readline 输入、退出后打印 resume 信息、Ctrl+C 中断、Ctrl+D 干净退出。
+
 ## CLI
 
 | 参数 | 说明 | 默认值 |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ cd rust && cargo build --release && cp target/release/rustagent ~/.local/bin/rus
 
 ## tcode — tmux Chat UI 包装器
 
+<details>
+<summary>tmux 三栏界面包装器，点开查看详情</summary>
+
 `tcode` 是 agent 的 tmux 三栏界面包装器，提供 watch sidebar + agent 对话 + 输入框的布局。
 
 ```bash
@@ -129,6 +132,8 @@ tcode goagent -p openai -m gpt-4o
 ```
 
 支持 readline 输入、退出后打印 resume 信息、Ctrl+C 中断、Ctrl+D 干净退出。
+
+</details>
 
 ## 环境变量
 

--- a/README.md
+++ b/README.md
@@ -91,25 +91,6 @@ cd rust && cargo build --release && cp target/release/rustagent ~/.local/bin/rus
 
 预构建产物下载（Go / Rust）见 [Releases](https://github.com/lloydzhou/bash-agent/releases)。
 
-## tcode — tmux Chat UI 包装器
-
-`tcode` 是 agent 的 tmux 三栏界面包装器，提供 watch sidebar + agent 对话 + 输入框的布局。
-
-```bash
-# 启动（默认 rustagent）
-tcode
-
-# 指定 agent 并透传参数
-tcode goagent
-tcode rustagent --session my-session
-tcode goagent -p openai -m gpt-4o
-
-# 从 release 下载后直接运行
-./tcode
-```
-
-支持 readline 输入、退出后打印 resume 信息、Ctrl+C 中断、Ctrl+D 干净退出。
-
 ## CLI
 
 | 参数 | 说明 | 默认值 |
@@ -129,6 +110,25 @@ tcode goagent -p openai -m gpt-4o
 | `-i` | 交互模式 | - |
 | `--print` | stream-json 输出 | - |
 | `-v` | 详细日志 | - |
+
+## tcode — tmux Chat UI 包装器
+
+`tcode` 是 agent 的 tmux 三栏界面包装器，提供 watch sidebar + agent 对话 + 输入框的布局。
+
+```bash
+# 启动（默认 rustagent）
+tcode
+
+# 指定 agent 并透传参数
+tcode goagent
+tcode rustagent --session my-session
+tcode goagent -p openai -m gpt-4o
+
+# 从 release 下载后直接运行
+./tcode
+```
+
+支持 readline 输入、退出后打印 resume 信息、Ctrl+C 中断、Ctrl+D 干净退出。
 
 ## 环境变量
 

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -21,9 +21,29 @@ set -euo pipefail
 
 AGENT="${1:-bash-agent}"
 shift 2>/dev/null || true
-AGENT_ARGS=("$@")
+ORIG_ARGS=("$@")
 SESSION="tcode-$$"
 SHELL="${SHELL:-/bin/bash}"
+
+# ─── 提取或生成 session ID（与 agent.sh util_new_session_id 一致）───
+SESSION_ID=""
+PENDING_ARGS=()
+i=0
+while [[ $i -lt ${#ORIG_ARGS[@]} ]]; do
+    if [[ "${ORIG_ARGS[$i]}" == "--session" && $((i+1)) -lt ${#ORIG_ARGS[@]} ]]; then
+        SESSION_ID="${ORIG_ARGS[$((i+1))]}"
+        PENDING_ARGS+=("${ORIG_ARGS[$i]}" "${ORIG_ARGS[$((i+1))]}")
+        i=$((i+2))
+    else
+        PENDING_ARGS+=("${ORIG_ARGS[$i]}")
+        i=$((i+1))
+    fi
+done
+if [[ -z "$SESSION_ID" ]]; then
+    SESSION_ID="$(date +%Y%m%d-%H%M%S)-$(printf '%04x' "$(( RANDOM << 1 | (RANDOM & 1) ))")"
+    PENDING_ARGS+=("--session" "$SESSION_ID")
+fi
+AGENT_ARGS=("${PENDING_ARGS[@]}")
 
 # ─── 清理残留 ───
 tmux kill-session -t "$SESSION" 2>/dev/null || true
@@ -74,6 +94,7 @@ WRAPPER=$(mktemp "${TMPDIR:-/tmp}/tcode-wrapper.XXXXXX")
 cat > "$WRAPPER" << WRAPPER_SCRIPT
 #!/usr/bin/env bash
 TC_SESSION="$SESSION"
+TC_SESSION_ID="$SESSION_ID"
 HISTFILE="\${BASH_AGENT_HOME:-\$HOME}/.bash-agent/history"
 mkdir -p "\$(dirname "\$HISTFILE")" 2>/dev/null || true
 touch "\$HISTFILE" 2>/dev/null || true
@@ -104,10 +125,7 @@ while true; do
         # Ctrl+D / EOF: 退出
         tmux send-keys -t "\$TC_SESSION:0.1" C-d
         tmux send-keys -t "\$TC_SESSION:0.0" C-c
-        sleep 0.5
-        # 捕获 agent 的 resume session 信息
-        resume=\$(tmux capture-pane -t "\$TC_SESSION:0.1" -p -S -5 2>/dev/null | grep 'Resume with:' | tail -1)
-        [[ -n "\$resume" ]] && printf '\n\033[36m%s\033[0m\n' "\$resume"
+        printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n' "\$TC_SESSION_ID"
         break
     fi
     printf '\033[A\033[2K'

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -1,26 +1,31 @@
 #!/usr/bin/env bash
-# tcode — 在 tmux 中模拟类 Chat 界面使用 bash-agent
+# tcode — tmux chat UI 包装器：在 tmux 三栏界面中运行 agent
 #
 # 布局:
 #   ┌──────────┬────────────────────────────────┐
-#   │          │  agent (bash-agent -i)         │
+#   │          │  agent (rustagent/goagent/...) │
 #   │  watch   │  (对话在此 pane 中完整展示)     │
 #   │  list-   │                                │
 #   │  sessions│                                │
 #   │  (25%)   │                                │
 #   │          ├────────────────────────────────┤
-#   │          │  > 输入行 (输入 → INPUT_FIFO)  │
+#   │          │  > 输入行                       │
 #   └──────────┴────────────────────────────────┘
 #
 # 用法:
-#   tcode                         # 默认 bash-agent
+#   tcode                         # 默认 rustagent
 #   tcode goagent                 # 用 goagent
 #   tcode rustagent --session x   # 透传参数
 
 set -euo pipefail
 
-AGENT="${1:-bash-agent}"
-shift 2>/dev/null || true
+# 第一个参数可选：指定 agent，默认 rustagent
+if [[ "${1:-}" =~ ^(bash-agent|goagent|rustagent|rust2agent)$ ]]; then
+    AGENT="$1"
+    shift
+else
+    AGENT="rustagent"
+fi
 ORIG_ARGS=("$@")
 SHELL="${SHELL:-/bin/bash}"
 
@@ -50,8 +55,8 @@ SESSION="$SESSION_ID"
 # ─── 清理残留 ───
 tmux kill-session -t "$SESSION" 2>/dev/null || true
 
-# ─── 创建 session ───
-tmux new-session -d -s "$SESSION"
+# ─── 创建 session（同步终端尺寸，避免 attach 时比例变形）───
+tmux new-session -d -s "$SESSION" -x - -y -
 
 # ─── 设置 session 环境变量 ───
 set_session_env() {
@@ -66,14 +71,9 @@ set_session_env() {
 }
 set_session_env
 
-# ─── 计算分栏尺寸（25%/75%）───
-COLS=$(tput cols 2>/dev/null || echo 80)
-LEFT_W=$(( COLS * 25 / 100 ))
-RIGHT_W=$(( COLS - LEFT_W ))
-
-# ─── 三 pane 布局（创建时直接指定尺寸，无闪烁）───
-tmux split-window -h -l "$RIGHT_W" -t "$SESSION:0.0"   # pane 0=左(25%), pane 1=右(75%)
-tmux split-window -v -l 4 -t "$SESSION:0.1"             # pane 1=右上(agent), pane 2=右下(输入, 4行)
+# ─── 三 pane 布局 ───
+tmux split-window -h -l '75%' -t "$SESSION:0.0"      # 左 25%, 右 75%
+tmux split-window -v -l 4 -t "$SESSION:0.1"           # 右上(agent), 右下(输入, 4行)
 
 # ─── 构建 exec env 需要的环境变量字符串 ───
 ENV_VARS=""

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -66,9 +66,14 @@ set_session_env() {
 }
 set_session_env
 
-# ─── 三 pane 布局 ───
-tmux split-window -h -t "$SESSION:0.0"      # pane 0=左, pane 1=右
-tmux split-window -v -t "$SESSION:0.1"      # pane 1=右上(agent), pane 2=右下(输入)
+# ─── 计算分栏尺寸（25%/75%）───
+COLS=$(tput cols 2>/dev/null || echo 80)
+LEFT_W=$(( COLS * 25 / 100 ))
+RIGHT_W=$(( COLS - LEFT_W ))
+
+# ─── 三 pane 布局（创建时直接指定尺寸，无闪烁）───
+tmux split-window -h -l "$RIGHT_W" -t "$SESSION:0.0"   # pane 0=左(25%), pane 1=右(75%)
+tmux split-window -v -l 4 -t "$SESSION:0.1"             # pane 1=右上(agent), pane 2=右下(输入, 4行)
 
 # ─── 构建 exec env 需要的环境变量字符串 ───
 ENV_VARS=""
@@ -148,17 +153,6 @@ tmux send-keys -t "$SESSION:0.2" "exec $WRAPPER" Enter
 
 # 聚焦输入 pane
 tmux select-pane -t "$SESSION:0.2"
-
-# 缓存终端尺寸，attach 后 resize
-COLS=$(tput cols 2>/dev/null || echo 80)
-LINES=$(tput lines 2>/dev/null || echo 24)
-
-(sleep 0.5
- WIN_WIDTH=$(tmux display -t "$SESSION:0" -p '#{window_width}' 2>/dev/null || echo "$COLS")
- LEFT=$(( WIN_WIDTH * 25 / 100 ))
- tmux resize-pane -t "$SESSION:0.0" -x "$LEFT"
- tmux resize-pane -t "$SESSION:0.2" -y 4
-) &
 
 tmux attach -t "$SESSION" >/dev/null 2>&1 || true
 

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -128,7 +128,9 @@ while true; do
         # Ctrl+D / EOF: 退出
         tmux send-keys -t "\$TC_SESSION:0.1" C-d
         tmux send-keys -t "\$TC_SESSION:0.0" C-c
-        printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n\033[90mReattach: tmux attach -t %s\033[0m\n' "\$TC_SESSION_ID" "\$TC_TMUX_SESSION"
+        sleep 0.3
+        # 退出 tmux 回到外部终端，让外部脚本打印 resume 信息
+        tmux detach-client 2>/dev/null || true
         break
     fi
     printf '\033[A\033[2K'
@@ -150,6 +152,7 @@ tmux select-pane -t "$SESSION:0.2"
 
 echo "tmux session: $SESSION"
 echo "Ctrl+B D 分离，Ctrl+C 停止"
+echo "从输入框 Ctrl+D 干净退出，会返回这里打印 resume 信息"
 
 # 缓存终端尺寸，attach 后 resize
 COLS=$(tput cols 2>/dev/null || echo 80)
@@ -162,4 +165,7 @@ LINES=$(tput lines 2>/dev/null || echo 24)
  tmux resize-pane -t "$SESSION:0.2" -y 4
 ) &
 
-tmux attach -t "$SESSION"
+tmux attach -t "$SESSION" || true
+
+# 从 tmux 返回后（Ctrl+D 退出或 Ctrl+B D 分离），打印 resume 信息
+printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n\033[90mReattach: tmux attach -t %s\033[0m\n' "$SESSION_ID" "$SESSION"

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -160,7 +160,7 @@ LINES=$(tput lines 2>/dev/null || echo 24)
  tmux resize-pane -t "$SESSION:0.2" -y 4
 ) &
 
-tmux attach -t "$SESSION" || true
+tmux attach -t "$SESSION" 2>/dev/null || true
 
 # 从 tmux 返回后（Ctrl+D 退出或 Ctrl+B D 分离），打印 resume 信息
 printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n' "$SESSION_ID"

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -160,7 +160,7 @@ LINES=$(tput lines 2>/dev/null || echo 24)
  tmux resize-pane -t "$SESSION:0.2" -y 4
 ) &
 
-tmux attach -t "$SESSION" 2>/dev/null || true
+tmux attach -t "$SESSION" >/dev/null 2>&1 || true
 
 # 从 tmux 返回后（Ctrl+D 退出或 Ctrl+B D 分离），打印 resume 信息
 printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n' "$SESSION_ID"

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -163,4 +163,4 @@ LINES=$(tput lines 2>/dev/null || echo 24)
 tmux attach -t "$SESSION" >/dev/null 2>&1 || true
 
 # 从 tmux 返回后（Ctrl+D 退出或 Ctrl+B D 分离），打印 resume 信息
-printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n' "$SESSION_ID"
+printf '\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n' "$SESSION_ID"

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -97,7 +97,6 @@ cat > "$WRAPPER" << WRAPPER_SCRIPT
 #!/usr/bin/env bash
 TC_SESSION="$SESSION"
 TC_SESSION_ID="$SESSION_ID"
-TC_TMUX_SESSION="$SESSION"
 HISTFILE="\${BASH_AGENT_HOME:-\$HOME}/.bash-agent/history"
 mkdir -p "\$(dirname "\$HISTFILE")" 2>/dev/null || true
 touch "\$HISTFILE" 2>/dev/null || true
@@ -150,10 +149,6 @@ tmux send-keys -t "$SESSION:0.2" "exec $WRAPPER" Enter
 # 聚焦输入 pane
 tmux select-pane -t "$SESSION:0.2"
 
-echo "tmux session: $SESSION"
-echo "Ctrl+B D 分离，Ctrl+C 停止"
-echo "从输入框 Ctrl+D 干净退出，会返回这里打印 resume 信息"
-
 # 缓存终端尺寸，attach 后 resize
 COLS=$(tput cols 2>/dev/null || echo 80)
 LINES=$(tput lines 2>/dev/null || echo 24)
@@ -168,4 +163,4 @@ LINES=$(tput lines 2>/dev/null || echo 24)
 tmux attach -t "$SESSION" || true
 
 # 从 tmux 返回后（Ctrl+D 退出或 Ctrl+B D 分离），打印 resume 信息
-printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n\033[90mReattach: tmux attach -t %s\033[0m\n' "$SESSION_ID" "$SESSION"
+printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n' "$SESSION_ID"

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -104,6 +104,10 @@ while true; do
         # Ctrl+D / EOF: 退出
         tmux send-keys -t "\$TC_SESSION:0.1" C-d
         tmux send-keys -t "\$TC_SESSION:0.0" C-c
+        sleep 0.5
+        # 捕获 agent 的 resume session 信息
+        resume=\$(tmux capture-pane -t "\$TC_SESSION:0.1" -p -S -5 2>/dev/null | grep 'Resume with:' | tail -1)
+        [[ -n "\$resume" ]] && printf '\n\033[36m%s\033[0m\n' "\$resume"
         break
     fi
     printf '\033[A\033[2K'

--- a/scripts/tcode
+++ b/scripts/tcode
@@ -22,7 +22,6 @@ set -euo pipefail
 AGENT="${1:-bash-agent}"
 shift 2>/dev/null || true
 ORIG_ARGS=("$@")
-SESSION="tcode-$$"
 SHELL="${SHELL:-/bin/bash}"
 
 # ─── 提取或生成 session ID（与 agent.sh util_new_session_id 一致）───
@@ -44,6 +43,9 @@ if [[ -z "$SESSION_ID" ]]; then
     PENDING_ARGS+=("--session" "$SESSION_ID")
 fi
 AGENT_ARGS=("${PENDING_ARGS[@]}")
+
+# Tmux session 名与 agent session ID 一致
+SESSION="$SESSION_ID"
 
 # ─── 清理残留 ───
 tmux kill-session -t "$SESSION" 2>/dev/null || true
@@ -95,6 +97,7 @@ cat > "$WRAPPER" << WRAPPER_SCRIPT
 #!/usr/bin/env bash
 TC_SESSION="$SESSION"
 TC_SESSION_ID="$SESSION_ID"
+TC_TMUX_SESSION="$SESSION"
 HISTFILE="\${BASH_AGENT_HOME:-\$HOME}/.bash-agent/history"
 mkdir -p "\$(dirname "\$HISTFILE")" 2>/dev/null || true
 touch "\$HISTFILE" 2>/dev/null || true
@@ -125,7 +128,7 @@ while true; do
         # Ctrl+D / EOF: 退出
         tmux send-keys -t "\$TC_SESSION:0.1" C-d
         tmux send-keys -t "\$TC_SESSION:0.0" C-c
-        printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n' "\$TC_SESSION_ID"
+        printf '\n\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n\033[90mReattach: tmux attach -t %s\033[0m\n' "\$TC_SESSION_ID" "\$TC_TMUX_SESSION"
         break
     fi
     printf '\033[A\033[2K'


### PR DESCRIPTION
## 新增 `tcode` 工具

tmux 三栏式 agent 聊天界面包装器。

### 布局

```
┌──────────┬────────────────────────────────┐
│          │  agent (rustagent/goagent/...) │
│  watch   │  (对话在此 pane 中完整展示)     │
│  list-   │                                │
│  sessions│                                │
│  (25%)   │                                │
│          ├────────────────────────────────┤
│          │  > 输入行                       │
└──────────┴────────────────────────────────┘
```

- **左栏**: `watch -t` 实时展示 `agent --list-sessions`
- **右上方**: agent 主进程 (bash-agent/goagent/rustagent)
- **右下方**: 输入框 (readline 模式，支持历史/编辑)

### 用法

```bash
tcode                         # 默认 rustagent
tcode goagent --session x     # 指定 agent + 透传参数
tcode --session x             # 默认 rustagent + 指定 session
```

### 主要特性

- 三 pane 布局，启动即定位（无闪烁）
- 输入框 Ctrl+C 中断 agent、Ctrl+D 干净退出并打印 resume 信息
- 窗口标题动态跟随 agent 标题
- 退出后打印 `Resume with: --session <id> or --continue`
- session ID 自动生成，与 agent 共享同一 ID
- tmux session 名 = agent session ID，支持 `tmux attach` 重连

### CI / 发布

- `make build-tcode` 将 `scripts/tcode` 复制到 `dist/tcode`
- `make build` 已包含 `build-tcode`
- CI 新增 `tcode` job，release 时包含 `dist/tcode`