### PR TITLE
修复 C 版本 OpenAI Chat 请求体转换并对齐工具调用语义

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -769,10 +769,15 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
         const char *tools_json = embedded_tools_json;
 
         /* 构建请求体 */
-        char *body = build_claude_request(agent->model, system_prompt,
-                                          tools_json, lines, line_count,
-                                          agent->max_tokens,
-                                          agent->thinking, agent->effort);
+        char *claude_body = build_claude_request(agent->model, system_prompt,
+                                                 tools_json, lines, line_count,
+                                                 agent->max_tokens,
+                                                 agent->thinking, agent->effort);
+        char *body = claude_body;
+        if (strcmp(agent->provider, "openai") == 0) {
+            body = convert_to_openai(claude_body);
+            free(claude_body);
+        }
 
         /* 构建 HTTP headers */
         const char *headers[8];
@@ -780,9 +785,9 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
         int hdr_count = 0;
         headers[hdr_count++] = "Content-Type: application/json";
         headers[hdr_count++] = "User-Agent: claude-cli/1.0.33 (max, cli)";
-        headers[hdr_count++] = "x-app: cli";
 
         if (strcmp(agent->provider, "claude") == 0) {
+            headers[hdr_count++] = "x-app: cli";
             snprintf(auth_header, sizeof(auth_header), "x-api-key: %s", agent->api_key);
             headers[hdr_count++] = auth_header;
             headers[hdr_count++] = "anthropic-version: 2023-06-01";
@@ -2291,6 +2296,11 @@ int agent_compact_context(Agent *agent, const char *trigger) {
     sb_append(&req_body, "}]}");
 
     char *summary_body = req_body.data;
+    if (strcmp(agent->provider, "openai") == 0) {
+        char *openai_body = convert_to_openai(summary_body);
+        free(summary_body);
+        summary_body = openai_body;
+    }
 
     /* 发送 summary 请求 */
     const char *headers[8];
@@ -2298,8 +2308,8 @@ int agent_compact_context(Agent *agent, const char *trigger) {
     int hdr_count = 0;
     headers[hdr_count++] = "Content-Type: application/json";
     headers[hdr_count++] = "User-Agent: claude-cli/1.0.33 (max, cli)";
-    headers[hdr_count++] = "x-app: cli";
     if (strcmp(agent->provider, "claude") == 0) {
+        headers[hdr_count++] = "x-app: cli";
         snprintf(auth_header, sizeof(auth_header), "x-api-key: %s", agent->api_key);
         headers[hdr_count++] = auth_header;
         headers[hdr_count++] = "anthropic-version: 2023-06-01";

--- a/c/transport.c
+++ b/c/transport.c
@@ -634,8 +634,251 @@ char *build_claude_request(const char *model, const char *system_prompt,
     return result;
 }
 
+static void sb_append_json_val(StrBuf *sb, JsonVal v) {
+    if (v.type == JSON_NULL || !v.src) {
+        sb_append(sb, "null");
+        return;
+    }
+    sb_appendn(sb, v.src + v.start, v.end - v.start);
+}
+
+static void openai_convert_tools(StrBuf *out, JsonVal tools_val) {
+    if (tools_val.type != JSON_ARRAY) {
+        sb_append(out, "[]");
+        return;
+    }
+    sb_append_char(out, '[');
+    int n = json_array_len(tools_val);
+    for (int i = 0; i < n; i++) {
+        JsonVal td = json_array_get(tools_val, i);
+        if (i > 0) sb_append_char(out, ',');
+        char *type = json_get_string(td, "type");
+        if (type && strcmp(type, "function") == 0) {
+            sb_append_json_val(out, td);
+            FREE_PTR(type);
+            continue;
+        }
+        FREE_PTR(type);
+        char *name = json_get_string(td, "name");
+        char *desc = json_get_string(td, "description");
+        JsonVal params = json_get(td, "input_schema");
+        if (params.type == JSON_NULL) params = json_get(td, "parameters");
+        sb_append(out, "{\"type\":\"function\",\"function\":{\"name\":");
+        sb_append_json_string(out, name ? name : "");
+        sb_append(out, ",\"description\":");
+        sb_append_json_string(out, desc ? desc : "");
+        sb_append(out, ",\"parameters\":");
+        if (params.type == JSON_NULL) sb_append(out, "{}");
+        else sb_append_json_val(out, params);
+        sb_append(out, "}}");
+        FREE_PTR(name);
+        FREE_PTR(desc);
+    }
+    sb_append_char(out, ']');
+}
+
+static void openai_convert_assistant_message(StrBuf *out, JsonVal content_val) {
+    StrBuf text, reasoning, tool_calls;
+    sb_init(&text);
+    sb_init(&reasoning);
+    sb_init(&tool_calls);
+
+    int n = json_array_len(content_val);
+    for (int i = 0; i < n; i++) {
+        JsonVal block = json_array_get(content_val, i);
+        char *btype = json_get_string(block, "type");
+        if (!btype) continue;
+        if (strcmp(btype, "thinking") == 0) {
+            char *t = json_get_string(block, "thinking");
+            if (t) { sb_append(&reasoning, t); FREE_PTR(t); }
+        } else if (strcmp(btype, "text") == 0) {
+            char *t = json_get_string(block, "text");
+            if (t) { sb_append(&text, t); FREE_PTR(t); }
+        } else if (strcmp(btype, "tool_use") == 0) {
+            char *id = json_get_string(block, "id");
+            char *name = json_get_string(block, "name");
+            JsonVal input = json_get(block, "input");
+            if (tool_calls.len > 0) sb_append_char(&tool_calls, ',');
+            sb_append(&tool_calls, "{\"id\":");
+            sb_append_json_string(&tool_calls, id ? id : "");
+            sb_append(&tool_calls, ",\"type\":\"function\",\"function\":{\"name\":");
+            sb_append_json_string(&tool_calls, name ? name : "");
+            sb_append(&tool_calls, ",\"arguments\":");
+            if (input.type == JSON_NULL) sb_append_json_string(&tool_calls, "{}");
+            else {
+                StrBuf arg;
+                sb_init(&arg);
+                sb_append_json_val(&arg, input);
+                sb_append_json_string(&tool_calls, arg.data ? arg.data : "{}");
+                sb_free(&arg);
+            }
+            sb_append(&tool_calls, "}}");
+            FREE_PTR(id);
+            FREE_PTR(name);
+        }
+        FREE_PTR(btype);
+    }
+
+    sb_append(out, "{\"role\":\"assistant\",\"reasoning_content\":");
+    sb_append_json_string(out, reasoning.data ? reasoning.data : "");
+    sb_append(out, ",\"content\":");
+    sb_append_json_string(out, text.data ? text.data : "");
+    if (tool_calls.len > 0) {
+        sb_append(out, ",\"tool_calls\":[");
+        sb_append(out, tool_calls.data);
+        sb_append_char(out, ']');
+    }
+    sb_append_char(out, '}');
+
+    sb_free(&text);
+    sb_free(&reasoning);
+    sb_free(&tool_calls);
+}
+
+static int openai_convert_tool_results(StrBuf *out, JsonVal content_val) {
+    int written = 0;
+    int n = json_array_len(content_val);
+    for (int i = 0; i < n; i++) {
+        JsonVal block = json_array_get(content_val, i);
+        char *btype = json_get_string(block, "type");
+        if (!btype || strcmp(btype, "tool_result") != 0) {
+            FREE_PTR(btype);
+            continue;
+        }
+        char *tool_use_id = json_get_string(block, "tool_use_id");
+        char *content = json_get_string(block, "content");
+        if (written > 0) sb_append_char(out, ',');
+        sb_append(out, "{\"role\":\"tool\",\"tool_call_id\":");
+        sb_append_json_string(out, tool_use_id ? tool_use_id : "");
+        sb_append(out, ",\"content\":");
+        sb_append_json_string(out, content ? content : "");
+        sb_append_char(out, '}');
+        written++;
+        FREE_PTR(tool_use_id);
+        FREE_PTR(content);
+        FREE_PTR(btype);
+    }
+    return written;
+}
+
+static void openai_convert_messages(StrBuf *out, JsonVal messages_val) {
+    sb_append_char(out, '[');
+    int wrote = 0;
+    int n = json_array_len(messages_val);
+    for (int i = 0; i < n; i++) {
+        JsonVal msg = json_array_get(messages_val, i);
+        char *role = json_get_string(msg, "role");
+        JsonVal content = json_get(msg, "content");
+        if (role && strcmp(role, "assistant") == 0 && content.type == JSON_ARRAY) {
+            if (wrote > 0) sb_append_char(out, ',');
+            openai_convert_assistant_message(out, content);
+            wrote++;
+        } else if (role && strcmp(role, "user") == 0 && content.type == JSON_ARRAY) {
+            int before = wrote;
+            if (wrote > 0 && json_array_len(content) > 0) {
+                /* openai_convert_tool_results handles commas after the first item */
+            }
+            if (wrote > 0) {
+                StrBuf tmp;
+                sb_init(&tmp);
+                int tool_written = openai_convert_tool_results(&tmp, content);
+                if (tool_written > 0) {
+                    sb_append_char(out, ',');
+                    sb_append(out, tmp.data);
+                    wrote += tool_written;
+                } else {
+                    if (wrote > 0) sb_append_char(out, ',');
+                    sb_append_json_val(out, msg);
+                    wrote++;
+                }
+                sb_free(&tmp);
+            } else {
+                int tool_written = openai_convert_tool_results(out, content);
+                if (tool_written > 0) wrote += tool_written;
+                else {
+                    sb_append_json_val(out, msg);
+                    wrote++;
+                }
+            }
+            (void)before;
+        } else {
+            if (wrote > 0) sb_append_char(out, ',');
+            sb_append_json_val(out, msg);
+            wrote++;
+        }
+        FREE_PTR(role);
+    }
+    sb_append_char(out, ']');
+}
+
 char *convert_to_openai(const char *claude_body) {
-    /* 简化的 Claude → OpenAI 转换 */
-    /* 对于完整的转换需要解析并重组 JSON，这里先返回原样 */
-    return util_strdup(claude_body);
+    JsonParse jp = json_parse_root(claude_body);
+    if (jp.error) return util_strdup(claude_body);
+
+    char *model = json_get_string(jp.val, "model");
+    int max_tokens = json_get_int(jp.val, "max_tokens");
+    JsonVal system_val = json_get(jp.val, "system");
+    JsonVal thinking_val = json_get(jp.val, "thinking");
+    JsonVal output_config_val = json_get(jp.val, "output_config");
+    JsonVal messages_val = json_get(jp.val, "messages");
+    JsonVal tools_val = json_get(jp.val, "tools");
+
+    StrBuf messages, tools, result;
+    sb_init(&messages);
+    sb_init(&tools);
+    sb_init(&result);
+
+    openai_convert_messages(&messages, messages_val);
+    if (tools_val.type == JSON_ARRAY && json_array_len(tools_val) > 0) {
+        openai_convert_tools(&tools, tools_val);
+    }
+
+    sb_append(&result, "{\"model\":");
+    sb_append_json_string(&result, model ? model : "");
+    sb_append(&result, ",\"max_tokens\":");
+    sb_appendf(&result, "%d", max_tokens);
+    sb_append(&result, ",\"stream\":true");
+
+    if (system_val.type != JSON_NULL) {
+        char *sys = json_as_string(system_val);
+        if (sys && sys[0]) {
+            StrBuf with_system;
+            sb_init(&with_system);
+            sb_append(&with_system, "[{\"role\":\"system\",\"content\":");
+            sb_append_json_string(&with_system, sys);
+            if (messages.len > 2) {
+                sb_append_char(&with_system, ',');
+                sb_appendn(&with_system, messages.data + 1, messages.len - 2);
+            }
+            sb_append_char(&with_system, ']');
+            sb_free(&messages);
+            messages = with_system;
+        }
+        FREE_PTR(sys);
+    }
+
+    char *thinking_type = json_get_string(thinking_val, "type");
+    if (thinking_type &&
+        (strcmp(thinking_type, "adaptive") == 0 || strcmp(thinking_type, "enabled") == 0)) {
+        sb_append(&result, ",\"thinking\":{\"type\":\"enabled\"}");
+        char *effort = json_get_string(output_config_val, "effort");
+        sb_append(&result, ",\"reasoning_effort\":");
+        sb_append_json_string(&result, (effort && effort[0]) ? effort : "high");
+        FREE_PTR(effort);
+    }
+    FREE_PTR(thinking_type);
+
+    if (tools.len > 0 && strcmp(tools.data, "[]") != 0) {
+        sb_append(&result, ",\"tools\":");
+        sb_append(&result, tools.data);
+    }
+
+    sb_append(&result, ",\"messages\":");
+    sb_append(&result, messages.data ? messages.data : "[]");
+    sb_append_char(&result, '}');
+
+    FREE_PTR(model);
+    sb_free(&messages);
+    sb_free(&tools);
+    return result.data;
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -456,6 +456,22 @@ test_agent_e2e_openai() {
     check "Agent e2e OpenAI" "$("$AGENT" -p openai --base-url "$BASE/v1" -m test --api-key test 'Hello' 2>&1 || true)" "Hello from" "mock"
 }
 
+test_agent_openai_request_body() {
+    info "Test 11a: Agent OpenAI request body carries converted tools"
+    "$AGENT" -p openai --base-url "$BASE/v1" -m test --api-key test 'Hello' >/dev/null 2>&1 || true
+    local req body
+    req=$(curl -fsS "$BASE/last-request")
+    body=$(printf '%s' "$req" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["body"])')
+    if echo "$body" | grep -Fq '"role":"system"' && \
+       echo "$body" | grep -Fq '"type":"function"' && \
+       echo "$body" | grep -Fq '"parameters":' && \
+       ! echo "$body" | grep -Fq '"input_schema"'; then
+        green "Agent OpenAI request body carries converted tools"; ((PASS++)) || true
+    else
+        red "Agent OpenAI request body carries converted tools"; echo "  Body: $body"; ((FAIL++)) || true
+    fi
+}
+
 # Test 13: Skill injection
 test_agent_skill_injection() {
     local skill_dir skill_file
@@ -2330,6 +2346,7 @@ test_transport_body
 test_transport_body_tools
 test_agent_e2e_claude
 test_agent_e2e_openai
+test_agent_openai_request_body
 test_agent_skill_injection
 test_agent_skill_injection_from_repo_skills_dir
 test_agent_skill_index


### PR DESCRIPTION
  ## 变更内容

  修复 C 版本在 `--provider openai` / OpenAI Chat Completions 接口下，请求体仍沿用 Claude 格式的问题。

  原来的行为是：
  - URL 已切到 `/chat/completions`
  - 但 body 仍然是 Claude Messages 结构
  - `convert_to_openai()` 只是空壳，未真正参与请求构造

  这会导致：
  - `tools` 没有按 OpenAI `type=function` 结构发送
  - `system` 没有转成 `messages[].role=system`
  - assistant 的 `tool_use` / user 的 `tool_result` 也没有转成 OpenAI chat 语义
  - 长会话 compact 后的 summary 请求在 OpenAI 模式下同样不兼容

  ## 具体修复

  ### 1. 实现 C 版 Claude -> OpenAI body conversion
  在 `c/transport.c` 中补全 `convert_to_openai()`，对齐 bash / Rust / Go 的语义：

  - `system` -> prepend 为 OpenAI `system` message
  - Claude `tools` -> OpenAI `{"type":"function","function":...}`
  - assistant content blocks 中的 `tool_use` -> `tool_calls`
  - user content blocks 中的 `tool_result` -> `role=tool`
  - `thinking` / `output_config.effort` -> OpenAI `thinking` + `reasoning_effort`

  ### 2. 主请求路径接入转换
  在 `c/agent.c` 中：
  - 继续先构造统一的 Claude request
  - provider=`openai` 时再调用 `convert_to_openai()`

  ### 3. compact / summary 请求也接入转换
  修复长会话 compact 时的 OpenAI 路径：
  - summary 请求原来同样直接把 Claude conversation 发给 `/chat/completions`
  - 现在也统一走 `convert_to_openai()`

  ### 4. 对齐 OpenAI header 语义
  修复一个顺手发现的对齐问题：
  - C 版原来在 OpenAI 请求中也发送 `x-app: cli`
  - 现在改为只在 Claude 请求中发送，与 bash 版一致

  ### 5. 补充回归测试
  在 `tests/test.sh` 中新增 OpenAI request body 检查：
  - 跑 OpenAI mock
  - 读取 `/last-request`
  - 断言请求体中：
    - 包含 `role=system`
    - 包含 OpenAI `tools[].type=function`
    - 包含 `parameters`
    - 不再残留 Claude `input_schema`

  ## 验证

  已验证：

  - `make build-c`
  - `/bin/zsh -lc 'AGENT=./dist/cagent bash tests/test.sh 9904'`

  结果：

  - `125 passed, 0 failed`