### PR TITLE
  Align cagent stats, cache accounting, and linenoise behavior

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -220,10 +220,11 @@ Agent *agent_create(const char *provider, const char *model,
     a->paths = store_session_paths_for(home, cwd, sid);
     free(sid);
 
-    /* 判断是否新会话 */
+    /* 判断是否新会话：与 bash 版一致，以 events.jsonl 是否为空为准。
+     * 只看 conversation.jsonl 是否存在会把已有空会话当作旧会话，也可能在跨版本切换时误判。 */
     int is_new = 1;
-    FILE *f = fopen(a->paths.conversation, "r");
-    if (f) { is_new = 0; fclose(f); }
+    struct stat st;
+    if (stat(a->paths.events, &st) == 0 && st.st_size > 0) is_new = 0;
 
     store_session_init(&a->paths, is_new);
 
@@ -2311,6 +2312,31 @@ int agent_compact_context(Agent *agent, const char *trigger) {
  * 终端标题更新
  * ============================================================ */
 
+static void format_int_commas(int n, char *out, size_t out_size) {
+    char raw[32];
+    snprintf(raw, sizeof(raw), "%d", n);
+    size_t len = strlen(raw);
+    size_t commas = (len > 0) ? (len - 1) / 3 : 0;
+    size_t need = len + commas + 1;
+    if (out_size < need) {
+        snprintf(out, out_size, "%d", n);
+        return;
+    }
+
+    out[need - 1] = '\0';
+    int ri = (int)len - 1;
+    int oi = (int)need - 2;
+    int group = 0;
+    while (ri >= 0) {
+        if (group == 3) {
+            out[oi--] = ',';
+            group = 0;
+        }
+        out[oi--] = raw[ri--];
+        group++;
+    }
+}
+
 void agent_update_title(Agent *agent) {
     if (!agent->interactive) return;
     char *stats_content = store_stats_read(agent->paths.stats);
@@ -2329,8 +2355,15 @@ void agent_update_title(Agent *agent) {
     int total_i = ai + cr;
     int pct = (total_i > 0) ? (cr * 100 / total_i) : 0;
 
-    fprintf(stderr, "\x1b]0;%s T:%d R:%d I:%d(%d%%) O:%d C:%d\x07",
-            agent->model, tc, ar, total_i, pct, ao, ct);
+    char tc_s[32], ar_s[32], total_i_s[32], ao_s[32], ct_s[32];
+    format_int_commas(tc, tc_s, sizeof(tc_s));
+    format_int_commas(ar, ar_s, sizeof(ar_s));
+    format_int_commas(total_i, total_i_s, sizeof(total_i_s));
+    format_int_commas(ao, ao_s, sizeof(ao_s));
+    format_int_commas(ct, ct_s, sizeof(ct_s));
+
+    fprintf(stderr, "\x1b]0;%s T:%s R:%s I:%s(%d%%) O:%s C:%s\x07",
+            agent->model, tc_s, ar_s, total_i_s, pct, ao_s, ct_s);
     fflush(stderr);
 
     free(stats_content);

--- a/c/readline.c
+++ b/c/readline.c
@@ -89,6 +89,7 @@ static void *readline_thread_fn(void *arg) {
                 *last_slash = '/';
             }
         }
+        linenoiseSetMultiLine(1);
         linenoiseHistorySetMaxLen(4096);
         linenoiseHistoryLoad(hist_path);
 

--- a/c/store.c
+++ b/c/store.c
@@ -394,6 +394,34 @@ char *store_stats_read(const char *path) {
     return util_read_file(path);
 }
 
+static void stats_write_canonical(const char *path,
+                                  int current_turn_count,
+                                  int agent_request_count,
+                                  int compact_request_count,
+                                  int sub_agent_request_count,
+                                  int total_input_tokens,
+                                  int total_output_tokens,
+                                  int total_cache_read_tokens,
+                                  int total_cache_creation_tokens,
+                                  int current_context_tokens,
+                                  const char *last_updated) {
+    StrBuf buf;
+    sb_init(&buf);
+    sb_appendf(&buf, "{\"current_turn_count\":%d,\"agent_request_count\":%d,"
+               "\"compact_request_count\":%d,\"sub_agent_request_count\":%d,"
+               "\"total_input_tokens\":%d,\"total_output_tokens\":%d,"
+               "\"total_cache_read_tokens\":%d,\"total_cache_creation_tokens\":%d,"
+               "\"current_context_tokens\":%d,\"last_updated\":",
+               current_turn_count, agent_request_count, compact_request_count,
+               sub_agent_request_count, total_input_tokens, total_output_tokens,
+               total_cache_read_tokens, total_cache_creation_tokens,
+               current_context_tokens);
+    sb_append_json_string(&buf, last_updated ? last_updated : "");
+    sb_append(&buf, "}\n");
+    util_write_file(path, buf.data);
+    sb_free(&buf);
+}
+
 void store_stats_add_int(JsonVal obj, const char *key, int delta) {
     int cur = store_stats_get_int(obj, key);
     store_stats_set_int(obj, key, cur + delta);
@@ -441,88 +469,55 @@ int store_stats_get_file_int(const char *path, const char *key) {
     return val;
 }
 
-/* 简易文件级操作：设置 stats 文件中的整数字段（原地修改 JSON 数字值） */
 /* 设置 stats 文件中的整数字段。
- * 由于原地覆盖在值变长时会失败（如 0→13），改用解析→修改→重建策略。
- * 同时更新 last_updated 字段 — 对齐 bash 版 stats.awk _now() */
+ * 读取已有字段；缺失/无效字段按 0 处理；写回标准 stats JSON。
+ * 这样旧版本缺字段时，下一次正常写入会自然补齐，不做历史回算。 */
 void store_stats_set_int_file(const char *path, const char *key, int value) {
-    char *content = store_stats_read(path);
-    if (!content) return;
-    JsonParse jp = json_parse_root(content);
-    if (!jp.error) {
-        /* 先更新 last_updated */
-        {
-            time_t now = time(NULL);
-            struct tm tm_buf;
-            gmtime_r(&now, &tm_buf);
-            char ts[32];
-            strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
-            /* 查找并替换 last_updated 值 */
-            const char *lu_search = "\"last_updated\":\"";
-            char *lu_pos = strstr((char*)content, lu_search);
-            if (lu_pos) {
-                char *val_start = lu_pos + strlen(lu_search);
-                char *val_end = strchr(val_start, '"');
-                if (val_end) {
-                    size_t old_len = val_end - val_start;
-                    size_t new_len = strlen(ts);
-                    if (new_len == old_len) {
-                        memcpy(val_start, ts, new_len);
-                    } else {
-                        /* 长度不同，重建 */
-                        StrBuf rebuilt;
-                        sb_init(&rebuilt);
-                        sb_appendn(&rebuilt, content, val_start - content);
-                        sb_append(&rebuilt, ts);
-                        sb_append(&rebuilt, val_end);
-                        util_write_file(path, rebuilt.data);
-                        sb_free(&rebuilt);
-                        free(content);
-                        /* 重新读取以更新 key */
-                        content = store_stats_read(path);
-                        if (!content) return;
-                        jp = json_parse_root(content);
-                        if (jp.error) { free(content); return; }
-                    }
-                }
-            }
-        }
-        /* 再更新目标 key */
-        {
-            char search[128];
-            snprintf(search, sizeof(search), "\"%s\"", key);
-            char *p = strstr((char*)jp.val.src, search);
-            if (p) {
-                p += strlen(search);
-                while (*p == ' ' || *p == ':') p++;
-                char *vs = p;
-                while (*p && *p != ',' && *p != '}' && *p != ' ' && *p != '\n' && *p != '\r') p++;
-                int old_len = (int)(p - vs);
-                char nv[32];
-                snprintf(nv, sizeof(nv), "%d", value);
-                int nl = (int)strlen(nv);
+    int current_turn_count = 0, agent_request_count = 0;
+    int compact_request_count = 0, sub_agent_request_count = 0;
+    int total_input_tokens = 0, total_output_tokens = 0;
+    int total_cache_read_tokens = 0, total_cache_creation_tokens = 0;
+    int current_context_tokens = 0;
 
-                if (nl <= old_len) {
-                    /* 原地覆盖，用空格填充多余空间 */
-                    memcpy(vs, nv, nl);
-                    for (int i = nl; i < old_len; i++) vs[i] = ' ';
-                    util_write_file(path, content);
-                } else {
-                    /* 值变长：切分拼接，重建 JSON 文件 */
-                    int prefix_len = (int)(vs - content);
-                    int suffix_start = (int)(p - content);
-                    StrBuf rebuilt;
-                    sb_init(&rebuilt);
-                    sb_appendn(&rebuilt, content, prefix_len);
-                    sb_append(&rebuilt, nv);
-                    sb_append(&rebuilt, content + suffix_start);
-                    util_write_file(path, rebuilt.data);
-                    sb_free(&rebuilt);
-                }
-            }
+    char *content = store_stats_read(path);
+    if (content && content[0]) {
+        JsonParse jp = json_parse_root(content);
+        if (!jp.error) {
+            current_turn_count = json_get_int(jp.val, "current_turn_count");
+            agent_request_count = json_get_int(jp.val, "agent_request_count");
+            compact_request_count = json_get_int(jp.val, "compact_request_count");
+            sub_agent_request_count = json_get_int(jp.val, "sub_agent_request_count");
+            total_input_tokens = json_get_int(jp.val, "total_input_tokens");
+            total_output_tokens = json_get_int(jp.val, "total_output_tokens");
+            total_cache_read_tokens = json_get_int(jp.val, "total_cache_read_tokens");
+            total_cache_creation_tokens = json_get_int(jp.val, "total_cache_creation_tokens");
+            current_context_tokens = json_get_int(jp.val, "current_context_tokens");
         }
     }
-    free(content);
+
+    if (strcmp(key, "current_turn_count") == 0) current_turn_count = value;
+    else if (strcmp(key, "agent_request_count") == 0) agent_request_count = value;
+    else if (strcmp(key, "compact_request_count") == 0) compact_request_count = value;
+    else if (strcmp(key, "sub_agent_request_count") == 0) sub_agent_request_count = value;
+    else if (strcmp(key, "total_input_tokens") == 0) total_input_tokens = value;
+    else if (strcmp(key, "total_output_tokens") == 0) total_output_tokens = value;
+    else if (strcmp(key, "total_cache_read_tokens") == 0) total_cache_read_tokens = value;
+    else if (strcmp(key, "total_cache_creation_tokens") == 0) total_cache_creation_tokens = value;
+    else if (strcmp(key, "current_context_tokens") == 0) current_context_tokens = value;
+
+    time_t now = time(NULL);
+    struct tm tm_buf;
+    gmtime_r(&now, &tm_buf);
+    char ts[32];
+    strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
+    stats_write_canonical(path, current_turn_count, agent_request_count,
+                          compact_request_count, sub_agent_request_count,
+                          total_input_tokens, total_output_tokens,
+                          total_cache_read_tokens, total_cache_creation_tokens,
+                          current_context_tokens, ts);
+    if (content) {
+        free(content);
+    }
 }
 
 /* 通用 stats 更新：读取→修改→写回 */

--- a/c/transport.c
+++ b/c/transport.c
@@ -136,6 +136,25 @@ HttpResponse http_post(const char *url, const char **headers, int header_count,
 static void emit_simple_event(sse_callback_fn callback, void *ctx,
                               SseEventType type, const char *content);
 
+static int openai_cached_tokens(JsonVal usage) {
+    int cached = json_get_int(usage, "cached_tokens");
+    if (cached > 0) return cached;
+    JsonVal details = json_get(usage, "prompt_tokens_details");
+    if (details.type != JSON_NULL) cached = json_get_int(details, "cached_tokens");
+    return cached;
+}
+
+static void fill_openai_usage_event(SseEvent *evt, JsonVal usage) {
+    int prompt = json_get_int(usage, "prompt_tokens");
+    int cached = openai_cached_tokens(usage);
+    evt->out_tokens = json_get_int(usage, "completion_tokens");
+    evt->cache_read_tokens = cached;
+    if (prompt > 0) {
+        evt->in_tokens = prompt - cached;
+        if (evt->in_tokens < 0) evt->in_tokens = 0;
+    }
+}
+
 int http_post_sse(const char *url, const char **headers, int header_count,
                   const char *body, size_t body_len,
                   const char *provider,
@@ -257,8 +276,7 @@ int http_post_sse(const char *url, const char **headers, int header_count,
                         SseEvent evt;
                         memset(&evt, 0, sizeof(evt));
                         evt.type = SSE_USAGE;
-                        evt.in_tokens = json_get_int(usage, "prompt_tokens");
-                        evt.out_tokens = json_get_int(usage, "completion_tokens");
+                        fill_openai_usage_event(&evt, usage);
                         callback(ctx, &evt);
                     }
                 }
@@ -438,8 +456,7 @@ int sse_parse_event(const char *provider, const char *data, size_t data_len,
                 SseEvent evt;
                 memset(&evt, 0, sizeof(evt));
                 evt.type = SSE_USAGE;
-                evt.in_tokens = json_get_int(usage, "prompt_tokens");
-                evt.out_tokens = json_get_int(usage, "completion_tokens");
+                fill_openai_usage_event(&evt, usage);
                 callback(ctx, &evt);
             }
         }

--- a/go/cmd/goagent/readline.go
+++ b/go/cmd/goagent/readline.go
@@ -37,6 +37,7 @@ func NewReadline(home string) *Readline {
 
 // Start launches the background readline goroutine.
 func (r *Readline) Start() {
+	linenoise.SetMultiLine(true)
 	linenoise.HistorySetMaxLen(4096)
 	linenoise.HistoryLoad(r.histPath)
 

--- a/go/store.go
+++ b/go/store.go
@@ -50,7 +50,6 @@ func (s *FileStore) UpdateStats(usage Usage, model string) error {
 	s.stats.OutputTokens += usage.OutputTokens
 	s.stats.CacheWrite += usage.CacheWrite
 	s.stats.CacheRead += usage.CacheRead
-	s.stats.TotalCost += usage.Cost
 
 	return s.flushStats()
 }

--- a/go/types.go
+++ b/go/types.go
@@ -124,15 +124,14 @@ type ToolResultInfo struct {
 // Stats 会话统计数据
 type Stats struct {
 	TurnCount        int     `json:"current_turn_count"`          // user turn count
-	InputTokens      int     `json:"total_input_tokens"`          // cumulative input
-	OutputTokens     int     `json:"total_output_tokens"`         // cumulative output
-	CacheWrite       int     `json:"total_cache_creation_tokens"` // cumulative cache write
-	CacheRead        int     `json:"total_cache_read_tokens"`     // cumulative cache read
-	TotalCost        float64 `json:"total_cost"`                  // cumulative cost
 	TotalRequests    int     `json:"agent_request_count"`         // total LLM requests
 	TotalCompact     int     `json:"compact_request_count"`       // number of compactions
-	ContextTokens    int     `json:"current_context_tokens"`      // current context size
 	SubAgentRequests int     `json:"sub_agent_request_count"`     // sub-agent requests
+	InputTokens      int     `json:"total_input_tokens"`          // cumulative input
+	OutputTokens     int     `json:"total_output_tokens"`         // cumulative output
+	CacheRead        int     `json:"total_cache_read_tokens"`     // cumulative cache read
+	CacheWrite       int     `json:"total_cache_creation_tokens"` // cumulative cache write
+	ContextTokens    int     `json:"current_context_tokens"`      // current context size
 	LastUpdated      string  `json:"last_updated"`                // ISO 8601 timestamp
 }
 

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -348,7 +348,11 @@ impl Agent {
         let paths = session::paths_for(&home, &cwd, &sid);
         session::ensure_dir(&paths.base_dir)?;
         session::ensure_dir(&paths.session_dir)?;
-        let new_session = !paths.events.exists();
+        let new_session = paths
+            .events
+            .metadata()
+            .map(|m| m.len() == 0)
+            .unwrap_or(true);
         for f in [
             &paths.conversation,
             &paths.events,
@@ -621,12 +625,13 @@ impl Agent {
         let msg_tx_arc = self.msg_tx.clone();
         let history_path_clone = history_path.to_string_lossy().to_string();
         let readline_handle = std::thread::spawn(move || {
+            ffi::set_multiline(true);
             ffi::history_load(&history_path_clone);
             ffi::history_set_max_len(1000);
             // 借鉴 bash 版本：线程退出时主动 drop 发送端，让 main_loop 收到 Disconnected
             let result = (|| {
                 loop {
-                    let line = match ffi::line("> ") {
+                    let line = match ffi::line("\x1b[32m> \x1b[0m") {
                         Ok(s) => s.trim_end().to_string(),
                         Err(ffi::LineError::Interrupted) => {
                             // Ctrl+C 重新输入当前行（与 Go 版本一致）
@@ -714,10 +719,6 @@ impl Agent {
                         if !is_interrupt {
                             self.error(&msg);
                         }
-                    }
-                    if self.cfg.interactive {
-                        // agent 执行完成后重新显示提示符
-                        let _ = write!(self.stderr.borrow_mut(), "\x1b[32m> \x1b[0m");
                     }
                     // 通知 readline 线程处理完成
                     let _ = done.send(());

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -166,8 +166,29 @@ use std::path::{Path, PathBuf};
         Ok(stats)
     }
 
+    fn stats_num(stats: &serde_json::Map<String, Value>, key: &str) -> i64 {
+        stats.get(key).and_then(Value::as_i64).unwrap_or(0)
+    }
+
     pub fn store_stats_write(stats_path: &Path, stats: &serde_json::Map<String, Value>) -> Result<()> {
-        fs::write(stats_path, serde_json::to_string(stats)? + "\n")?;
+        let last_updated = stats
+            .get("last_updated")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let line = format!(
+            "{{\"current_turn_count\":{},\"agent_request_count\":{},\"compact_request_count\":{},\"sub_agent_request_count\":{},\"total_input_tokens\":{},\"total_output_tokens\":{},\"total_cache_read_tokens\":{},\"total_cache_creation_tokens\":{},\"current_context_tokens\":{},\"last_updated\":{}}}\n",
+            stats_num(stats, "current_turn_count"),
+            stats_num(stats, "agent_request_count"),
+            stats_num(stats, "compact_request_count"),
+            stats_num(stats, "sub_agent_request_count"),
+            stats_num(stats, "total_input_tokens"),
+            stats_num(stats, "total_output_tokens"),
+            stats_num(stats, "total_cache_read_tokens"),
+            stats_num(stats, "total_cache_creation_tokens"),
+            stats_num(stats, "current_context_tokens"),
+            serde_json::to_string(last_updated)?,
+        );
+        fs::write(stats_path, line)?;
         Ok(())
     }
 


### PR DESCRIPTION
  ## Summary
  - Fix C agent stats writes so missing fields are treated as zero and `stats.json` is written in the standard single-line format.
  - Fix C OpenAI cache accounting by reading `prompt_tokens_details.cached_tokens` and counting uncached input as `prompt_tokens - cached_tokens`.
  - Align terminal title formatting in C with comma-separated numbers.
  - Align Go and Rust stats writes with the standard stats field set and ordering.
  - Enable linenoise multiline mode across C, Go, and Rust.
  - Fix Rust interactive prompt behavior:
    - remove the duplicate manually printed prompt after each turn
    - use the same green prompt as C/Go
  - Align Rust new-session detection with the `events.jsonl` empty/missing behavior used by the other implementations.

  ## Tests
  - `make -C c`
  - `go test ./...`
  - `cargo test`
  - `AGENT=./dist/cagent bash tests/test.sh 9899` -> 118 passed, 0 failed