### PR TITLE
Reduce replay memory usage and harden runtime parity

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -1523,12 +1523,22 @@ static void prompt_append_attr_escaped(StrBuf *buf, const char *src) {
 static void prompt_append_section(StrBuf *buf, const char *tag,
                                    const char *content, const char *name) {
     if (!content || !content[0]) return;
+    size_t content_len = strlen(content);
+    while (content_len > 0 &&
+           (content[content_len - 1] == '\n' || content[content_len - 1] == '\r')) {
+        content_len--;
+    }
+    if (content_len == 0) return;
     if (name && name[0]) {
         sb_appendf(buf, "<%s name=\"", tag);
         prompt_append_attr_escaped(buf, name);
-        sb_appendf(buf, "\">\n%s\n</%s>\n", content, tag);
+        sb_append(buf, "\">\n");
+        sb_appendn(buf, content, content_len);
+        sb_appendf(buf, "\n</%s>\n", tag);
     } else {
-        sb_appendf(buf, "<%s>\n%s\n</%s>\n", tag, content, tag);
+        sb_appendf(buf, "<%s>\n", tag);
+        sb_appendn(buf, content, content_len);
+        sb_appendf(buf, "\n</%s>\n", tag);
     }
 }
 

--- a/c/agent.c
+++ b/c/agent.c
@@ -433,38 +433,50 @@ static void push_display_event(const SessionPaths *paths, MsgQueue *dq, DisplayM
  * 核心逻辑：累积 per-token 的 text/thinking 事件为完整块，然后推送 DisplayMessage。
  * ============================================================ */
 
-/* 最近 N 轮事件的起始行号 */
-static int find_recent_turn_start(const SessionPaths *paths, int max_turns) {
-    char **lines = NULL;
-    int count = 0;
-    if (store_event_lines(paths, &lines, &count) != 0 || count == 0) return -1;
+/* 最近 N 轮事件的起始文件偏移。只记录 user_input 偏移，避免启动 replay 全量读 events.jsonl。 */
+static long find_recent_turn_start_offset(const SessionPaths *paths, int max_turns) {
+    FILE *f = fopen(paths->events, "r");
+    if (!f) return -1;
 
-    int user_input_count = 0;
-    int start_line = -1;
-    for (int i = count - 1; i >= 0; i--) {
-        if (strstr(lines[i], "\"type\":\"user_input\"")) {
-            user_input_count++;
-            start_line = i;
-            if (user_input_count >= max_turns) break;
+    if (max_turns <= 0) max_turns = 10;
+    long *offsets = calloc((size_t)max_turns, sizeof(long));
+    if (!offsets) {
+        fclose(f);
+        return -1;
+    }
+
+    char *line = NULL;
+    size_t cap = 0;
+    int seen = 0;
+    for (;;) {
+        long pos = ftell(f);
+        ssize_t n = getline(&line, &cap, f);
+        if (n < 0) break;
+        if (strstr(line, "\"type\":\"user_input\"")) {
+            offsets[seen % max_turns] = pos;
+            seen++;
         }
     }
 
-    /* 释放 */
-    for (int i = 0; i < count; i++) free(lines[i]);
-    free(lines);
+    long start = 0;
+    if (seen > 0) {
+        start = (seen >= max_turns) ? offsets[seen % max_turns] : offsets[0];
+    }
 
-    return start_line;
+    free(line);
+    free(offsets);
+    fclose(f);
+    return start;
 }
 
 void agent_replay_events(Agent *agent, int max_turns) {
-    char **lines = NULL;
-    int count = 0;
-    if (store_event_lines(&agent->paths, &lines, &count) != 0 || count == 0) return;
+    long start = find_recent_turn_start_offset(&agent->paths, max_turns);
+    if (start < 0) return;
 
-    int start = find_recent_turn_start(&agent->paths, max_turns);
-    if (start < 0) {
-        for (int i = 0; i < count; i++) free(lines[i]);
-        free(lines);
+    FILE *f = fopen(agent->paths.events, "r");
+    if (!f) return;
+    if (fseek(f, start, SEEK_SET) != 0) {
+        fclose(f);
         return;
     }
 
@@ -473,8 +485,15 @@ void agent_replay_events(Agent *agent, int max_turns) {
     sb_init(&acc_text);
     sb_init(&acc_thinking);
 
-    for (int i = start; i < count; i++) {
-        const char *line = lines[i];
+    char *line = NULL;
+    size_t line_cap = 0;
+    while (getline(&line, &line_cap, f) >= 0) {
+        size_t line_len = strlen(line);
+        while (line_len > 0 && (line[line_len - 1] == '\n' || line[line_len - 1] == '\r')) {
+            line[--line_len] = '\0';
+        }
+        if (line_len == 0) continue;
+
         JsonParse jp = json_parse_root(line);
         if (jp.error) {  continue; }
 
@@ -671,8 +690,8 @@ void agent_replay_events(Agent *agent, int max_turns) {
 
     sb_free(&acc_text);
     sb_free(&acc_thinking);
-    for (int i = 0; i < count; i++) free(lines[i]);
-    free(lines);
+    free(line);
+    fclose(f);
 }
 
 /* ============================================================

--- a/go/agent.go
+++ b/go/agent.go
@@ -129,6 +129,7 @@ func (a *Agent) BuildPrompt() string {
 
 	var sections []string
 	appendSection := func(tag, content string, name string) {
+		content = strings.TrimRight(content, "\r\n")
 		if content == "" {
 			return
 		}
@@ -351,7 +352,8 @@ func (a *Agent) loadSkillContent(name string) (string, error) {
 			continue
 		}
 		skillDir := base + "/" + name
-		content := strings.ReplaceAll(string(data), "${BASH_AGENT_SKILL_DIR}", skillDir)
+		content := strings.TrimRight(string(data), "\r\n")
+		content = strings.ReplaceAll(content, "${BASH_AGENT_SKILL_DIR}", skillDir)
 		return "Base directory: " + skillDir + "\n\n" + content, nil
 	}
 	return "", fmt.Errorf("skill not found: %s", name)
@@ -375,7 +377,7 @@ func findInstructionFile(dir string) string {
 
 // buildInstructionsSection 查找全局和项目级 instruction 文件
 func (a *Agent) buildInstructionsSection() string {
-	var sections []string
+	var sections strings.Builder
 	home := os.Getenv("HOME")
 
 	// 全局: ~/.bash-agent/AGENTS.md 等
@@ -383,7 +385,7 @@ func (a *Agent) buildInstructionsSection() string {
 		if f := findInstructionFile(home + "/.bash-agent"); f != "" {
 			data, err := os.ReadFile(f)
 			if err == nil {
-				sections = append(sections, "<instruction-file name=\"global\">\n"+string(data)+"\n</instruction-file>")
+				UtilAppendSection(&sections, "instruction-file", string(data), "global")
 			}
 		}
 	}
@@ -392,11 +394,11 @@ func (a *Agent) buildInstructionsSection() string {
 	if f := findInstructionFile(mustGetwd()); f != "" {
 		data, err := os.ReadFile(f)
 		if err == nil {
-			sections = append(sections, "<instruction-file name=\"project\">\n"+string(data)+"\n</instruction-file>")
+			UtilAppendSection(&sections, "instruction-file", string(data), "project")
 		}
 	}
 
-	return strings.Join(sections, "\n")
+	return sections.String()
 }
 
 // ─── agent_compact_context: 上下文压缩 ───

--- a/go/agent.go
+++ b/go/agent.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -543,17 +544,22 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 	_ = a.store.IncrementTurn()
 
 	// 中断处理：用 context.WithCancel 包装，Ctrl+C 同时取消 context（取消 HTTP 请求）
-	interrupted := false
+	var interrupted atomic.Bool
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	sigCh := make(chan os.Signal, 1)
+	sigDone := make(chan struct{})
 	signal.Notify(sigCh, syscall.SIGINT)
 	defer signal.Stop(sigCh)
+	defer close(sigDone)
 
 	go func() {
-		<-sigCh
-		interrupted = true
-		cancel()
+		select {
+		case <-sigCh:
+			interrupted.Store(true)
+			cancel()
+		case <-sigDone:
+		}
 	}()
 
 	for turn := 0; turn < a.cfg.MaxTurns; turn++ {
@@ -584,7 +590,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		var loopErr string
 
 		for ev := range ch {
-			if interrupted {
+			if interrupted.Load() {
 				stopReason = "interrupted"
 				break
 			}
@@ -691,7 +697,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		// 更新终端标题（与 bash 版 store_stats_update 后调 display_term_title 一致）
 		a.display.SetTitle(a.store.FormatTitle(a.cfg.Model))
 
-		if interrupted {
+		if interrupted.Load() {
 			a.EmitDisplay(Event{Type: EventStop, Fields: []string{"STOP", "interrupted"}})
 			a.emitJSON(map[string]interface{}{"type": "stop", "reason": "interrupted"})
 			return nil

--- a/go/agent_test.go
+++ b/go/agent_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -516,6 +518,31 @@ func TestSSEParser(t *testing.T) {
 	bt, tn, tid = tr.handleBlockStart(`{"type":"content_block_start","content_block":{"type":"tool_use","name":"Read","id":"toolu_123"}}`)
 	if bt != "tool" || tn != "Read" || tid != "toolu_123" {
 		t.Errorf("handleBlockStart tool: bt=%q tn=%q tid=%q", bt, tn, tid)
+	}
+}
+
+func TestSSEParserInterruptedStreamClosesAfterFallbackEvents(t *testing.T) {
+	cfg := DefaultConfig()
+	tr := NewHTTPTransport(cfg)
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader("")),
+	}
+	ch := make(chan Event, 2)
+
+	tr.parseSSEStream(resp, ch)
+
+	var events []Event
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+	if events[0].Type != EventError {
+		t.Fatalf("first event = %v, want EventError", events[0].Type)
+	}
+	if events[1].Type != EventStop || len(events[1].Fields) < 2 || events[1].Fields[1] != "error" {
+		t.Fatalf("second event = %#v, want STOP error", events[1])
 	}
 }
 

--- a/go/store.go
+++ b/go/store.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -272,35 +274,64 @@ func (s *FileStore) GetRecentEvents(maxUserTurns int) []string {
 	if file == "" {
 		return nil
 	}
-
-	data, err := os.ReadFile(file)
-	if err != nil || len(data) == 0 {
-		return nil
+	if maxUserTurns <= 0 {
+		maxUserTurns = 10
 	}
 
-	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	f, err := os.Open(file)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
 
-	// 找所有包含 "type":"user_input" 的行号
-	var userInputLines []int
-	for i, line := range lines {
-		if strings.Contains(line, `"type":"user_input"`) || strings.Contains(line, `"type":"user_input"`) {
-			userInputLines = append(userInputLines, i)
+	offsets := make([]int64, maxUserTurns)
+	reader := bufio.NewReader(f)
+	var pos int64
+	seen := 0
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			if strings.Contains(line, `"type":"user_input"`) {
+				offsets[seen%maxUserTurns] = pos
+				seen++
+			}
+			pos += int64(len(line))
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil
 		}
 	}
-
-	// 没有用户输入事件 → 不 replay
-	if len(userInputLines) == 0 {
+	if seen == 0 {
 		return nil
 	}
 
-	// 取最后 maxUserTurns 个 user_input 的第一个
-	start := len(userInputLines) - maxUserTurns
-	if start < 0 {
-		start = 0
+	startOffset := offsets[0]
+	if seen >= maxUserTurns {
+		startOffset = offsets[seen%maxUserTurns]
 	}
-	fromLine := userInputLines[start]
+	if _, err := f.Seek(startOffset, io.SeekStart); err != nil {
+		return nil
+	}
 
-	return lines[fromLine:]
+	reader = bufio.NewReader(f)
+	var lines []string
+	for {
+		line, err := reader.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+		if line != "" {
+			lines = append(lines, line)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil
+		}
+	}
+	return lines
 }
 
 // ─── Conversation ───

--- a/go/transport.go
+++ b/go/transport.go
@@ -133,6 +133,7 @@ func NewHTTPTransport(cfg Config) *HTTPTransport {
 func (t *HTTPTransport) parseSSEStream(resp *http.Response, ch chan<- Event) {
 	var stopEmitted bool
 	defer resp.Body.Close()
+	defer close(ch)
 	defer func() {
 		if !stopEmitted {
 			// No message_stop received — stream was interrupted (connection reset,
@@ -141,7 +142,6 @@ func (t *HTTPTransport) parseSSEStream(resp *http.Response, ch chan<- Event) {
 			ch <- Event{Type: EventStop, Fields: []string{"STOP", "error"}}
 		}
 	}()
-	defer close(ch)
 
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)

--- a/go/util.go
+++ b/go/util.go
@@ -125,6 +125,7 @@ func UtilIsStreamJSON(format string) bool {
 
 // UtilAppendSection 构建标签包裹的段落（对应 bash 的 util_append_section）
 func UtilAppendSection(out *strings.Builder, tag, content, name string) {
+	content = strings.TrimRight(content, "\r\n")
 	if content == "" {
 		return
 	}
@@ -196,7 +197,7 @@ func UtilReadOptional(path string) (string, error) {
 	if err != nil || len(data) == 0 {
 		return "", nil
 	}
-	return string(data), nil
+	return strings.TrimRight(string(data), "\r\n"), nil
 }
 
 // UtilFindSkillDirs 查找 skill 目录列表

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -24,7 +24,7 @@ use crate::ffi;
 use serde_json::{Value, json};
 use std::cell::RefCell;
 use std::fs;
-use std::io::{self, IsTerminal, Read, Write};
+use std::io::{self, BufRead, BufReader, IsTerminal, Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::io::IntoRawFd;
 use std::path::PathBuf;
@@ -1868,34 +1868,46 @@ impl Agent {
     }
 
     fn replay_last_turns(&self) {
-        let events = match store::store_event_lines(&self.paths) {
-            Ok(events) => events,
+        let max_turns = 10usize;
+        let mut file = match fs::File::open(&self.paths.events) {
+            Ok(file) => file,
             Err(_) => return,
         };
-        if events.is_empty() {
-            return;
-        }
 
-        // Find boundaries of "turns" — each user_input event starts a turn
-        let mut turn_starts: Vec<usize> = Vec::new();
-        for (i, evt) in events.iter().enumerate() {
-            let t = evt.get("type").and_then(Value::as_str).unwrap_or("");
-            if t == "user_input" || t == "user_message" {
-                turn_starts.push(i);
+        let mut offsets = vec![0u64; max_turns];
+        let mut seen = 0usize;
+        let mut reader = BufReader::new(file);
+        let mut pos = 0u64;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = match reader.read_line(&mut line) {
+                Ok(n) => n,
+                Err(_) => return,
+            };
+            if n == 0 {
+                break;
             }
+            if line.contains("\"type\":\"user_input\"") || line.contains("\"type\":\"user_message\"") {
+                offsets[seen % max_turns] = pos;
+                seen += 1;
+            }
+            pos += n as u64;
         }
-        if turn_starts.is_empty() {
+        if seen == 0 {
             return;
         }
 
-        // Keep last 10 turns (match bash)
-        let keep = turn_starts.len().saturating_sub(10);
-        let start_idx = if keep < turn_starts.len() {
-            turn_starts[keep]
+        let start_offset = if seen >= max_turns {
+            offsets[seen % max_turns]
         } else {
-            0
+            offsets[0]
         };
-        let had_turns = turn_starts.len().saturating_sub(keep) > 0;
+
+        file = reader.into_inner();
+        if file.seek(SeekFrom::Start(start_offset)).is_err() {
+            return;
+        }
 
         let mut ds = DisplayState {
             last_char: "\n".to_string(),
@@ -1904,7 +1916,15 @@ impl Agent {
         let mut acc_text = String::new();
         let mut acc_thinking = String::new();
 
-        for evt in &events[start_idx..] {
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let Ok(line) = line else { continue };
+            if line.trim().is_empty() {
+                continue;
+            }
+            let Ok(evt) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
             let evt_type = evt.get("type").and_then(Value::as_str).unwrap_or("");
             match evt_type {
                 "session_start" | "usage" | "stop" | "retry" => continue,
@@ -2023,10 +2043,8 @@ impl Agent {
             }
         }
         Self::flush_acc(self, &mut acc_thinking, &mut acc_text, &mut ds, "both");
-        if had_turns {
-            self.queue_display_only(DisplayEvent::Text("\n".to_string()));
-            self.flush_display();
-        }
+        self.queue_display_only(DisplayEvent::Text("\n".to_string()));
+        self.flush_display();
     }
 
     /// Flush accumulated text/thinking through display_replay_event.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1182,17 +1182,19 @@ pub mod prompt {
                 self.plan_draft_file.display().to_string()
             };
             let plan_lifecycle_guidance = format!(
-                "- **PLANNING WORKFLOW** — For complex multi-step tasks (3+ steps OR multi-file OR user requests planning)\n\
-                 - **Files**: PLAN_DRAFT_FILE: {} | PLAN_FILE: {}\n\
-                 - **Why draft first?** Writing to PLAN_FILE immediately invalidates the system prompt cache. Use PLAN_DRAFT_FILE for all drafting iterations to avoid this cost.\n\
-                 - **Drafting phase** (PLAN_DRAFT_FILE non-empty → you are drafting):\n\
-                   Every user reply MUST be classified as exactly ONE of:\n\
-                   ① REVISE (any feedback/question/change) → Edit PLAN_DRAFT_FILE → ask confirmation → stay in drafting\n\
-                   ② CONFIRM (explicit ok/go/confirmed) → call PlanConfirm IMMEDIATELY (before any other action) → TodoWrite checklist → execute\n\
-                   ③ CANCEL (explicit cancel/forget it) → Bash `: > PLAN_DRAFT_FILE` → exit to idle\n\
-                   ⚠ On CONFIRM you MUST call PlanConfirm first — no edits, no tool calls before it.\n\
-                 - **Execution phase**: after PlanConfirm → TodoWrite checklist → execute tasks → PlanClear when all done\n\
-                 - **Plan vs Todo**: PLAN_FILE=locked plan (only via PlanConfirm), PLAN_DRAFT_FILE=draft (edit freely), TodoWrite=progress tracker. Do NOT mix.",
+                concat!(
+                    "- **PLANNING WORKFLOW** — For complex multi-step tasks (3+ steps OR multi-file OR user requests planning)\n",
+                    "- **Files**: PLAN_DRAFT_FILE: {} | PLAN_FILE: {}\n",
+                    "- **Why draft first?** Writing to PLAN_FILE immediately invalidates the system prompt cache. Use PLAN_DRAFT_FILE for all drafting iterations to avoid this cost.\n",
+                    "- **Drafting phase** (PLAN_DRAFT_FILE non-empty → you are drafting):\n",
+                    "  Every user reply MUST be classified as exactly ONE of:\n",
+                    "  ① REVISE (any feedback/question/change) → Edit PLAN_DRAFT_FILE → ask confirmation → stay in drafting\n",
+                    "  ② CONFIRM (explicit ok/go/confirmed) → call PlanConfirm IMMEDIATELY (before any other action) → TodoWrite checklist → execute\n",
+                    "  ③ CANCEL (explicit cancel/forget it) → Bash `: > PLAN_DRAFT_FILE` → exit to idle\n",
+                    "  ⚠ On CONFIRM you MUST call PlanConfirm first — no edits, no tool calls before it.\n",
+                    "- **Execution phase**: after PlanConfirm → TodoWrite checklist → execute tasks → PlanClear when all done\n",
+                    "- **Plan vs Todo**: PLAN_FILE=locked plan (only via PlanConfirm), PLAN_DRAFT_FILE=draft (edit freely), TodoWrite=progress tracker. Do NOT mix."
+                ),
                 plan_draft_file_display, plan_file_display
             );
             sections.push(wrap_section(
@@ -1238,14 +1240,14 @@ pub mod prompt {
             if let Some(f) = global_file {
                 out.push(wrap_section(
                     "instruction-file",
-                    &fs::read_to_string(f)?,
+                    &trim_trailing_newlines(fs::read_to_string(f)?),
                     Some("global"),
                 ));
             }
             if let Some(f) = project_file {
                 out.push(wrap_section(
                     "instruction-file",
-                    &fs::read_to_string(f)?,
+                    &trim_trailing_newlines(fs::read_to_string(f)?),
                     Some("project"),
                 ));
             }
@@ -1308,7 +1310,7 @@ pub mod prompt {
                         "skill not found: {skill} (expected .claude/skills/{skill}/SKILL.md or ~/.claude/skills/{skill}/SKILL.md)"
                     ));
                 };
-                let content = fs::read_to_string(&skill_file)?;
+                let content = trim_trailing_newlines(fs::read_to_string(&skill_file)?);
                 let full = format!(
                     "Base directory: {}\n\n{}",
                     skill_file.parent().unwrap_or(Path::new("")).display(),
@@ -1328,6 +1330,7 @@ pub mod prompt {
     }
 
     fn wrap_section(tag: &str, content: &str, name: Option<&str>) -> String {
+        let content = content.trim_end_matches(['\r', '\n']);
         if content.is_empty() {
             return String::new();
         }
@@ -1358,12 +1361,19 @@ pub mod prompt {
         if !path.exists() {
             return Ok(None);
         }
-        let s = fs::read_to_string(path)?;
+        let s = trim_trailing_newlines(fs::read_to_string(path)?);
         if s.trim().is_empty() {
             Ok(None)
         } else {
             Ok(Some(s))
         }
+    }
+
+    fn trim_trailing_newlines(mut s: String) -> String {
+        while s.ends_with('\n') || s.ends_with('\r') {
+            s.pop();
+        }
+        s
     }
 
     fn find_skill_base_dirs(cwd: &Path, home: &Path) -> Vec<PathBuf> {
@@ -1464,8 +1474,6 @@ pub mod traits {
         fn get_messages(&self) -> Result<Vec<Message>>;
         fn append_event(&self, event: &str) -> Result<()>;
     }
-
-
     pub trait Transport: Send + Sync {
         fn convert_body(&self, claude_body: &[u8]) -> Result<Vec<u8>>;
         fn parse_sse(

--- a/tests/fixtures/system_prompt_expected.txt
+++ b/tests/fixtures/system_prompt_expected.txt
@@ -1,0 +1,92 @@
+<agent-identity>
+You are bash-agent, a lightweight coding agent that works in a terminal.
+</agent-identity>
+<environment>
+lang: en_US
+pwd: __PROJECT__
+home: __HOME__
+platform: __PLATFORM__
+shell: __SHELL__
+</environment>
+<rules>
+- Be concise and concrete. No pleasantries, no explanations unless asked. Raw results only.
+- Prefer safe, exact edits.
+- Report failures clearly.
+</rules>
+<using-your-tools>
+- Use Read for a single file. If you need multiple files, call Read multiple times.
+- Read supports optional offset and limit parameters to read specific line ranges (saves tokens for large files). Output includes line numbers.
+- Use Glob and Grep for one pattern at a time.
+- Grep supports a context parameter to show surrounding lines — use it to get enough text for Edit directly from Grep output, avoiding a separate Read.
+- Use multiple tool calls in one response when they are independent.
+- Prefer dedicated tools over Bash when a dedicated tool fits the task.
+- For Edit: copy old_string exactly (including whitespace/indent/newlines). If you already know the location from prior context, use Read with offset/limit. If you need to locate the text first, use Grep with context — its output is often sufficient for Edit without an extra Read.
+- For skills, first check the skill-index section, then use Skill(name) for the matching skill.
+- SubAgent launches a background agent session. Results are injected back into your conversation when complete. Use for parallelizable or independent sub-tasks. See sub-agent-guidance section for context inheritance rules.
+</using-your-tools>
+<sub-agent-guidance>
+- **When to use**: delegating independent sub-tasks that do NOT need your current conversation context — e.g. investigating a separate file, running a focused search, testing a hypothesis in isolation.
+- **When NOT to use**: tasks that depend on your working context, conversation history, or intermediate state. The child agent starts with a blank slate.
+- **Fork mode**: pass `fork=true` to inherit parent session context (conversation history, plan, skills). Use when the child needs your working context.
+- **Prompt design**: write a complete, self-contained prompt. Include all file paths, function names, error messages, and constraints the child needs. Assume zero shared context.
+- **Result handling**: when the child completes, its result is injected as a user message: `[sub-agent <id>] <status> (in=<n>, out=<n>)
+Thinking: ...
+Text: ...`. You then get another LLM turn to interpret and act on it.
+- **Parallelism**: multiple SubAgent calls in one turn run concurrently. Use this to parallelize independent investigations. **IMPORTANT**: results return asynchronously as each sub-agent finishes — they do NOT return together. When you receive a result for one sub-agent, the others are still running. Simply wait for all results to arrive before acting. Do NOT re-launch a sub-agent just because another one finished first — match results by session_id.
+- **Failure**: if the child fails (status=failed), the result text may be partial or empty. Handle gracefully — do not retry automatically.
+</sub-agent-guidance>
+<todo-guidance>
+- Use TodoWrite proactively for complex multi-step implementation, debugging, refactoring, review, or multi-file tasks.
+- Do not use TodoWrite for trivial single-step, single-command, or purely informational requests.
+- After receiving a non-trivial task, create an initial checklist before or as you begin work.
+- When you use TodoWrite, write the full updated checklist for the current session, not a partial diff.
+- Keep the checklist short, concrete, and actionable.
+- Prefer exactly one in_progress item when work is actively underway.
+- Mark items completed immediately after finishing them, and remove stale items that no longer matter.
+</todo-guidance>
+<plan-lifecycle-guidance>
+- **PLANNING WORKFLOW** — For complex multi-step tasks (3+ steps OR multi-file OR user requests planning)
+- **Files**: PLAN_DRAFT_FILE: __HOME__/.bash-agent/projects/__PROJECT_KEY__/system-prompt-parity/plan.draft | PLAN_FILE: __HOME__/.bash-agent/projects/__PROJECT_KEY__/system-prompt-parity/plan.md
+- **Why draft first?** Writing to PLAN_FILE immediately invalidates the system prompt cache. Use PLAN_DRAFT_FILE for all drafting iterations to avoid this cost.
+- **Drafting phase** (PLAN_DRAFT_FILE non-empty → you are drafting):
+  Every user reply MUST be classified as exactly ONE of:
+  ① REVISE (any feedback/question/change) → Edit PLAN_DRAFT_FILE → ask confirmation → stay in drafting
+  ② CONFIRM (explicit ok/go/confirmed) → call PlanConfirm IMMEDIATELY (before any other action) → TodoWrite checklist → execute
+  ③ CANCEL (explicit cancel/forget it) → Bash `: > PLAN_DRAFT_FILE` → exit to idle
+  ⚠ On CONFIRM you MUST call PlanConfirm first — no edits, no tool calls before it.
+- **Execution phase**: after PlanConfirm → TodoWrite checklist → execute tasks → PlanClear when all done
+- **Plan vs Todo**: PLAN_FILE=locked plan (only via PlanConfirm), PLAN_DRAFT_FILE=draft (edit freely), TodoWrite=progress tracker. Do NOT mix.
+</plan-lifecycle-guidance>
+<instruction-files>
+<instruction-file name="project">
+Project instruction fixture.
+Keep this text stable for system prompt parity checks.
+</instruction-file>
+</instruction-files>
+<skill-index>
+- parity-skill: Use this fixture skill only for system prompt parity tests.
+</skill-index>
+<selected-skills>
+<skill name="parity-skill">
+Base directory: __PROJECT__/skills/parity-skill
+
+# Parity Skill
+
+Use this fixture skill only for system prompt parity tests.
+Base path token: __PROJECT__/skills/parity-skill
+</skill>
+</selected-skills>
+<current-plan name="__HOME__/.bash-agent/projects/__PROJECT_KEY__/system-prompt-parity/plan.md">
+1. Keep the fixture plan stable.
+2. Compare generated system prompts exactly.
+</current-plan>
+<context-snapshot>
+Task focus: system prompt parity fixture.
+Latest request: compare prompt construction across runtimes.
+Progress: fixture seeded before agent execution.
+Tool evidence: none.
+Reflections: exact prompt drift must fail this test.
+</context-snapshot>
+<output-language>
+MUST use "en_US" for all output, including your Chain of Thought/reasoning/thinking! Never mix languages! Code, commands, and file content remain as-is.
+</output-language>

--- a/tests/fixtures/system_prompt_expected_zh_CN.txt
+++ b/tests/fixtures/system_prompt_expected_zh_CN.txt
@@ -1,0 +1,92 @@
+<agent-identity>
+你是 bash-agent，一个在终端中运行的轻量级编码智能体。
+</agent-identity>
+<environment>
+lang: zh_CN
+pwd: __PROJECT__
+home: __HOME__
+platform: __PLATFORM__
+shell: __SHELL__
+</environment>
+<rules>
+- Be concise and concrete. No pleasantries, no explanations unless asked. Raw results only.
+- Prefer safe, exact edits.
+- Report failures clearly.
+</rules>
+<using-your-tools>
+- Use Read for a single file. If you need multiple files, call Read multiple times.
+- Read supports optional offset and limit parameters to read specific line ranges (saves tokens for large files). Output includes line numbers.
+- Use Glob and Grep for one pattern at a time.
+- Grep supports a context parameter to show surrounding lines — use it to get enough text for Edit directly from Grep output, avoiding a separate Read.
+- Use multiple tool calls in one response when they are independent.
+- Prefer dedicated tools over Bash when a dedicated tool fits the task.
+- For Edit: copy old_string exactly (including whitespace/indent/newlines). If you already know the location from prior context, use Read with offset/limit. If you need to locate the text first, use Grep with context — its output is often sufficient for Edit without an extra Read.
+- For skills, first check the skill-index section, then use Skill(name) for the matching skill.
+- SubAgent launches a background agent session. Results are injected back into your conversation when complete. Use for parallelizable or independent sub-tasks. See sub-agent-guidance section for context inheritance rules.
+</using-your-tools>
+<sub-agent-guidance>
+- **When to use**: delegating independent sub-tasks that do NOT need your current conversation context — e.g. investigating a separate file, running a focused search, testing a hypothesis in isolation.
+- **When NOT to use**: tasks that depend on your working context, conversation history, or intermediate state. The child agent starts with a blank slate.
+- **Fork mode**: pass `fork=true` to inherit parent session context (conversation history, plan, skills). Use when the child needs your working context.
+- **Prompt design**: write a complete, self-contained prompt. Include all file paths, function names, error messages, and constraints the child needs. Assume zero shared context.
+- **Result handling**: when the child completes, its result is injected as a user message: `[sub-agent <id>] <status> (in=<n>, out=<n>)
+Thinking: ...
+Text: ...`. You then get another LLM turn to interpret and act on it.
+- **Parallelism**: multiple SubAgent calls in one turn run concurrently. Use this to parallelize independent investigations. **IMPORTANT**: results return asynchronously as each sub-agent finishes — they do NOT return together. When you receive a result for one sub-agent, the others are still running. Simply wait for all results to arrive before acting. Do NOT re-launch a sub-agent just because another one finished first — match results by session_id.
+- **Failure**: if the child fails (status=failed), the result text may be partial or empty. Handle gracefully — do not retry automatically.
+</sub-agent-guidance>
+<todo-guidance>
+- Use TodoWrite proactively for complex multi-step implementation, debugging, refactoring, review, or multi-file tasks.
+- Do not use TodoWrite for trivial single-step, single-command, or purely informational requests.
+- After receiving a non-trivial task, create an initial checklist before or as you begin work.
+- When you use TodoWrite, write the full updated checklist for the current session, not a partial diff.
+- Keep the checklist short, concrete, and actionable.
+- Prefer exactly one in_progress item when work is actively underway.
+- Mark items completed immediately after finishing them, and remove stale items that no longer matter.
+</todo-guidance>
+<plan-lifecycle-guidance>
+- **PLANNING WORKFLOW** — For complex multi-step tasks (3+ steps OR multi-file OR user requests planning)
+- **Files**: PLAN_DRAFT_FILE: __HOME__/.bash-agent/projects/__PROJECT_KEY__/system-prompt-parity/plan.draft | PLAN_FILE: __HOME__/.bash-agent/projects/__PROJECT_KEY__/system-prompt-parity/plan.md
+- **Why draft first?** Writing to PLAN_FILE immediately invalidates the system prompt cache. Use PLAN_DRAFT_FILE for all drafting iterations to avoid this cost.
+- **Drafting phase** (PLAN_DRAFT_FILE non-empty → you are drafting):
+  Every user reply MUST be classified as exactly ONE of:
+  ① REVISE (any feedback/question/change) → Edit PLAN_DRAFT_FILE → ask confirmation → stay in drafting
+  ② CONFIRM (explicit ok/go/confirmed) → call PlanConfirm IMMEDIATELY (before any other action) → TodoWrite checklist → execute
+  ③ CANCEL (explicit cancel/forget it) → Bash `: > PLAN_DRAFT_FILE` → exit to idle
+  ⚠ On CONFIRM you MUST call PlanConfirm first — no edits, no tool calls before it.
+- **Execution phase**: after PlanConfirm → TodoWrite checklist → execute tasks → PlanClear when all done
+- **Plan vs Todo**: PLAN_FILE=locked plan (only via PlanConfirm), PLAN_DRAFT_FILE=draft (edit freely), TodoWrite=progress tracker. Do NOT mix.
+</plan-lifecycle-guidance>
+<instruction-files>
+<instruction-file name="project">
+Project instruction fixture.
+Keep this text stable for system prompt parity checks.
+</instruction-file>
+</instruction-files>
+<skill-index>
+- parity-skill: Use this fixture skill only for system prompt parity tests.
+</skill-index>
+<selected-skills>
+<skill name="parity-skill">
+Base directory: __PROJECT__/skills/parity-skill
+
+# Parity Skill
+
+Use this fixture skill only for system prompt parity tests.
+Base path token: __PROJECT__/skills/parity-skill
+</skill>
+</selected-skills>
+<current-plan name="__HOME__/.bash-agent/projects/__PROJECT_KEY__/system-prompt-parity/plan.md">
+1. Keep the fixture plan stable.
+2. Compare generated system prompts exactly.
+</current-plan>
+<context-snapshot>
+Task focus: system prompt parity fixture.
+Latest request: compare prompt construction across runtimes.
+Progress: fixture seeded before agent execution.
+Tool evidence: none.
+Reflections: exact prompt drift must fail this test.
+</context-snapshot>
+<output-language>
+再次强调：必须使用中文进行所有输出，包括你的思考过程（Chain of Thought/推理/thinking）！严禁在思考或回答中出现任何英文内容！
+</output-language>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3243,54 +3243,134 @@ test_agent_plan_confirm_mv() {
     rm -rf "$home_dir"
 }
 
-# Test 47: system prompt format — no extra blank lines before closing tags (SP1/SP2)
+# Test 47: system prompt golden — current AGENT must produce the byte-exact expected prompt
 test_agent_system_prompt_format() {
-    info "Test 47: system prompt format (SP1/SP2 — no extra blank lines before closing tags)"
-    local home_dir last_body
+    info "Test 47: system prompt byte-exact golden"
+    local home_dir project_dir session_id project_key_value project_storage candidate_agent
+    local expected_prompt actual_prompt candidate_err diff_file platform prompt_shell
     home_dir=$(mktemp -d)
+    project_dir="$home_dir/project"
+    session_id="system-prompt-parity"
+    case "$AGENT" in
+        /*) candidate_agent="$AGENT" ;;
+        *) candidate_agent="$ROOT_DIR/${AGENT#./}" ;;
+    esac
 
-    BASH_AGENT_HOME="$home_dir" "$AGENT" -p claude --base-url "$BASE/v1" -m test --api-key test 'SP_FORMAT_CHECK' >/dev/null 2>&1 || true
+    mkdir -p "$project_dir" "$home_dir/.bash-agent"
+    project_dir="$(cd "$project_dir" && pwd -P)"
+    mkdir -p "$project_dir/skills/parity-skill"
+    cat > "$project_dir/AGENTS.md" <<'EOF'
+Project instruction fixture.
+Keep this text stable for system prompt parity checks.
+EOF
+    cat > "$project_dir/skills/parity-skill/SKILL.md" <<'EOF'
+# Parity Skill
 
-    last_body=$(curl -sS "$BASE/last-request" 2>/dev/null)
-    if [[ -z "$last_body" ]]; then
-        red "system prompt format: no last request captured"; ((FAIL++)) || true
-        rm -rf "$home_dir"; return
-    fi
+Use this fixture skill only for system prompt parity tests.
+Base path token: ${BASH_AGENT_SKILL_DIR}
+EOF
 
-    # Extract system prompt content from request body
-    local sp_check
-    sp_check=$(echo "$last_body" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-body = json.loads(d.get('body','{}'))
-msgs = body.get('messages', [])
-for m in msgs:
-    if m.get('role') == 'user':
-        content = m.get('content', '')
-        if isinstance(content, list):
-            for block in content:
-                if isinstance(block, dict) and block.get('type') == 'text':
-                    content = block.get('text', '')
-                    break
-        if '</instruction-files>' in content:
-            # Check no double newline before closing tag
-            if '\\n\\n</instruction-files>' in content:
-                print('EXTRA_NEWLINE_INSTRUCTION')
-            else:
-                print('OK_INSTRUCTION')
-        if '</selected-skills>' in content:
-            if '\\n\\n</selected-skills>' in content:
-                print('EXTRA_NEWLINE_SKILLS')
-            else:
-                print('OK_SKILLS')
-        break
-" 2>/dev/null)
+    project_key_value="$(cd "$project_dir" && project_key)"
+    project_storage="$home_dir/.bash-agent/projects/$project_key_value/$session_id"
+    mkdir -p "$project_storage"
+    cat > "$project_storage/plan.md" <<'EOF'
+1. Keep the fixture plan stable.
+2. Compare generated system prompts exactly.
+EOF
+    cat > "$project_storage/summary.txt" <<'EOF'
+Task focus: system prompt parity fixture.
+Latest request: compare prompt construction across runtimes.
+Progress: fixture seeded before agent execution.
+Tool evidence: none.
+Reflections: exact prompt drift must fail this test.
+EOF
+    : > "$project_storage/conversation.jsonl"
+    : > "$project_storage/events.jsonl"
+    : > "$project_storage/plan.draft"
+    : > "$project_storage/stats.json"
 
-    if [[ "$sp_check" == *"EXTRA_NEWLINE"* ]]; then
-        red "system prompt format: extra blank line before closing tag ($sp_check)"; ((FAIL++)) || true
-    else
-        green "system prompt format: no extra blank lines before closing tags"; ((PASS++)) || true
-    fi
+    expected_prompt="$home_dir/expected.system"
+    actual_prompt="$home_dir/actual.system"
+    candidate_err="$home_dir/candidate.err"
+    diff_file="$home_dir/system.diff"
+    platform="$(uname -s 2>/dev/null || printf unknown)"
+    prompt_shell="${SHELL:-/bin/sh}"
+
+    extract_system_prompt() {
+        local marker="$1"
+        curl -sS "$BASE/last-request" 2>/dev/null | EXPECTED_MARKER="$marker" python3 -c '
+import json, os, sys
+try:
+    captured = json.load(sys.stdin)
+    body = json.loads(captured.get("body", "{}"))
+except Exception as exc:
+    print(f"failed to parse captured request: {exc}", file=sys.stderr)
+    sys.exit(2)
+marker = os.environ["EXPECTED_MARKER"]
+if marker not in json.dumps(body.get("messages", []), ensure_ascii=False):
+    print("captured request did not contain expected marker", file=sys.stderr)
+    sys.exit(3)
+system = body.get("system")
+if not isinstance(system, str) or not system:
+    print("captured request has no top-level system prompt", file=sys.stderr)
+    sys.exit(4)
+sys.stdout.write(system)
+'
+    }
+
+    render_expected_system_prompt() {
+        local template_file="$1"
+        EXPECTED_HOME="$home_dir" \
+        EXPECTED_PROJECT="$project_dir" \
+        EXPECTED_PROJECT_KEY="$project_key_value" \
+        EXPECTED_PLATFORM="$platform" \
+        EXPECTED_SHELL="$prompt_shell" \
+        python3 - "$template_file" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+template = Path(sys.argv[1]).read_text()
+template = template.replace("__HOME__", os.environ["EXPECTED_HOME"])
+template = template.replace("__PROJECT__", os.environ["EXPECTED_PROJECT"])
+template = template.replace("__PROJECT_KEY__", os.environ["EXPECTED_PROJECT_KEY"])
+template = template.replace("__PLATFORM__", os.environ["EXPECTED_PLATFORM"])
+template = template.replace("__SHELL__", os.environ["EXPECTED_SHELL"])
+if template.endswith("\n"):
+    template = template[:-1]
+sys.stdout.write(template)
+PY
+    }
+
+    check_system_prompt_locale() {
+        local locale_name="$1" locale_value="$2" template_file="$3" marker="$4"
+        render_expected_system_prompt "$template_file" > "$expected_prompt"
+
+        (
+            cd "$project_dir" &&
+            BASH_AGENT_HOME="$home_dir" HOME="$home_dir" SHELL="$prompt_shell" \
+            LANG="$locale_value" LC_ALL="$locale_value" \
+            "$candidate_agent" -p claude --base-url "$BASE/v1" -m test --api-key test \
+                --session "$session_id" --skill parity-skill "$marker" \
+                >/dev/null 2>"$candidate_err"
+        ) || true
+        if ! extract_system_prompt "$marker" > "$actual_prompt"; then
+            red "system prompt golden ($locale_name): failed to capture candidate prompt"; cat "$candidate_err" 2>/dev/null; ((FAIL++)) || true
+            return
+        fi
+
+        if cmp -s "$expected_prompt" "$actual_prompt"; then
+            green "system prompt golden ($locale_name): byte-exact match"; ((PASS++)) || true
+        else
+            red "system prompt golden ($locale_name): differs from expected bytes"
+            diff -u "$expected_prompt" "$actual_prompt" > "$diff_file" || true
+            sed -n '1,160p' "$diff_file"
+            ((FAIL++)) || true
+        fi
+    }
+
+    check_system_prompt_locale "en_US" "en_US.UTF-8" "$ROOT_DIR/tests/fixtures/system_prompt_expected.txt" "SYSTEM_PROMPT_GOLDEN_EN"
+    check_system_prompt_locale "zh_CN" "zh_CN.UTF-8" "$ROOT_DIR/tests/fixtures/system_prompt_expected_zh_CN.txt" "SYSTEM_PROMPT_GOLDEN_ZH"
 
     rm -rf "$home_dir"
 }


### PR DESCRIPTION
  Fixes replay memory behavior, system prompt parity, and a Go interrupt crash.

  Changes:

  - Stream replay from recent event offsets instead of loading full event history into memory.
  - Add byte-exact system prompt golden tests for Bash, C, Go, and Rust.
  - Cover both en_US and zh_CN prompt generation.
  - Parameterize machine-dependent golden fields: home, project path, project key, platform, and shell.
  - Centralize trailing newline trimming in section append/wrap helpers across C, Go, and Rust.
  - Fix Rust plan lifecycle prompt indentation to match Bash/C/Go exactly.
  - Align Go instruction-file section generation with UtilAppendSection.
  - Fix Go SSE interrupt panic by sending fallback events before closing the stream channel.
  - Harden Go SIGINT handling with atomic.Bool and a goroutine shutdown signal.

  Validation:

  - bash -n tests/test.sh
  - go test ./...
  - cargo check
  - AGENT=./src/agent.sh bash tests/test.sh 9901
  - AGENT=./dist/cagent bash tests/test.sh 9904
  - AGENT=./dist/goagent bash tests/test.sh 9902
  - AGENT=./dist/rustagent bash tests/test.sh 9903