### PR TITLE
Align stream-json events, display queues, and stats behavior across agents

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -417,7 +417,12 @@ static void push_display_event(const SessionPaths *paths, MsgQueue *dq, DisplayM
             free(evt);
         }
     }
-    if (dq) mq_push(dq, msg);
+    if (dq && !store_event_stream_json_enabled()) {
+        mq_push(dq, msg);
+    } else {
+        display_message_free(msg);
+        free(msg);
+    }
 }
 
 /* ============================================================

--- a/c/agent.c
+++ b/c/agent.c
@@ -23,6 +23,53 @@
 static void push_display(MsgQueue *dq, DisplayMessage *msg);
 static void push_display_event(const SessionPaths *paths, MsgQueue *dq, DisplayMessage *msg);
 
+static char *agent_tool_display_summary(const char *name, JsonVal input, const char *input_json) {
+    char *field = NULL;
+    if (strcmp(name, "Read") == 0 || strcmp(name, "Write") == 0 || strcmp(name, "Edit") == 0) {
+        field = json_get_string(input, "path");
+    } else if (strcmp(name, "Glob") == 0 || strcmp(name, "Grep") == 0) {
+        field = json_get_string(input, "pattern");
+    } else if (strcmp(name, "Bash") == 0) {
+        field = json_get_string(input, "command");
+    } else if (strcmp(name, "Skill") == 0) {
+        field = json_get_string(input, "name");
+    } else if (strcmp(name, "SubAgent") == 0) {
+        field = json_get_string(input, "description");
+    } else if (strcmp(name, "WebSearch") == 0) {
+        field = json_get_string(input, "query");
+    } else if (strcmp(name, "WebFetch") == 0 || strcmp(name, "WebReader") == 0) {
+        field = json_get_string(input, "url");
+    } else if (strcmp(name, "TodoWrite") == 0) {
+        JsonVal todos_arr = json_get(input, "todos");
+        if (todos_arr.type == JSON_ARRAY) {
+            int total = json_array_len(todos_arr);
+            int comp = 0;
+            for (int ti = 0; ti < total; ti++) {
+                JsonVal ti_item = json_array_get(todos_arr, ti);
+                char *ti_status = json_get_string(ti_item, "status");
+                if (ti_status && strcmp(ti_status, "completed") == 0) comp++;
+                free(ti_status);
+            }
+            char buf[32];
+            snprintf(buf, sizeof(buf), "%d/%d", comp, total);
+            field = util_strdup(buf);
+        }
+    }
+    if (field) return field;
+
+    if (input_json && input_json[0]) {
+        size_t len = strlen(input_json);
+        if (len > 80) {
+            char *summary = malloc(84);
+            memcpy(summary, input_json, 80);
+            strcpy(summary + 80, "...");
+            return summary;
+        }
+        return util_strdup(input_json);
+    }
+    return util_strdup("");
+}
+
 typedef struct {
     SseAccumulator accum;
     MsgQueue *display_queue;
@@ -493,22 +540,22 @@ void agent_replay_events(Agent *agent, int max_turns) {
             }
             char *name = json_get_string(jp.val, "name");
             char *id = json_get_string(jp.val, "id");
-            /* 从 input 提取摘要（截断） */
-            char summary[84] = "";
             JsonVal input_val = json_get(jp.val, "input");
+            char *input_str = NULL;
+            char *summary = NULL;
             if (input_val.type != JSON_NULL) {
-                char *input_str = json_as_string(input_val);
-                if (input_str) {
-                    strncpy(summary, input_str, sizeof(summary) - 1);
-                    summary[sizeof(summary) - 1] = '\0';
-                    util_truncate_str(summary, 80);
-                    free(input_str);
-                }
+                input_str = json_as_string(input_val);
+                summary = agent_tool_display_summary(name ? name : "", input_val, input_str);
             }
+            if (!input_str) input_str = util_strdup("{}");
+            if (!summary) summary = util_strdup("");
+
             DisplayMessage *dm = malloc(sizeof(DisplayMessage));
             *dm = display_msg_tool_call(id ? id : "", name ? name : "", summary);
+            free(dm->tool_input);
+            dm->tool_input = util_strdup(input_str);
             push_display(agent->display_queue, dm);
-            free(name); free(id);
+            free(input_str); free(summary); free(name); free(id);
         }
         else if (strcmp(type, "tool_result") == 0) {
             /* flush 累积 */
@@ -767,55 +814,11 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
         /* ---- 显示工具调用 ---- */
         for (int i = 0; i < accum->tool_count; i++) {
             ToolCallAccum *tc = &accum->tools[i];
-            /* 从 input_json 提取摘要 */
             char *summary = NULL;
             if (tc->input_json.len > 0) {
                 JsonParse jp2 = json_parse_root(tc->input_json.data);
                 if (!jp2.error) {
-                    char *field = NULL;
-                    if (strcmp(tc->name, "Read") == 0 || strcmp(tc->name, "Write") == 0 || strcmp(tc->name, "Edit") == 0) {
-                        field = json_get_string(jp2.val, "path");
-                    } else if (strcmp(tc->name, "Glob") == 0 || strcmp(tc->name, "Grep") == 0) {
-                        field = json_get_string(jp2.val, "pattern");
-                    } else if (strcmp(tc->name, "Bash") == 0) {
-                        field = json_get_string(jp2.val, "command");
-                    } else if (strcmp(tc->name, "Skill") == 0) {
-                        field = json_get_string(jp2.val, "name");
-                    } else if (strcmp(tc->name, "SubAgent") == 0) {
-                        field = json_get_string(jp2.val, "description");
-                    } else if (strcmp(tc->name, "WebSearch") == 0) {
-                        field = json_get_string(jp2.val, "query");
-                    } else if (strcmp(tc->name, "WebFetch") == 0 || strcmp(tc->name, "WebReader") == 0) {
-                        field = json_get_string(jp2.val, "url");
-                    } else if (strcmp(tc->name, "TodoWrite") == 0) {
-                        /* 计算 completed/total */
-                        JsonVal todos_arr = json_get(jp2.val, "todos");
-                        if (todos_arr.type == JSON_ARRAY) {
-                            int total = json_array_len(todos_arr);
-                            int comp = 0;
-                            for (int ti = 0; ti < total; ti++) {
-                                JsonVal ti_item = json_array_get(todos_arr, ti);
-                                char *ti_status = json_get_string(ti_item, "status");
-                                if (ti_status && strcmp(ti_status, "completed") == 0) comp++;
-                                free(ti_status);
-                            }
-                            char buf[32];
-                            snprintf(buf, sizeof(buf), "%d/%d", comp, total);
-                            field = util_strdup(buf);
-                        }
-                    }
-                    if (field) {
-                        summary = field;
-                    } else {
-                        /* 使用整个 input_json（截断） */
-                        if (tc->input_json.len > 80) {
-                            summary = malloc(84);
-                            memcpy(summary, tc->input_json.data, 80);
-                            strcpy(summary + 80, "...");
-                        } else {
-                            summary = util_strdup(tc->input_json.data);
-                        }
-                    }
+                    summary = agent_tool_display_summary(tc->name, jp2.val, tc->input_json.data);
                 }
             }
             if (!summary) summary = util_strdup("");

--- a/c/agent.c
+++ b/c/agent.c
@@ -313,6 +313,14 @@ static void push_display(MsgQueue *dq, DisplayMessage *msg) {
     }
 }
 
+static void display_tool_result_set_tool(DisplayMessage *msg, const ToolCallAccum *tc) {
+    if (!msg || !tc) return;
+    free(msg->tool_id);
+    free(msg->tool_name);
+    msg->tool_id = util_strdup(tc->id ? tc->id : "");
+    msg->tool_name = util_strdup(tc->name ? tc->name : "");
+}
+
 /* 将 DisplayMessage 转为事件 JSON 字符串（用于 events.jsonl） */
 static char *display_msg_to_event(DisplayMessage *msg) {
     StrBuf buf;
@@ -578,6 +586,8 @@ void agent_replay_events(Agent *agent, int max_turns) {
             }
             DisplayMessage *dm = malloc(sizeof(DisplayMessage));
             *dm = display_msg_tool_result(content ? content : "", 0);
+            dm->tool_id = json_get_string(jp.val, "tool_use_id");
+            dm->tool_name = json_get_string(jp.val, "name");
             push_display(agent->display_queue, dm);
             free(content);
         }
@@ -966,6 +976,7 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                     /* display 只显示 summary 行 */
                     DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                     *dm = display_msg_tool_result(summary.data, tr.exit_code);
+                    display_tool_result_set_tool(dm, tc);
                     push_display_event(&agent->paths, agent->display_queue, dm);
 
                     free(summary.data);
@@ -973,6 +984,7 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                     /* 显示工具结果 */
                     DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                     *dm = display_msg_tool_result(tr.output ? tr.output : "(empty)", tr.exit_code);
+                    display_tool_result_set_tool(dm, tc);
                     push_display_event(&agent->paths, agent->display_queue, dm);
                 }
 

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -18,6 +18,7 @@
 #include "msgqueue.h"
 #include "readline.h"
 #include "display.h"
+#include "store.h"
 #include "util.h"
 #include <curl/curl.h>
 #include <stdio.h>
@@ -226,6 +227,8 @@ int main(int argc, char *argv[]) {
     mq_init(&input_queue);
     mq_init(&display_queue);
 
+    store_event_set_stream_json(strcmp(output_fmt, "stream-json") == 0);
+
     /* 创建 Agent */
     Agent *agent = agent_create(provider, effective_model,
                                 effective_api_key, effective_base_url,
@@ -273,14 +276,14 @@ int main(int argc, char *argv[]) {
         pthread_t display_thread;
         DisplayConfig dcfg;
         dcfg.queue = &display_queue;
-        dcfg.format = agent->output_format ? OUTPUT_STREAM_JSON : OUTPUT_HUMAN;
+        dcfg.format = OUTPUT_HUMAN;
         dcfg.interactive = 1;
         display_thread_start(&display_thread, &dcfg);
 
         /* Replay 最近 10 轮事件（复用 display 线程渲染） */
-        agent_replay_events(agent, 10);
+        if (!agent->output_format) agent_replay_events(agent, 10);
         /* replay 后输出换行 */
-        {
+        if (!agent->output_format) {
             DisplayMessage *dm = malloc(sizeof(DisplayMessage));
             *dm = display_msg_text("\n");
             mq_push(&display_queue, dm);
@@ -319,7 +322,7 @@ int main(int argc, char *argv[]) {
         pthread_t display_thread;
         DisplayConfig dcfg;
         dcfg.queue = &display_queue;
-        dcfg.format = agent->output_format ? OUTPUT_STREAM_JSON : OUTPUT_HUMAN;
+        dcfg.format = OUTPUT_HUMAN;
         dcfg.interactive = 0;
         display_thread_start(&display_thread, &dcfg);
 

--- a/c/display.c
+++ b/c/display.c
@@ -63,62 +63,79 @@ static void ensure_newline(DisplayState *ds, FILE *out) {
 static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
                             int interactive, DisplayMessage *msg) {
     if (format == OUTPUT_STREAM_JSON) {
-        /* stream-json 模式：直接输出 JSON */
+        /* stream-json 模式：对齐 bash 版 util_msg_to_stream 的事件形状 */
         StrBuf buf;
         sb_init(&buf);
-        const char *type_name = "";
         switch (msg->type) {
-            case DISPLAY_TEXT: type_name = "text"; break;
-            case DISPLAY_THINKING: type_name = "thinking"; break;
-            case DISPLAY_TOOL_CALL: type_name = "tool_call"; break;
-            case DISPLAY_TOOL_RESULT: type_name = "tool_result"; break;
-            case DISPLAY_USAGE: type_name = "usage"; break;
-            case DISPLAY_STOP: type_name = "stop"; break;
-            case DISPLAY_ERROR: type_name = "error"; break;
-            case DISPLAY_SUB_AGENT_START: type_name = "sub_agent_start"; break;
-            case DISPLAY_SUB_AGENT_RESULT: type_name = "sub_agent_result"; break;
-            case DISPLAY_CONTEXT_UPDATE: type_name = "context_update"; break;
-        }
-        sb_append_char(&buf, '{');
-        sb_append(&buf, "\"type\":");
-        sb_append_json_string(&buf, type_name);
-        if (msg->content) {
-            sb_append(&buf, ",\"text\":");
-            sb_append_json_string(&buf, msg->content);
-        }
-        if (msg->type == DISPLAY_USAGE) {
-            sb_appendf(&buf, ",\"input_tokens\":%d,\"output_tokens\":%d,"
-                       "\"cache_read_input_tokens\":%d,\"cache_creation_input_tokens\":%d",
+        case DISPLAY_TEXT:
+            sb_append(&buf, "{\"type\":\"text\",\"content\":");
+            sb_append_json_string(&buf, msg->content ? msg->content : "");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_THINKING:
+            sb_append(&buf, "{\"type\":\"thinking\",\"content\":");
+            sb_append_json_string(&buf, msg->content ? msg->content : "");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_TOOL_CALL:
+            sb_append(&buf, "{\"type\":\"tool_call\",\"name\":");
+            sb_append_json_string(&buf, msg->tool_name ? msg->tool_name : "");
+            sb_append(&buf, ",\"id\":");
+            sb_append_json_string(&buf, msg->tool_id ? msg->tool_id : "");
+            sb_append(&buf, ",\"input\":");
+            sb_append(&buf, (msg->tool_input && msg->tool_input[0]) ? msg->tool_input : "{}");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_TOOL_RESULT:
+            sb_append(&buf, "{\"type\":\"tool_result\",\"tool_use_id\":");
+            sb_append_json_string(&buf, msg->tool_id ? msg->tool_id : "");
+            sb_append(&buf, ",\"name\":");
+            sb_append_json_string(&buf, msg->tool_name ? msg->tool_name : "");
+            sb_append(&buf, ",\"content\":");
+            sb_append_json_string(&buf, msg->content ? msg->content : "");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_USAGE:
+            sb_appendf(&buf, "{\"type\":\"usage\",\"input_tokens\":%d,\"output_tokens\":%d,"
+                       "\"cache_read_input_tokens\":%d,\"cache_creation_input_tokens\":%d,"
+                       "\"kind\":\"agent\"}",
                        msg->in_tokens, msg->out_tokens,
                        msg->cache_read_tokens, msg->cache_creation_tokens);
-        }
-        if (msg->type == DISPLAY_CONTEXT_UPDATE) {
-            sb_append(&buf, ",\"kind\":\"compact\",\"trigger\":");
+            break;
+        case DISPLAY_STOP:
+            sb_append(&buf, "{\"type\":\"stop\",\"reason\":");
+            sb_append_json_string(&buf, msg->content ? msg->content : "");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_ERROR:
+            sb_append(&buf, "{\"type\":\"error\",\"message\":");
+            sb_append_json_string(&buf, msg->content ? msg->content : "");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_SUB_AGENT_START:
+            sb_append(&buf, "{\"type\":\"sub_agent_start\",\"session_id\":");
+            sb_append_json_string(&buf, msg->session_id ? msg->session_id : "");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_SUB_AGENT_RESULT:
+            sb_append(&buf, "{\"type\":\"sub_agent_result\",\"session_id\":");
+            sb_append_json_string(&buf, msg->session_id ? msg->session_id : "");
+            sb_append(&buf, ",\"status\":");
+            sb_append_json_string(&buf, msg->tool_exit_code == 0 ? "ok" : "failed");
+            sb_appendf(&buf, ",\"input_tokens\":%d,\"output_tokens\":%d",
+                       msg->in_tokens, msg->out_tokens);
+            sb_append(&buf, ",\"thinking\":");
+            sb_append_json_string(&buf, msg->tool_name ? msg->tool_name : "");
+            sb_append(&buf, ",\"text\":");
+            sb_append_json_string(&buf, msg->content ? msg->content : "");
+            sb_append_char(&buf, '}');
+            break;
+        case DISPLAY_CONTEXT_UPDATE:
+            sb_append(&buf, "{\"type\":\"context_update\",\"kind\":\"compact\",\"trigger\":");
             sb_append_json_string(&buf, msg->tool_name ? msg->tool_name : "auto");
+            sb_append_char(&buf, '}');
+            break;
         }
-        if (msg->type == DISPLAY_TOOL_CALL) {
-            if (msg->tool_name) {
-                sb_append(&buf, ",\"name\":");
-                sb_append_json_string(&buf, msg->tool_name);
-            }
-            if (msg->tool_id) {
-                sb_append(&buf, ",\"id\":");
-                sb_append_json_string(&buf, msg->tool_id);
-            }
-            if (msg->tool_input) {
-                sb_append(&buf, ",\"input\":");
-                sb_append_json_string(&buf, msg->tool_input);
-            }
-        }
-        if (msg->type == DISPLAY_TOOL_RESULT && msg->content) {
-            sb_append(&buf, ",\"content\":");
-            sb_append_json_string(&buf, msg->content);
-        }
-        if (msg->type == DISPLAY_STOP && msg->content) {
-            sb_append(&buf, ",\"reason\":");
-            sb_append_json_string(&buf, msg->content);
-        }
-        sb_append_char(&buf, '}');
         fprintf(out, "%s\n", buf.data);
         fflush(out);
         sb_free(&buf);

--- a/c/store.c
+++ b/c/store.c
@@ -560,7 +560,21 @@ int store_stats_update(const char *path, stats_update_fn fn, void *ctx) {
  * events.jsonl 操作
  * ============================================================ */
 
+static _Thread_local int g_store_event_stream_json = 0;
+
+void store_event_set_stream_json(int enabled) {
+    g_store_event_stream_json = enabled ? 1 : 0;
+}
+
+int store_event_stream_json_enabled(void) {
+    return g_store_event_stream_json;
+}
+
 int store_event_append(const SessionPaths *p, const char *json_str) {
+    if (g_store_event_stream_json) {
+        printf("%s\n", json_str);
+        fflush(stdout);
+    }
     return jsonl_append(p->events, json_str);
 }
 

--- a/c/store.h
+++ b/c/store.h
@@ -97,6 +97,9 @@ void store_stats_set_int(JsonVal obj, const char *key, int value);
 int store_stats_get_file_int(const char *path, const char *key);
 void store_stats_set_int_file(const char *path, const char *key, int value);
 
+void store_event_set_stream_json(int enabled);
+int store_event_stream_json_enabled(void);
+
 /* 从 stats 中读取整数值 */
 int store_stats_get_int(JsonVal obj, const char *key);
 

--- a/c/tools.c
+++ b/c/tools.c
@@ -592,11 +592,13 @@ static ToolResult tool_plan_confirm(const SessionPaths *paths) {
     ToolResult r = {NULL, 0};
     /* 只检查 draft 是否存在，不做 mv — mv 由 agent_loop 在 compact 之后执行
      * 对齐 bash 版: agent_compact_context(plan_confirm) → store_plan_confirm(mv) */
-    if (paths && store_plan_draft_read(paths) && store_plan_draft_read(paths)[0]) {
+    char *draft = paths ? store_plan_draft_read(paths) : NULL;
+    if (draft && draft[0]) {
         r.output = util_strdup("Plan confirmed.");
     } else {
         r.output = util_strdup("No plan draft to confirm.");
     }
+    free(draft);
     return r;
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -688,11 +688,15 @@ awk 端使用 `emit1()`/`emit()`/`emit_flush()` 三个函数构建消息；bash 
 当前事件类型：
 
 - `session_start`
+- `user_input`
 - `text`
 - `thinking`
 - `tool_call`
 - `tool_result`
 - `usage`
+- `sub_agent_start`
+- `sub_agent_result`
+- `sub_agent_end`
 - `stop`
 - `error`
 - `context_update`
@@ -701,7 +705,10 @@ awk 端使用 `emit1()`/`emit()`/`emit_flush()` 三个函数构建消息；bash 
 
 - 每行一个 JSON 事件
 - 不混入 human 文本
-- 不把 session 内部事件直接混入 stdout
+- bash 版本由 `store_event_append` 统一写入 `events.jsonl`
+- `output-format=stream-json` 时，`store_event_append` 使用同一行 JSON tee 到 stdout
+- display 层只负责人类可读渲染，不再单独序列化 stream-json
+- bash 通过 RESP pipe 连接 agent loop 和 display；C/Go/Rust 使用结构化 display event 队列传递同一层语义
 
 `usage` 当前字段：
 

--- a/docs/refactor-7class.md
+++ b/docs/refactor-7class.md
@@ -89,8 +89,14 @@ agent_loop_stream
              │   ├─ display_human_text
              │   ├─ display_ensure_newline
              │   └─ display_sub_agent_result
-             └─ 或 stream-json (util_msg_to_stream → stdout)
+             └─ stream-json 不走 display_message；由 store_event_append tee 到 stdout
 ```
+
+Go/C/Rust 版本保留同一层级边界，但不强行复制 bash 的 RESP 编码：
+
+- C: `DisplayMessage` 经 `display_queue` 进入 display thread。
+- Go: `Event` 经 `displayCh` 进入 display goroutine。
+- Rust: `DisplayEvent` 经 `mpsc` display channel 进入 display consumer。
 
 ```text
 回放面: replay

--- a/go/agent.go
+++ b/go/agent.go
@@ -25,6 +25,8 @@ type Agent struct {
 	llm              Transport
 	tools            *ToolDispatcher
 	display          *TermDisplay
+	displayCh        chan Event
+	displayWG        sync.WaitGroup
 	toolDefs         string // JSON 格式工具定义
 	ctxTokens        int    // 当前上下文 token 数
 	pendingSubAgents int    // 等待中的子 agent 数量
@@ -53,12 +55,38 @@ func NewAgent(cfg Config, store SessionStore, llm Transport, tools *ToolDispatch
 		display:     display,
 		subResultCh: make(chan SubAgentResult, 8),
 	}
+	if cfg.OutputFormat != "stream-json" {
+		a.displayCh = make(chan Event, 128)
+		a.displayWG.Add(1)
+		go func() {
+			defer a.displayWG.Done()
+			for ev := range a.displayCh {
+				a.display.ShowEvent(ev)
+			}
+		}()
+	}
 	// 设置回调
 	a.tools.SetSubAgentLauncher(a.LaunchSubAgent)
 	a.tools.SetPlanConfirm(a.HandlePlanConfirm)
 	a.tools.SetPlanClear(a.HandlePlanClear)
 	a.tools.SetSkillLoader(a.LoadSkill)
 	return a
+}
+
+func (a *Agent) EmitDisplay(ev Event) {
+	if a.displayCh == nil {
+		return
+	}
+	a.displayCh <- ev
+}
+
+func (a *Agent) CloseDisplay() {
+	if a.displayCh == nil {
+		return
+	}
+	close(a.displayCh)
+	a.displayWG.Wait()
+	a.displayCh = nil
 }
 
 // SetToolDefs 设置工具定义 JSON
@@ -418,8 +446,7 @@ func (a *Agent) CompactContext(ctx context.Context, trigger string) (bool, error
 			"cache_creation_input_tokens": summaryUsage.CacheWrite,
 			"kind":                        "compact",
 		}
-		evJSON, _ := json.Marshal(ev)
-		_ = a.store.AppendEvent(string(evJSON))
+		a.emitJSON(ev)
 		_ = a.store.UpdateCompactStats(summaryUsage)
 	}
 
@@ -486,9 +513,7 @@ func (a *Agent) emitJSON(obj map[string]interface{}) {
 func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 	// 记录 user_input 事件（提前到 AddUserMessage 之前，与 bash 版一致）
 	if turnKind == "user_input" {
-		ev := map[string]interface{}{"type": "user_input", "content": userInput}
-		evJSON, _ := json.Marshal(ev)
-		_ = a.store.AppendEvent(string(evJSON))
+		a.emitJSON(map[string]interface{}{"type": "user_input", "content": userInput})
 	}
 
 	// 添加用户消息
@@ -514,7 +539,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 	for turn := 0; turn < a.cfg.MaxTurns; turn++ {
 		// Compact
 		if compacted, _ := a.CompactContext(ctx, "auto"); compacted {
-			a.display.ShowEvent(Event{Type: EventContextUpdate, Fields: []string{"CONTEXT_UPDATE", "compact", "auto"}})
+			a.EmitDisplay(Event{Type: EventContextUpdate, Fields: []string{"CONTEXT_UPDATE", "compact", "auto"}})
 		}
 
 		// 获取 messages
@@ -527,7 +552,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		// LLM 调用
 		ch, err := a.llm.Call(ctx, messages, systemPrompt, a.toolDefs, a.cfg.MaxTokens, a.cfg.Thinking)
 		if err != nil {
-			a.display.ShowEvent(Event{Type: EventError, Fields: []string{"ERROR", err.Error()}})
+			a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", err.Error()}})
 			return err
 		}
 
@@ -546,13 +571,13 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 
 			switch ev.Type {
 			case EventText:
-				a.display.ShowEvent(ev)
+				a.EmitDisplay(ev)
 				if len(ev.Fields) > 1 {
 					text += ev.Fields[1]
 					a.emitJSON(map[string]interface{}{"type": "text", "content": ev.Fields[1]})
 				}
 			case EventThinking:
-				a.display.ShowEvent(ev)
+				a.EmitDisplay(ev)
 				if len(ev.Fields) > 1 {
 					thinking += ev.Fields[1]
 					a.emitJSON(map[string]interface{}{"type": "thinking", "content": ev.Fields[1]})
@@ -569,7 +594,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 					// 生成 CallSummary 并显示（替代 transport 的原始事件）
 					params := ExtractToolParams(tc.Name, json.RawMessage(tc.Input))
 					callSummary := a.tools.CallSummary(tc.Name, params)
-					a.display.ShowEvent(Event{Type: EventToolCall, Fields: []string{"TOOL_CALL", tc.Name, tc.ID, tc.Input, callSummary}})
+					a.EmitDisplay(Event{Type: EventToolCall, Fields: []string{"TOOL_CALL", tc.Name, tc.ID, tc.Input, callSummary}})
 
 					// 执行工具
 					output, toolErr := a.tools.Dispatch(ctx, tc.Name, params)
@@ -589,7 +614,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 					}
 
 					// 显示结果
-					a.display.ShowEvent(Event{Type: EventToolResult, Fields: []string{"TOOL_RESULT", tc.ID, tc.Name, output}})
+					a.EmitDisplay(Event{Type: EventToolResult, Fields: []string{"TOOL_RESULT", tc.ID, tc.Name, output}})
 
 					// stream-json + events.jsonl: 分别写 tool_call 和 tool_result（与 bash 版一致）
 					a.emitJSON(map[string]interface{}{
@@ -620,13 +645,13 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 					})
 				}
 			case EventStop:
-				a.display.ShowEvent(ev)
+				a.EmitDisplay(ev)
 				if len(ev.Fields) > 1 {
 					stopReason = ev.Fields[1]
 				}
 				a.emitJSON(map[string]interface{}{"type": "stop", "reason": stopReason})
 			case EventError:
-				a.display.ShowEvent(ev)
+				a.EmitDisplay(ev)
 				if len(ev.Fields) > 1 {
 					loopErr = ev.Fields[1]
 				}
@@ -635,7 +660,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 				// 与 bash 版对齐：ERROR 立即 break 出事件循环
 				break
 			default:
-				a.display.ShowEvent(ev)
+				a.EmitDisplay(ev)
 			}
 		}
 
@@ -647,8 +672,8 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		a.display.SetTitle(a.store.FormatTitle(a.cfg.Model))
 
 		if interrupted {
-			a.display.ShowEvent(Event{Type: EventStop, Fields: []string{"STOP", "interrupted"}})
-			_ = a.store.AppendEvent(`{"type":"stop","reason":"interrupted"}`)
+			a.EmitDisplay(Event{Type: EventStop, Fields: []string{"STOP", "interrupted"}})
+			a.emitJSON(map[string]interface{}{"type": "stop", "reason": "interrupted"})
 			return nil
 		}
 
@@ -656,7 +681,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		switch stopReason {
 		case "error", "max_tokens", "length":
 			if stopReason != "error" {
-				a.display.ShowEvent(Event{Type: EventError, Fields: []string{"ERROR", "Response truncated (max_tokens reached)"}})
+				a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", "Response truncated (max_tokens reached)"}})
 			}
 			if loopErr != "" {
 				return fmt.Errorf("LLM error: %s", loopErr)
@@ -710,8 +735,7 @@ func (a *Agent) LaunchSubAgent(ctx context.Context, prompt, description, fork st
 		"description": description,
 		"fork":        fork == "true",
 	}
-	startJSON, _ := json.Marshal(startEvent)
-	_ = a.store.AppendEvent(string(startJSON))
+	a.emitJSON(startEvent)
 
 	// 增加计数
 	a.subMu.Lock()
@@ -819,8 +843,7 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 		"kind":                        "sub_agent",
 		"sub_session_id":              r.SessionID,
 	}
-	usageJSON, _ := json.Marshal(usageEvent)
-	_ = a.store.AppendEvent(string(usageJSON))
+	a.emitJSON(usageEvent)
 
 	// 记录 sub_agent_result 事件（供 replay 和 stream-json 复现）
 	resultEvent := map[string]interface{}{
@@ -832,8 +855,7 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 		"thinking":      r.Thinking,
 		"text":          r.Text,
 	}
-	resultJSON, _ := json.Marshal(resultEvent)
-	_ = a.store.AppendEvent(string(resultJSON))
+	a.emitJSON(resultEvent)
 
 	// 记录 sub_agent_end 事件
 	endEvent := map[string]interface{}{
@@ -842,11 +864,10 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 		"timestamp":  time.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		"status":     r.Status,
 	}
-	endJSON, _ := json.Marshal(endEvent)
-	_ = a.store.AppendEvent(string(endJSON))
+	a.emitJSON(endEvent)
 
 	// 显示结果（统一走 Display 接口）
-	a.display.ShowEvent(Event{
+	a.EmitDisplay(Event{
 		Type: EventSubAgentResult,
 		Fields: []string{
 			"SUB_AGENT_RESULT",
@@ -869,14 +890,4 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 	// 注入为用户消息（不记录 user_input 事件，与 bash 版 agent_loop turn_kind=sub_agent_result 一致）
 	_ = a.store.AddUserMessage(injectMsg)
 
-	// stream-json 输出（含 thinking/text，与 bash 版一致）
-	a.emitJSON(map[string]interface{}{
-		"type":          "sub_agent_result",
-		"session_id":    r.SessionID,
-		"status":        r.Status,
-		"input_tokens":  r.InputTokens,
-		"output_tokens": r.OutputTokens,
-		"thinking":      r.Thinking,
-		"text":          r.Text,
-	})
 }

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -185,6 +185,7 @@ Examples:
 
 	// 创建 agent
 	a := agent.NewAgent(cfg, store, llm, tools, display)
+	defer a.CloseDisplay()
 
 	// 加载工具定义（编译时嵌入的 tools.json）
 	a.SetToolDefs(agent.UtilLoadToolDefs())

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -895,6 +895,7 @@ impl Agent {
                 last_char: String::from("\n"),
                 prev_was_thinking: false,
             };
+            let (display_tx, display_rx) = mpsc::channel::<DisplayEvent>();
 
             while turn < self.cfg.max_turns {
                 turn += 1;
@@ -959,15 +960,15 @@ impl Agent {
                     }
                     match evt {
                         Event::Thinking(ThinkingEvent { content }) => {
-                            self.display_event(&mut ds, DisplayEvent::Thinking(content.clone()))?;
+                            self.queue_display_event(&display_tx, &display_rx, &mut ds, DisplayEvent::Thinking(content.clone()))?;
                             thinking.push_str(&content);
                         }
                         Event::Text(TextEvent { content }) => {
-                            self.display_event(&mut ds, DisplayEvent::Text(content.clone()))?;
+                            self.queue_display_event(&display_tx, &display_rx, &mut ds, DisplayEvent::Text(content.clone()))?;
                             text.push_str(&content);
                         }
                         Event::ToolCall(call) => {
-                            self.display_event(&mut ds, DisplayEvent::ToolCall(call.clone()))?;
+                            self.queue_display_event(&display_tx, &display_rx, &mut ds, DisplayEvent::ToolCall(call.clone()))?;
                             calls.push(call.clone());
 
                             if self.is_interrupted() {
@@ -1038,24 +1039,21 @@ impl Agent {
                                 content: output.clone(),
                                 conv_content,
                             };
-                            self.display_event(
-                                &mut ds,
-                                DisplayEvent::ToolResult(tool_result.clone()),
-                            )?;
+                            self.queue_display_event(&display_tx, &display_rx, &mut ds, DisplayEvent::ToolResult(tool_result.clone()))?;
                             tool_results.push(tool_result);
                         }
                         Event::Usage(usage) => {
-                            self.display_event(&mut ds, DisplayEvent::Usage(usage))?;
+                            self.queue_display_event(&display_tx, &display_rx, &mut ds, DisplayEvent::Usage(usage))?;
                         }
                         Event::Stop(StopEvent { reason }) => {
                             stop = reason.clone();
-                            self.display_event(&mut ds, DisplayEvent::Stop(reason))?;
+                            self.queue_display_event(&display_tx, &display_rx, &mut ds, DisplayEvent::Stop(reason))?;
                             break;
                         }
                         Event::Error(ErrorEvent { message }) => {
                             loop_error = message.clone();
                             stop = "error".to_string();
-                            let _ = self.display_event(&mut ds, DisplayEvent::Error(message));
+                            let _ = self.queue_display_event(&display_tx, &display_rx, &mut ds, DisplayEvent::Error(message));
                             break;
                         }
                         Event::Retry(RetryEvent {}) => {
@@ -1137,13 +1135,22 @@ impl Agent {
         .build_system_prompt()
     }
 
-    /// emit_and_append_event writes an event to events.jsonl (always) and to
-    /// stdout (only in stream-json mode). Mirrors Go's emitAndAppendEvent and
-    /// bash's session_append_line + (stream-json || human display) pattern.
+    /// append_event writes an event to events.jsonl and, in stream-json mode,
+    /// tees the same JSON line to stdout.
     fn emit_and_append_event(&self, value: Value) -> Result<()> {
-        self.append_event(value.clone())?;
-        if self.is_stream_json_mode() {
-            self.emit_stream(value)?;
+        self.append_event(value)
+    }
+
+    fn queue_display_event(
+        &mut self,
+        tx: &mpsc::Sender<DisplayEvent>,
+        rx: &mpsc::Receiver<DisplayEvent>,
+        ds: &mut DisplayState,
+        evt: DisplayEvent,
+    ) -> Result<()> {
+        tx.send(evt).map_err(|e| anyhow!(e.to_string()))?;
+        while let Ok(queued) = rx.try_recv() {
+            self.display_event(ds, queued)?;
         }
         Ok(())
     }
@@ -1560,7 +1567,11 @@ impl Agent {
         if self.paths.events.as_os_str().is_empty() {
             return Ok(());
         }
-        store::store_event_append_json(&self.paths, &value)
+        store::store_event_append_json(&self.paths, &value)?;
+        if self.is_stream_json_mode() {
+            self.emit_stream(value)?;
+        }
+        Ok(())
     }
 
     /// increment_turn_count increments the current_turn_count in stats.json.
@@ -1673,10 +1684,8 @@ impl Agent {
     /// Emit a context_update event: write to events.jsonl + emit to stream-json or print info.
     fn emit_context_update(&self, trigger: &str) -> Result<()> {
         let evt = json!({"type":"context_update","kind":"compact","trigger":trigger});
-        self.append_event(evt.clone())?;
-        if self.is_stream_json_mode() {
-            self.emit_stream(evt)?;
-        } else {
+        self.append_event(evt)?;
+        if !self.is_stream_json_mode() {
             self.info(&format!("Context compacted ({}).", trigger));
         }
         Ok(())

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -404,7 +404,7 @@ store_session_resolve_continue() {
 # 处理子 agent 通过 FIFO 发回的 AGENT_RESULT 将 result_text 注入主 agent conversation，触发 agent_loop 让主 agent 处理
 store_event_append() {
     [[ -n "${SESSION_EVENT_FILE:-}" ]] || return 0
-    printf '%s\n' "$1" >> "$SESSION_EVENT_FILE"
+    if util_is_stream_json; then printf '%s\n' "$1" | tee -a "$SESSION_EVENT_FILE"; else printf '%s\n' "$1" >> "$SESSION_EVENT_FILE"; fi
 }
 
 store_conv_add_user() {
@@ -935,15 +935,12 @@ display_sub_agent_result() {
     DISPLAY_LAST_CHAR=$'\n'
 }
 
-# Convert REPLY_MESSAGE to a stream event JSON string (for events.jsonl and stream-json output). Prints JSON to stdout; returns 1 if type has no event representation.
-# Render a single RESP message from REPLY_MESSAGE (human-readable or stream-json).
-# JSON event construction is still handled by util_msg_to_stream().
+# Convert REPLY_MESSAGE to a stream event JSON string. Prints JSON to stdout;
+# returns 1 if type has no event representation.
+# Render a single RESP message from REPLY_MESSAGE in human-readable mode.
+# stream-json output is emitted by store_event_append teeing the event line.
 display_message() {
     local _type="${REPLY_MESSAGE[0]}" _tc_kv=() i _n _tc_summary="" _tr_name _tr_text="" _um_text
-    if util_is_stream_json; then
-        printf '%s\n' "$(util_msg_to_stream)"
-        return
-    fi
     case "$_type" in
         TEXT)
             if [[ "$INTERACTIVE" == true && "$DISPLAY_LAST_CHAR" == $'\n' ]]; then
@@ -1146,7 +1143,7 @@ agent_handle_sub_result() {
     active_sub_count=$(( active_sub_count - 1 ))
     [[ "$silent" == true ]] && return 0
     # 展示结果摘要——通过 fd 7 交给 display_stream，不直接写 stdout（避免和子进程争终端）
-    ( util_write_msg "SUB_AGENT_RESULT" "$session_id" "$status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
+    util_is_stream_json || ( util_write_msg "SUB_AGENT_RESULT" "$session_id" "$status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
     agent_run_loop "[sub-agent $session_id] $status (in=$_in, out=$_out)"$'\n'"Thinking: $_thinking"$'\n'"Text: $_text" sub_agent_result
 }
 
@@ -1290,7 +1287,7 @@ agent_loop() {
         _reason="${REPLY_MESSAGE[1]-}"
         [[ "$_type" == "TOOL_CALL" && "$_reason" == "SubAgent" ]] && active_sub_count=$(( active_sub_count + 1 ))
         _se=$(util_msg_to_stream) && [[ -n "$_se" ]] && store_event_append "$_se"
-        ( util_write_msg "${REPLY_MESSAGE[@]}" ) >&4 2>/dev/null || true
+        util_is_stream_json || ( util_write_msg "${REPLY_MESSAGE[@]}" ) >&4 2>/dev/null || true
         if [[ "$_type" == "ERROR" ]]; then
             had_error=true
             break


### PR DESCRIPTION
  ## Summary
  - Fix C agent stats/cache accounting, title formatting, and replay tool display alignment.
  - Move stream-json output to the event write path so the same JSON line is written to `events.jsonl` and
  stdout.
  - Align display layering across bash/C/Go/Rust:
    - bash uses RESP pipe to display
    - C uses `display_queue`
    - Go now uses `displayCh`
    - Rust now uses an `mpsc` display event channel
  - Update architecture docs for the event/write/display boundary.

  ## Validation
  - bash e2e: 118 passed
  - cagent e2e: 118 passed
  - goagent e2e: 118 passed
  - rustagent e2e: 118 passed
  - `go test ./...`
  - `cargo test`
  - `make -C c`
  - `bash -n src/agent.sh`
  - `git diff --check`