### PR TITLE
修复 C 版本 OpenAI 工具调用链与工具结果处理

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -469,18 +469,18 @@ static long find_recent_turn_start_offset(const SessionPaths *paths, int max_tur
     return start;
 }
 
-void agent_replay_events(Agent *agent, int max_turns) {
+int agent_replay_events(Agent *agent, int max_turns) {
     long start = find_recent_turn_start_offset(&agent->paths, max_turns);
-    if (start < 0) return;
+    int replayed = 0;
+    if (start < 0) return 0;
 
     FILE *f = fopen(agent->paths.events, "r");
-    if (!f) return;
+    if (!f) return 0;
     if (fseek(f, start, SEEK_SET) != 0) {
         fclose(f);
-        return;
+        return 0;
     }
 
-    /* 累积缓冲 */
     StrBuf acc_text, acc_thinking;
     sb_init(&acc_text);
     sb_init(&acc_thinking);
@@ -495,31 +495,29 @@ void agent_replay_events(Agent *agent, int max_turns) {
         if (line_len == 0) continue;
 
         JsonParse jp = json_parse_root(line);
-        if (jp.error) {  continue; }
+        if (jp.error) continue;
 
         char *type = json_get_string(jp.val, "type");
-        if (!type) {  continue; }
+        if (!type) continue;
 
         if (strcmp(type, "user_input") == 0) {
-            /* flush 累积 */
             if (acc_thinking.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_thinking(acc_thinking.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_thinking, 0);
             }
             if (acc_text.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_text(acc_text.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_text, 0);
             }
-            /* 显示 user_input（与 Rust 版 display_replay_event USER_MESSAGE 对齐） */
             char *content = json_get_string(jp.val, "content");
             if (content && content[0]) {
-                /* 截断到 80 字节（含 "..."），UTF-8 安全 */
                 util_truncate_str(content, 80);
-                /* 取第一行 */
                 char *nl = strchr(content, '\n');
                 if (nl) *nl = '\0';
 
@@ -529,46 +527,45 @@ void agent_replay_events(Agent *agent, int max_turns) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_text(user_display.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_free(&user_display);
             }
             free(content);
-        }
-        else if (strcmp(type, "text") == 0) {
-            /* flush thinking */
+        } else if (strcmp(type, "text") == 0) {
             if (acc_thinking.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_thinking(acc_thinking.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_thinking, 0);
             }
             char *content = json_get_string(jp.val, "content");
             if (content && *content) sb_append(&acc_text, content);
             free(content);
-        }
-        else if (strcmp(type, "thinking") == 0) {
-            /* flush text */
+        } else if (strcmp(type, "thinking") == 0) {
             if (acc_text.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_text(acc_text.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_text, 0);
             }
             char *content = json_get_string(jp.val, "content");
             if (content && *content) sb_append(&acc_thinking, content);
             free(content);
-        }
-        else if (strcmp(type, "tool_call") == 0) {
-            /* flush 累积 */
+        } else if (strcmp(type, "tool_call") == 0) {
             if (acc_thinking.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_thinking(acc_thinking.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_thinking, 0);
             }
             if (acc_text.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_text(acc_text.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_text, 0);
             }
             char *name = json_get_string(jp.val, "name");
@@ -588,46 +585,48 @@ void agent_replay_events(Agent *agent, int max_turns) {
             free(dm->tool_input);
             dm->tool_input = util_strdup(input_str);
             push_display(agent->display_queue, dm);
-            free(input_str); free(summary); free(name); free(id);
-        }
-        else if (strcmp(type, "tool_result") == 0) {
-            /* flush 累积 */
+            replayed = 1;
+            free(input_str);
+            free(summary);
+            free(name);
+            free(id);
+        } else if (strcmp(type, "tool_result") == 0) {
             if (acc_thinking.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_thinking(acc_thinking.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_thinking, 0);
             }
             if (acc_text.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_text(acc_text.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_text, 0);
             }
             char *content = json_get_string(jp.val, "content");
-            /* 截断到 200 字节（含 "..."，UTF-8 安全） */
-            if (content) {
-                util_truncate_str(content, 200);
-            }
+            if (content) util_truncate_str(content, 200);
             DisplayMessage *dm = malloc(sizeof(DisplayMessage));
             *dm = display_msg_tool_result(content ? content : "", 0);
             dm->tool_id = json_get_string(jp.val, "tool_use_id");
             dm->tool_name = json_get_string(jp.val, "name");
             push_display(agent->display_queue, dm);
+            replayed = 1;
             free(content);
-        }
-        else if (strcmp(type, "sub_agent_result") == 0) {
-            /* flush 累积 */
+        } else if (strcmp(type, "sub_agent_result") == 0) {
             if (acc_thinking.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_thinking(acc_thinking.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_thinking, 0);
             }
             if (acc_text.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_text(acc_text.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_text, 0);
             }
             char *sid = json_get_string(jp.val, "session_id");
@@ -636,62 +635,61 @@ void agent_replay_events(Agent *agent, int max_turns) {
             char *text = json_get_string(jp.val, "text");
             int in_tok = json_get_int(jp.val, "input_tokens");
             int out_tok = json_get_int(jp.val, "output_tokens");
-            /* 截断 thinking（无省略号，UTF-8 安全） */
-            if (thinking) {
-                thinking[util_utf8_truncate_len(thinking, 120)] = '\0';
-            }
-            /* 截断 text（UTF-8 安全） */
-            if (text) {
-                util_truncate_str(text, 200);
-            }
+            if (thinking) thinking[util_utf8_truncate_len(thinking, 120)] = '\0';
+            if (text) util_truncate_str(text, 200);
             DisplayMessage *dm = malloc(sizeof(DisplayMessage));
             *dm = display_msg_sub_agent_result(sid ? sid : "", status ? status : "ok",
-                                                thinking, text ? text : "", in_tok, out_tok);
+                                               thinking, text ? text : "", in_tok, out_tok);
             push_display(agent->display_queue, dm);
-            free(sid); free(status); free(thinking); free(text);
-        }
-        else if (strcmp(type, "error") == 0) {
-            /* flush 累积 */
+            replayed = 1;
+            free(sid);
+            free(status);
+            free(thinking);
+            free(text);
+        } else if (strcmp(type, "error") == 0) {
             if (acc_thinking.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_thinking(acc_thinking.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_thinking, 0);
             }
             if (acc_text.len > 0) {
                 DisplayMessage *dm = malloc(sizeof(DisplayMessage));
                 *dm = display_msg_text(acc_text.data);
                 push_display(agent->display_queue, dm);
+                replayed = 1;
                 sb_truncate(&acc_text, 0);
             }
             char *message = json_get_string(jp.val, "message");
             DisplayMessage *dm = malloc(sizeof(DisplayMessage));
             *dm = display_msg_error(message ? message : "unknown");
             push_display(agent->display_queue, dm);
+            replayed = 1;
             free(message);
         }
-        /* stop, usage, session_start, retry, sub_agent_start, sub_agent_end 等跳过 */
 
         free(type);
-        
     }
 
-    /* flush 最后的累积 */
     if (acc_thinking.len > 0) {
         DisplayMessage *dm = malloc(sizeof(DisplayMessage));
         *dm = display_msg_thinking(acc_thinking.data);
         push_display(agent->display_queue, dm);
+        replayed = 1;
     }
     if (acc_text.len > 0) {
         DisplayMessage *dm = malloc(sizeof(DisplayMessage));
         *dm = display_msg_text(acc_text.data);
         push_display(agent->display_queue, dm);
+        replayed = 1;
     }
 
     sb_free(&acc_text);
     sb_free(&acc_thinking);
     free(line);
     fclose(f);
+    return replayed;
 }
 
 /* ============================================================

--- a/c/agent.c
+++ b/c/agent.c
@@ -137,9 +137,9 @@ static void stream_display_callback(void *ctx, const SseEvent *evt) {
         }
         ToolCallAccum *tc = &acc->tools[acc->tool_count];
         memset(tc, 0, sizeof(*tc));
+        sb_init(&tc->input_json);
         tc->id = util_strdup(evt->tool_id);
         tc->name = util_strdup(evt->tool_name);
-        sb_init(&tc->input_json);
         acc->tool_count++;
         break;
     }
@@ -778,6 +778,12 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
             body = convert_to_openai(claude_body);
             free(claude_body);
         }
+        if (agent->verbose && body) {
+            int body_len = (int)strlen(body);
+            int preview_len = body_len > 200 ? 200 : body_len;
+            fprintf(stderr, "[verbose] Request body (%dKB): %.*s%s\n",
+                    body_len / 1024, preview_len, body, body_len > 200 ? "..." : "");
+        }
 
         /* 构建 HTTP headers */
         const char *headers[8];
@@ -909,32 +915,15 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
             agent_update_title(agent);
         }
 
-        /* ---- 保存 assistant 消息到 conversation ---- */
-        const char **tc_ids = NULL, **tc_names = NULL, **tc_inputs = NULL;
-        if (accum->tool_count > 0) {
-            tc_ids = malloc(accum->tool_count * sizeof(char*));
-            tc_names = malloc(accum->tool_count * sizeof(char*));
-            tc_inputs = malloc(accum->tool_count * sizeof(char*));
-            for (int i = 0; i < accum->tool_count; i++) {
-                tc_ids[i] = accum->tools[i].id;
-                tc_names[i] = accum->tools[i].name;
-                tc_inputs[i] = accum->tools[i].input_json.data;
-            }
-        }
-        store_conv_add_assistant(agent->paths.conversation,
-                          accum->thinking.data, accum->text.data,
-                          accum->tool_count, tc_ids, tc_names, tc_inputs);
-        free(tc_ids);
-        free(tc_names);
-        free(tc_inputs);
-
         /* ---- 执行工具调用 ---- */
+        const char **result_ids = NULL;
+        const char **result_contents = NULL;
         if (accum->tool_count > 0 && accum->stop_reason &&
             (strcmp(accum->stop_reason, "tool_use") == 0 ||
              strcmp(accum->stop_reason, "tool_calls") == 0)) {
 
-            const char **result_ids = malloc(accum->tool_count * sizeof(char*));
-            const char **result_contents = malloc(accum->tool_count * sizeof(char*));
+            result_ids = malloc(accum->tool_count * sizeof(char*));
+            result_contents = malloc(accum->tool_count * sizeof(char*));
 
             for (int i = 0; i < accum->tool_count; i++) {
                 ToolCallAccum *tc = &accum->tools[i];
@@ -1040,11 +1029,6 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                 }
 
             }
-
-            /* 保存 tool_results */
-            store_conv_add_tool_results(agent->paths.conversation, accum->tool_count,
-                                  result_ids, result_contents);
-
             /* PlanClear / PlanConfirm 触发 compact（在 tool_result 写入之后）
              * 对齐 bash 版: PlanConfirm→先 compact 再 mv draft→plan; PlanClear→compact+clear */
             for (int i = 0; i < accum->tool_count; i++) {
@@ -1066,10 +1050,31 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                 }
             }
 
-            /* 释放 tool result 输出 */
+        }
+
+        /* ---- 保存 assistant / tool_results 到 conversation ---- */
+        const char **tc_ids = NULL, **tc_names = NULL, **tc_inputs = NULL;
+        if (accum->tool_count > 0) {
+            tc_ids = malloc(accum->tool_count * sizeof(char*));
+            tc_names = malloc(accum->tool_count * sizeof(char*));
+            tc_inputs = malloc(accum->tool_count * sizeof(char*));
             for (int i = 0; i < accum->tool_count; i++) {
-                free((void*)result_contents[i]);
+                tc_ids[i] = accum->tools[i].id;
+                tc_names[i] = accum->tools[i].name;
+                tc_inputs[i] = accum->tools[i].input_json.data;
             }
+        }
+        store_conv_add_assistant(agent->paths.conversation,
+                          accum->thinking.data, accum->text.data,
+                          accum->tool_count, tc_ids, tc_names, tc_inputs);
+        free(tc_ids);
+        free(tc_names);
+        free(tc_inputs);
+
+        if (result_ids && result_contents) {
+            store_conv_add_tool_results(agent->paths.conversation, accum->tool_count,
+                                  result_ids, result_contents);
+            for (int i = 0; i < accum->tool_count; i++) free((void *)result_contents[i]);
             free(result_ids);
             free(result_contents);
         }
@@ -2301,7 +2306,6 @@ int agent_compact_context(Agent *agent, const char *trigger) {
         free(summary_body);
         summary_body = openai_body;
     }
-
     /* 发送 summary 请求 */
     const char *headers[8];
     char auth_header[512];

--- a/c/agent.h
+++ b/c/agent.h
@@ -100,7 +100,7 @@ char *agent_build_prompt(Agent *agent);
 int agent_compact_context(Agent *agent, const char *trigger);
 
 /* 从 events.jsonl 重放最近 N 轮事件到 display_queue */
-void agent_replay_events(Agent *agent, int max_turns);
+int agent_replay_events(Agent *agent, int max_turns);
 
 /* 更新终端标题 */
 void agent_update_title(Agent *agent);

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -290,9 +290,10 @@ int main(int argc, char *argv[]) {
         display_thread_start(&display_thread, &dcfg);
 
         /* Replay 最近 10 轮事件（复用 display 线程渲染） */
-        if (!agent->output_format) agent_replay_events(agent, 10);
+        int replayed = 0;
+        if (!agent->output_format) replayed = agent_replay_events(agent, 10);
         /* replay 后输出换行 */
-        if (!agent->output_format) {
+        if (!agent->output_format && replayed) {
             DisplayMessage *dm = malloc(sizeof(DisplayMessage));
             *dm = display_msg_text("\n");
             mq_push(&display_queue, dm);

--- a/c/tools.c
+++ b/c/tools.c
@@ -201,7 +201,16 @@ static ToolResult tool_edit(const char *input_json) {
     memcpy(new_content + prefix_len, new_str, new_len);
     memcpy(new_content + prefix_len + new_len, pos + old_len, suffix_len + 1);
 
-    util_write_file(path, new_content);
+    if (util_write_file(path, new_content) != 0) {
+        r.output = util_strdup("Error: cannot write file");
+        r.exit_code = 1;
+        free(content);
+        free(new_content);
+        free(path);
+        free(old_str);
+        free(new_str);
+        return r;
+    }
 
     /* 生成 diff 摘要 — 对齐 bash 版: diff -u --label a/$label --label b/$label */
     int added = 0, removed = 0;
@@ -573,6 +582,12 @@ static ToolResult tool_bash(const char *input_json, int timeout_secs) {
     return r;
 }
 
+static char *tool_take_buf_or(StrBuf *buf, const char *fallback) {
+    if (buf->data && buf->data[0]) return buf->data;
+    sb_free(buf);
+    return util_strdup(fallback);
+}
+
 static ToolResult tool_glob(const char *input_json, const char *cwd) {
     ToolResult r = {NULL, 0};
     JsonParse jp = json_parse_root(input_json);
@@ -616,8 +631,7 @@ static ToolResult tool_glob(const char *input_json, const char *cwd) {
         buf.data[--buf.len] = '\0';
     }
 
-    r.output = buf.data[0] ? buf.data : util_strdup("(no matches)");
-    if (r.output != buf.data) sb_free(&buf);
+    r.output = tool_take_buf_or(&buf, "");
 
     sb_free(&cmd);
     free(pattern);
@@ -650,7 +664,11 @@ static ToolResult tool_grep(const char *input_json, const char *cwd) {
     sb_init(&cmd);
     sb_append(&cmd, "rg -n --color never --heading ");
     if (context > 0) sb_appendf(&cmd, "-C %d ", context);
-    if (glob_pat && glob_pat[0]) sb_appendf(&cmd, "-g '%s' ", glob_pat);
+    if (glob_pat && glob_pat[0]) {
+        sb_append(&cmd, "-g ");
+        sb_append_json_string(&cmd, glob_pat);
+        sb_append_char(&cmd, ' ');
+    }
     sb_append(&cmd, "-- ");
     sb_append_json_string(&cmd, pattern);
     sb_append(&cmd, " ");
@@ -668,8 +686,7 @@ static ToolResult tool_grep(const char *input_json, const char *cwd) {
         }
         pclose(pipe);
     }
-    r.output = buf.data[0] ? buf.data : util_strdup("(no matches)");
-    if (r.output != buf.data) sb_free(&buf);
+    r.output = tool_take_buf_or(&buf, "");
 
     sb_free(&cmd);
     free(pattern);

--- a/c/tools.c
+++ b/c/tools.c
@@ -611,9 +611,9 @@ static ToolResult tool_glob(const char *input_json, const char *cwd) {
     StrBuf cmd;
     sb_init(&cmd);
     sb_append(&cmd, "rg --files ");
-    sb_append_json_string(&cmd, base);
+    sb_append_shell_arg(&cmd, base);
     sb_append(&cmd, " -g ");
-    sb_append_json_string(&cmd, pattern);
+    sb_append_shell_arg(&cmd, pattern);
     sb_append(&cmd, " 2>/dev/null || true");
 
     FILE *pipe = popen(cmd.data, "r");
@@ -666,13 +666,13 @@ static ToolResult tool_grep(const char *input_json, const char *cwd) {
     if (context > 0) sb_appendf(&cmd, "-C %d ", context);
     if (glob_pat && glob_pat[0]) {
         sb_append(&cmd, "-g ");
-        sb_append_json_string(&cmd, glob_pat);
+        sb_append_shell_arg(&cmd, glob_pat);
         sb_append_char(&cmd, ' ');
     }
     sb_append(&cmd, "-- ");
-    sb_append_json_string(&cmd, pattern);
+    sb_append_shell_arg(&cmd, pattern);
     sb_append(&cmd, " ");
-    sb_append_json_string(&cmd, base);
+    sb_append_shell_arg(&cmd, base);
     sb_append(&cmd, " 2>/dev/null || true");
 
     /* 执行 */

--- a/c/transport.c
+++ b/c/transport.c
@@ -15,6 +15,13 @@ typedef struct {
     size_t cap;
 } CurlBuffer;
 
+typedef struct {
+    int index;
+    char *id;
+    char *name;
+    StrBuf arguments;
+} OpenAIToolAccum;
+
 static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *userdata) {
     CurlBuffer *buf = (CurlBuffer *)userdata;
     size_t total = size * nmemb;
@@ -37,7 +44,147 @@ typedef struct {
     StrBuf line_buf;        /* 累积 SSE 行 */
     char *provider;         /* "claude" 或 "openai" */
     volatile int *cancelled;
+    OpenAIToolAccum *openai_tools;
+    int openai_tool_count;
+    int openai_tool_cap;
 } StreamCtx;
+
+static void emit_simple_event(sse_callback_fn callback, void *ctx,
+                              SseEventType type, const char *content);
+static void fill_openai_usage_event(SseEvent *evt, JsonVal usage);
+
+static void streamctx_free_openai_tools(StreamCtx *sctx) {
+    for (int i = 0; i < sctx->openai_tool_count; i++) {
+        FREE_PTR(sctx->openai_tools[i].id);
+        FREE_PTR(sctx->openai_tools[i].name);
+        sb_free(&sctx->openai_tools[i].arguments);
+    }
+    FREE_PTR(sctx->openai_tools);
+    sctx->openai_tool_count = 0;
+    sctx->openai_tool_cap = 0;
+}
+
+static void streamctx_reset_openai_tool(OpenAIToolAccum *tool) {
+    FREE_PTR(tool->id);
+    FREE_PTR(tool->name);
+    sb_free(&tool->arguments);
+    memset(tool, 0, sizeof(*tool));
+}
+
+static OpenAIToolAccum *streamctx_ensure_openai_tool(StreamCtx *sctx, int idx) {
+    for (int i = 0; i < sctx->openai_tool_count; i++) {
+        if (sctx->openai_tools[i].index == idx) return &sctx->openai_tools[i];
+    }
+    if (sctx->openai_tool_count >= sctx->openai_tool_cap) {
+        int old_cap = sctx->openai_tool_cap;
+        sctx->openai_tool_cap = sctx->openai_tool_cap ? sctx->openai_tool_cap * 2 : 4;
+        sctx->openai_tools = realloc(sctx->openai_tools,
+            (size_t)sctx->openai_tool_cap * sizeof(*sctx->openai_tools));
+        memset(sctx->openai_tools + old_cap, 0,
+            (size_t)(sctx->openai_tool_cap - old_cap) * sizeof(*sctx->openai_tools));
+    }
+    OpenAIToolAccum *tool = &sctx->openai_tools[sctx->openai_tool_count++];
+    tool->index = idx;
+    sb_init(&tool->arguments);
+    return tool;
+}
+
+static void streamctx_emit_openai_tool_calls(StreamCtx *sctx) {
+    for (int i = 0; i < sctx->openai_tool_count; i++) {
+        OpenAIToolAccum *tool = &sctx->openai_tools[i];
+        if (tool->arguments.len == 0) continue;
+        SseEvent evt;
+        memset(&evt, 0, sizeof(evt));
+        evt.type = SSE_TOOL_CALL;
+        evt.tool_id = tool->id ? tool->id : "";
+        evt.tool_name = tool->name ? tool->name : "";
+        evt.tool_input = tool->arguments.data ? tool->arguments.data : "{}";
+        sctx->callback(sctx->ctx, &evt);
+        streamctx_reset_openai_tool(tool);
+    }
+    sctx->openai_tool_count = 0;
+}
+
+static void parse_openai_sse_event(StreamCtx *sctx, const char *data, size_t data_len) {
+    if (data_len == 0) return;
+    if (strcmp(data, "[DONE]") == 0) return;
+
+    size_t pos = 0;
+    JsonParse jp = json_parse(data, &pos);
+    if (jp.error) return;
+
+    char *obj_type = json_get_string(jp.val, "object");
+    if (!obj_type || strcmp(obj_type, "chat.completion.chunk") != 0) {
+        FREE_PTR(obj_type);
+        return;
+    }
+    FREE_PTR(obj_type);
+
+    JsonVal choices = json_get(jp.val, "choices");
+    if (choices.type == JSON_ARRAY) {
+        JsonVal choice = json_array_get(choices, 0);
+        JsonVal delta = json_get(choice, "delta");
+        char *content = json_get_string(delta, "content");
+        if (content) {
+            emit_simple_event(sctx->callback, sctx->ctx, SSE_TEXT, content);
+            FREE_PTR(content);
+        }
+        char *reasoning = json_get_string(delta, "reasoning_content");
+        if (!reasoning) reasoning = json_get_string(delta, "reasoning");
+        if (reasoning) {
+            emit_simple_event(sctx->callback, sctx->ctx, SSE_THINKING, reasoning);
+            FREE_PTR(reasoning);
+        }
+        JsonVal tool_calls = json_get(delta, "tool_calls");
+        if (tool_calls.type == JSON_ARRAY) {
+            int tc_len = json_array_len(tool_calls);
+            for (int i = 0; i < tc_len; i++) {
+                JsonVal tc = json_array_get(tool_calls, i);
+                int idx = json_get_int(tc, "index");
+                JsonVal fn = json_get(tc, "function");
+                OpenAIToolAccum *tool = streamctx_ensure_openai_tool(sctx, idx);
+                char *id = json_get_string(tc, "id");
+                char *name = json_get_string(fn, "name");
+                char *arguments = json_get_string(fn, "arguments");
+                if (id) {
+                    FREE_PTR(tool->id);
+                    tool->id = id;
+                }
+                if (name) {
+                    FREE_PTR(tool->name);
+                    tool->name = name;
+                }
+                if (arguments) {
+                    sb_append(&tool->arguments, arguments);
+                    FREE_PTR(arguments);
+                }
+            }
+        }
+        char *finish = json_get_string(choice, "finish_reason");
+        if (finish) {
+            if (strcmp(finish, "tool_calls") == 0) {
+                streamctx_emit_openai_tool_calls(sctx);
+                emit_simple_event(sctx->callback, sctx->ctx, SSE_STOP, "tool_use");
+            } else if (strcmp(finish, "stop") == 0) {
+                emit_simple_event(sctx->callback, sctx->ctx, SSE_STOP, "end_turn");
+            } else if (strcmp(finish, "length") == 0) {
+                emit_simple_event(sctx->callback, sctx->ctx, SSE_STOP, "max_tokens");
+            } else {
+                emit_simple_event(sctx->callback, sctx->ctx, SSE_STOP, finish);
+            }
+            FREE_PTR(finish);
+        }
+    }
+
+    JsonVal usage = json_get(jp.val, "usage");
+    if (usage.type != JSON_NULL) {
+        SseEvent evt;
+        memset(&evt, 0, sizeof(evt));
+        evt.type = SSE_USAGE;
+        fill_openai_usage_event(&evt, usage);
+        sctx->callback(sctx->ctx, &evt);
+    }
+}
 
 static size_t stream_cb(char *ptr, size_t size, size_t nmemb, void *userdata) {
     StreamCtx *sctx = (StreamCtx *)userdata;
@@ -65,13 +212,13 @@ static size_t stream_cb(char *ptr, size_t size, size_t nmemb, void *userdata) {
 
             if (strncmp(line, "data: ", 6) == 0) {
                 const char *data = line + 6;
-                sse_parse_event(sctx->provider, data, strlen(data),
-                               sctx->callback, sctx->ctx);
+                if (strcmp(sctx->provider, "openai") == 0) parse_openai_sse_event(sctx, data, strlen(data));
+                else sse_parse_event(sctx->provider, data, strlen(data), sctx->callback, sctx->ctx);
             } else if (strncmp(line, "data:", 5) == 0) {
                 const char *data = line + 5;
                 while (*data == ' ') data++;
-                sse_parse_event(sctx->provider, data, strlen(data),
-                               sctx->callback, sctx->ctx);
+                if (strcmp(sctx->provider, "openai") == 0) parse_openai_sse_event(sctx, data, strlen(data));
+                else sse_parse_event(sctx->provider, data, strlen(data), sctx->callback, sctx->ctx);
             }
             /* 重置行缓冲 */
             sb_truncate(&sctx->line_buf, 0);
@@ -182,6 +329,9 @@ int http_post_sse(const char *url, const char **headers, int header_count,
     sb_init(&sctx.line_buf);
     sctx.cancelled = cancelled;
     sctx.provider = (char *)provider;
+    sctx.openai_tools = NULL;
+    sctx.openai_tool_count = 0;
+    sctx.openai_tool_cap = 0;
 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &sctx);
@@ -265,9 +415,38 @@ int http_post_sse(const char *url, const char **headers, int header_count,
                             emit_simple_event(callback, ctx, SSE_TEXT, content);
                             free(content);
                         }
+                        char *reasoning = json_get_string(msg, "reasoning_content");
+                        if (!reasoning) reasoning = json_get_string(msg, "reasoning");
+                        if (reasoning) {
+                            emit_simple_event(callback, ctx, SSE_THINKING, reasoning);
+                            free(reasoning);
+                        }
+                        JsonVal tool_calls = json_get(msg, "tool_calls");
+                        if (tool_calls.type == JSON_ARRAY) {
+                            int tc_len = json_array_len(tool_calls);
+                            for (int i = 0; i < tc_len; i++) {
+                                JsonVal tc = json_array_get(tool_calls, i);
+                                JsonVal fn = json_get(tc, "function");
+                                char *id = json_get_string(tc, "id");
+                                char *name = json_get_string(fn, "name");
+                                char *arguments = json_get_string(fn, "arguments");
+                                SseEvent evt;
+                                memset(&evt, 0, sizeof(evt));
+                                evt.type = SSE_TOOL_CALL;
+                                evt.tool_id = id;
+                                evt.tool_name = name;
+                                evt.tool_input = arguments ? arguments : (char *)"{}";
+                                callback(ctx, &evt);
+                                free(id);
+                                free(name);
+                                free(arguments);
+                            }
+                        }
                         char *finish = json_get_string(choice, "finish_reason");
                         if (finish) {
-                            emit_simple_event(callback, ctx, SSE_STOP, finish);
+                            if (strcmp(finish, "tool_calls") == 0) emit_simple_event(callback, ctx, SSE_STOP, "tool_use");
+                            else if (strcmp(finish, "stop") == 0) emit_simple_event(callback, ctx, SSE_STOP, "end_turn");
+                            else emit_simple_event(callback, ctx, SSE_STOP, finish);
                             free(finish);
                         }
                     }
@@ -285,6 +464,7 @@ int http_post_sse(const char *url, const char **headers, int header_count,
     }
 
     sb_free(&sctx.line_buf);
+    streamctx_free_openai_tools(&sctx);
     curl_slist_free_all(hdrs);
     curl_easy_cleanup(curl);
 
@@ -324,7 +504,7 @@ int sse_parse_event(const char *provider, const char *data, size_t data_len,
                     sse_callback_fn callback, void *ctx) {
     if (data_len == 0) return 0;
     if (strcmp(data, "[DONE]") == 0) {
-        emit_simple_event(callback, ctx, SSE_STOP, "end_turn");
+        if (strcmp(provider, "claude") == 0) emit_simple_event(callback, ctx, SSE_STOP, "end_turn");
         return 0;
     }
 
@@ -339,7 +519,6 @@ int sse_parse_event(const char *provider, const char *data, size_t data_len,
         if (!type) return 0;
 
         if (strcmp(type, "content_block_delta") == 0) {
-            int idx = json_get_int(jp.val, "index");
             JsonVal delta = json_get(jp.val, "delta");
             char *dtype = json_get_string(delta, "type");
             if (dtype && strcmp(dtype, "text_delta") == 0) {
@@ -361,10 +540,8 @@ int sse_parse_event(const char *provider, const char *data, size_t data_len,
                     free(partial);
                 }
             }
-            (void)idx;
             free(dtype);
         } else if (strcmp(type, "content_block_start") == 0) {
-            int idx = json_get_int(jp.val, "index");
             JsonVal cb = json_get(jp.val, "content_block");
             char *cb_type = json_get_string(cb, "type");
             if (cb_type && strcmp(cb_type, "tool_use") == 0) {
@@ -380,7 +557,6 @@ int sse_parse_event(const char *provider, const char *data, size_t data_len,
                 free(id);
                 free(name);
             }
-            (void)idx;
             free(cb_type);
         } else if (strcmp(type, "content_block_stop") == 0) {
             /* 工具调用完成 — 由累积器在收到 stop 后统一处理 */
@@ -441,10 +617,49 @@ int sse_parse_event(const char *provider, const char *data, size_t data_len,
                     emit_simple_event(callback, ctx, SSE_TEXT, content);
                     free(content);
                 }
+                char *reasoning = json_get_string(delta, "reasoning_content");
+                if (!reasoning) reasoning = json_get_string(delta, "reasoning");
+                if (reasoning) {
+                    emit_simple_event(callback, ctx, SSE_THINKING, reasoning);
+                    free(reasoning);
+                }
+                JsonVal tool_calls = json_get(delta, "tool_calls");
+                if (tool_calls.type == JSON_ARRAY) {
+                            int tc_len = json_array_len(tool_calls);
+                            for (int i = 0; i < tc_len; i++) {
+                                JsonVal tc = json_array_get(tool_calls, i);
+                                JsonVal fn = json_get(tc, "function");
+                                char *id = json_get_string(tc, "id");
+                                char *name = json_get_string(fn, "name");
+                        char *arguments = json_get_string(fn, "arguments");
+                        if (id || name) {
+                            SseEvent evt;
+                            memset(&evt, 0, sizeof(evt));
+                            evt.type = SSE_TOOL_CALL_START;
+                            evt.tool_id = id;
+                            evt.tool_name = name;
+                            callback(ctx, &evt);
+                        }
+                        if (arguments) {
+                            SseEvent evt;
+                            memset(&evt, 0, sizeof(evt));
+                            evt.type = SSE_TOOL_INPUT_DELTA;
+                            evt.content = arguments;
+                            callback(ctx, &evt);
+                        }
+                        free(id);
+                        free(name);
+                        free(arguments);
+                    }
+                }
                 char *finish = json_get_string(choice, "finish_reason");
                 if (finish) {
                     if (strcmp(finish, "tool_calls") == 0) {
                         emit_simple_event(callback, ctx, SSE_STOP, "tool_use");
+                    } else if (strcmp(finish, "stop") == 0) {
+                        emit_simple_event(callback, ctx, SSE_STOP, "end_turn");
+                    } else if (strcmp(finish, "length") == 0) {
+                        emit_simple_event(callback, ctx, SSE_STOP, "max_tokens");
                     } else {
                         emit_simple_event(callback, ctx, SSE_STOP, finish);
                     }
@@ -508,22 +723,20 @@ void sse_accum_callback(void *ctx, const SseEvent *evt) {
         break;
 
     case SSE_TOOL_CALL_START: {
-        /* 新工具调用开始 */
         if (acc->tool_count >= acc->tool_cap) {
             acc->tool_cap *= 2;
             acc->tools = realloc(acc->tools, acc->tool_cap * sizeof(ToolCallAccum));
         }
         ToolCallAccum *tc = &acc->tools[acc->tool_count];
         memset(tc, 0, sizeof(*tc));
+        sb_init(&tc->input_json);
         tc->id = util_strdup(evt->tool_id);
         tc->name = util_strdup(evt->tool_name);
-        sb_init(&tc->input_json);
         acc->tool_count++;
         break;
     }
 
     case SSE_TOOL_INPUT_DELTA: {
-        /* 追加到当前最后一个工具调用的 input_json */
         if (acc->tool_count > 0 && evt->content) {
             sb_append(&acc->tools[acc->tool_count - 1].input_json, evt->content);
         }
@@ -846,6 +1059,7 @@ char *convert_to_openai(const char *claude_body) {
             sb_init(&with_system);
             sb_append(&with_system, "[{\"role\":\"system\",\"content\":");
             sb_append_json_string(&with_system, sys);
+            sb_append_char(&with_system, '}');
             if (messages.len > 2) {
                 sb_append_char(&with_system, ',');
                 sb_appendn(&with_system, messages.data + 1, messages.len - 2);

--- a/c/util.c
+++ b/c/util.c
@@ -102,6 +102,19 @@ void sb_append_json_string(StrBuf *sb, const char *src) {
     sb_append_char(sb, '"');
 }
 
+void sb_append_shell_arg(StrBuf *sb, const char *src) {
+    if (!src) {
+        sb_append(sb, "''");
+        return;
+    }
+    sb_append_char(sb, '\'');
+    for (; *src; src++) {
+        if (*src == '\'') sb_append(sb, "'\\''");
+        else sb_append_char(sb, *src);
+    }
+    sb_append_char(sb, '\'');
+}
+
 /* ============================================================
  * 工具函数
  * ============================================================ */

--- a/c/util.h
+++ b/c/util.h
@@ -27,6 +27,8 @@ void sb_truncate(StrBuf *sb, size_t len);
 
 /* JSON 字符串转义：将 src 转义后追加到 sb */
 void sb_append_json_string(StrBuf *sb, const char *src);
+/* shell 参数转义：将 src 作为单个 shell 参数安全追加到 sb */
+void sb_append_shell_arg(StrBuf *sb, const char *src);
 
 /* 生成 session id: YYYYMMDD-HHMMSS-XXXX */
 char *util_new_session_id(void);

--- a/go/transport.go
+++ b/go/transport.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -151,8 +152,8 @@ func (t *HTTPTransport) parseSSEStream(resp *http.Response, ch chan<- Event) {
 	var inputTokens, outputTokens, cacheRead, cacheCreate int
 
 	// OpenAI 流状态
-	var openaiToolName, openaiToolID, openaiPartialArgs string
 	var openaiTextStarted bool // 是否已收到过非空前导换行的文本
+	openaiPendingCalls := map[int]*openAIPendingCall{}
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -171,7 +172,7 @@ func (t *HTTPTransport) parseSSEStream(resp *http.Response, ch chan<- Event) {
 			// ─── OpenAI 格式检测：如果有 choices 字段，按 OpenAI 格式处理 ───
 			if strings.Contains(data, `"choices"`) || data == "[DONE]" {
 				t.handleOpenAIChunk(data, ch,
-					&openaiToolName, &openaiToolID, &openaiPartialArgs,
+					openaiPendingCalls,
 					&openaiTextStarted,
 					&stopReason,
 					&inputTokens, &outputTokens, &cacheRead, &cacheCreate)
@@ -239,19 +240,39 @@ func (t *HTTPTransport) parseSSEStream(resp *http.Response, ch chan<- Event) {
 	}
 }
 
+type openAIPendingCall struct {
+	ID        string
+	Name      string
+	Arguments string
+}
+
+func emitOpenAIPendingCalls(ch chan<- Event, pending map[int]*openAIPendingCall) {
+	keys := make([]int, 0, len(pending))
+	for idx := range pending {
+		keys = append(keys, idx)
+	}
+	sort.Ints(keys)
+	for _, idx := range keys {
+		call := pending[idx]
+		if call == nil || call.Arguments == "" {
+			continue
+		}
+		ch <- Event{Type: EventToolCall, Fields: []string{"TOOL_CALL", call.Name, call.ID, call.Arguments}}
+	}
+	for k := range pending {
+		delete(pending, k)
+	}
+}
+
 // handleOpenAIChunk 处理 OpenAI chat.completion.chunk 格式的 SSE 数据
 func (t *HTTPTransport) handleOpenAIChunk(data string, ch chan<- Event,
-	toolName, toolID, partialArgs *string,
+	pending map[int]*openAIPendingCall,
 	textStarted *bool,
 	stopReason *string,
 	inputTokens, outputTokens, cacheRead, cacheCreate *int) {
 
 	if data == "[DONE]" {
-		// 发送 tool_calls 结束（如果有未完成的）
-		if *partialArgs != "" {
-			ch <- Event{Type: EventToolCall, Fields: []string{"TOOL_CALL", *toolName, *toolID, *partialArgs}}
-			*partialArgs = ""
-		}
+		emitOpenAIPendingCalls(ch, pending)
 		// 映射 stop reason
 		sr := *stopReason
 		switch sr {
@@ -342,17 +363,23 @@ func (t *HTTPTransport) handleOpenAIChunk(data string, ch chan<- Event,
 
 	// tool_calls
 	for _, tc := range choice.Delta.ToolCalls {
-		if tc.ID != "" {
-			// 新 tool call 开始 — 如果之前有未完成的，先发送
-			if *partialArgs != "" {
-				ch <- Event{Type: EventToolCall, Fields: []string{"TOOL_CALL", *toolName, *toolID, *partialArgs}}
-			}
-			*toolName = tc.Function.Name
-			*toolID = tc.ID
-			*partialArgs = tc.Function.Arguments
-		} else if tc.Function.Arguments != "" {
-			*partialArgs += tc.Function.Arguments
+		call := pending[tc.Index]
+		if call == nil {
+			call = &openAIPendingCall{}
+			pending[tc.Index] = call
 		}
+		if tc.ID != "" {
+			call.ID = tc.ID
+		}
+		if tc.Function.Name != "" {
+			call.Name = tc.Function.Name
+		}
+		if tc.Function.Arguments != "" {
+			call.Arguments += tc.Function.Arguments
+		}
+	}
+	if choice.FinishReason != nil && *choice.FinishReason == "tool_calls" {
+		emitOpenAIPendingCalls(ch, pending)
 	}
 }
 

--- a/src/awk/transport_openai_body.awk
+++ b/src/awk/transport_openai_body.awk
@@ -190,7 +190,7 @@ function convert_tools(tools_json,    n, tdefs, result, i, td, name, desc, param
         if (params == "") params = extract_value(td, "parameters")
         if (params == "") params = "{}"
         if (i > 1) result = result ","
-        result = result "{\"type\":\"function\",\"function\":{\"name\":\"" name "\",\"description\":\"" desc "\",\"parameters\":" params "}}"
+        result = result "{\"type\":\"function\",\"function\":{\"name\":\"" escape_json_string(name) "\",\"description\":\"" escape_json_string(desc) "\",\"parameters\":" params "}}"
     }
     result = result "]"
     return result

--- a/tests/fixtures/mock_server.py
+++ b/tests/fixtures/mock_server.py
@@ -327,6 +327,31 @@ class H(http.server.BaseHTTPRequestHandler):
                 else:
                     self.send_response(422); self.end_headers(); w.write(b'missing Glob tool_result content')
             return
+        if b'GLOB_NO_MATCH_MARKER' in body and b'"tool_result"' not in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_glob_none\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"I will search for matching files.\"}}\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_glob_none_1\",\"name\":\"Glob\",\"input\":{}}}\n\n',
+                    'event: content_block_delta\ndata: ' + json.dumps({'type':'content_block_delta','index':1,'delta':{'type':'input_json_delta','partial_json': json.dumps({'pattern':'*.missing','path':'/tmp/bash-agent-glob-nomatch-test'})}}) + '\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":20}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
+        if b'GLOB_NO_MATCH_MARKER' in body and b'"tool_result"' in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_glob_none_done\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Glob no-match complete.\"}}\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
         if b'GREP_MARKER' in body and b'"tool_result"' not in body:
             if path.startswith('/v1/messages'):
                 for c in [
@@ -354,6 +379,31 @@ class H(http.server.BaseHTTPRequestHandler):
                     ]: w.write(c.encode()); w.flush()
                 else:
                     self.send_response(422); self.end_headers(); w.write(b'missing Grep tool_result content')
+            return
+        if b'GREP_NO_MATCH_MARKER' in body and b'"tool_result"' not in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_grep_none\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"I will search file contents.\"}}\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_grep_none_1\",\"name\":\"Grep\",\"input\":{}}}\n\n',
+                    'event: content_block_delta\ndata: ' + json.dumps({'type':'content_block_delta','index':1,'delta':{'type':'input_json_delta','partial_json': json.dumps({'pattern':'needle','path':'/tmp/bash-agent-grep-nomatch-test','glob':'*.txt'})}}) + '\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":20}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
+        if b'GREP_NO_MATCH_MARKER' in body and b'"tool_result"' in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_grep_none_done\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Grep no-match complete.\"}}\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
             return
         if b'READ_OFFSET_LIMIT_MARKER' in body and b'"tool_result"' not in body:
             if path.startswith('/v1/messages'):
@@ -612,7 +662,7 @@ class H(http.server.BaseHTTPRequestHandler):
                 else:
                     self.send_response(422); self.end_headers(); w.write(b'missing code snippet edit tool_result content')
             return
-        if b'WRITE_FILE_MARKER' in body and b'"tool_result"' not in body:
+        if b'WRITE_FILE_MARKER' in body and b'"tool_result"' not in body and b'"role":"tool"' not in body:
             if path.startswith('/v1/messages'):
                 for c in [
                     'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_write\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
@@ -628,6 +678,8 @@ class H(http.server.BaseHTTPRequestHandler):
             elif path.startswith('/v1/chat/completions'):
                 for c in [
                     'data: {\"id\":\"chatcmpl-write\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"I will write the file now.\"},\"finish_reason\":null}]}\n\n',
+                    'data: {\"id\":\"chatcmpl-write\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_write_1\",\"type\":\"function\",\"function\":{\"name\":\"Write\",\"arguments\":\"{\\\"path\\\":\\\"/tmp/bash-agent-write-test.txt\\\"\"}}]},\"finish_reason\":null}]}\n\n',
+                    'data: {\"id\":\"chatcmpl-write\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\",\\\"content\\\":\\\"line1\\\\nline2\\\\nline3\\\"}\"}}]},\"finish_reason\":null}]}\n\n',
                     'data: {\"id\":\"chatcmpl-write\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":12}}\n\n',
                     'data: [DONE]\n\n',
                 ]: w.write(c.encode()); w.flush()
@@ -657,7 +709,7 @@ class H(http.server.BaseHTTPRequestHandler):
                     'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
                 ]: w.write(c.encode()); w.flush()
             return
-        if b'WRITE_FILE_MARKER' in body and b'"tool_result"' in body:
+        if b'WRITE_FILE_MARKER' in body and (b'"tool_result"' in body or b'"role":"tool"' in body):
             if path.startswith('/v1/messages'):
                 for c in [
                     'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_write_done\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
@@ -1200,7 +1252,7 @@ class H(http.server.BaseHTTPRequestHandler):
                 ]: w.write(c.encode()); w.flush()
             return
         # --- End SubAgent mock ---
-        if b'MULTI_TOOL_MARKER' in body and b'"tool_result"' not in body:
+        if b'MULTI_TOOL_MARKER' in body and b'"tool_result"' not in body and b'"role":"tool"' not in body:
             if path.startswith('/v1/messages'):
                 for c in [
                     'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_multi_tool\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
@@ -1216,8 +1268,16 @@ class H(http.server.BaseHTTPRequestHandler):
                     'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":20}}\n\n',
                     'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
                 ]: w.write(c.encode()); w.flush()
+            elif path.startswith('/v1/chat/completions'):
+                for c in [
+                    'data: {\"id\":\"chatcmpl-multi\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Running two tools.\"},\"finish_reason\":null}]}\n\n',
+                    'data: {\"id\":\"chatcmpl-multi\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_multi_read\",\"type\":\"function\",\"function\":{\"name\":\"Read\",\"arguments\":\"{\\\"path\\\":\\\"/tmp/bash-agent-multi-read.txt\\\"}\"}},{\"index\":1,\"id\":\"call_multi_bash\",\"type\":\"function\",\"function\":{\"name\":\"Bash\",\"arguments\":\"{\\\"command\\\":\\\"echo \"}}]},\"finish_reason\":null}]}\n\n',
+                    'data: {\"id\":\"chatcmpl-multi\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"multi-bash-ok\\\"}\"}}]},\"finish_reason\":null}]}\n\n',
+                    'data: {\"id\":\"chatcmpl-multi\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20}}\n\n',
+                    'data: [DONE]\n\n',
+                ]: w.write(c.encode()); w.flush()
             return
-        if b'MULTI_TOOL_MARKER' in body and b'"tool_result"' in body:
+        if b'MULTI_TOOL_MARKER' in body and (b'"tool_result"' in body or b'"role":"tool"' in body):
             if path.startswith('/v1/messages'):
                 if b'multi-read-content' in body and b'multi-bash-ok' in body:
                     for c in [
@@ -1227,6 +1287,15 @@ class H(http.server.BaseHTTPRequestHandler):
                         'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
                         'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n',
                         'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                    ]: w.write(c.encode()); w.flush()
+                else:
+                    self.send_response(422); self.end_headers(); w.write(b'missing one of the multi-tool results')
+            elif path.startswith('/v1/chat/completions'):
+                if b'multi-read-content' in body and b'multi-bash-ok' in body:
+                    for c in [
+                        'data: {\"id\":\"chatcmpl-multi-done\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Multi-tool complete.\"},\"finish_reason\":null}]}\n\n',
+                        'data: {\"id\":\"chatcmpl-multi-done\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":2}}\n\n',
+                        'data: [DONE]\n\n',
                     ]: w.write(c.encode()); w.flush()
                 else:
                     self.send_response(422); self.end_headers(); w.write(b'missing one of the multi-tool results')

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -462,13 +462,60 @@ test_agent_openai_request_body() {
     local req body
     req=$(curl -fsS "$BASE/last-request")
     body=$(printf '%s' "$req" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["body"])')
-    if echo "$body" | grep -Fq '"role":"system"' && \
-       echo "$body" | grep -Fq '"type":"function"' && \
-       echo "$body" | grep -Fq '"parameters":' && \
+    if printf '%s' "$body" | /usr/bin/python3 -c '
+import json, sys
+obj = json.loads(sys.stdin.read())
+assert obj["messages"][0]["role"] == "system"
+assert len(obj.get("tools", [])) > 0
+assert obj["tools"][0]["type"] == "function"
+assert "parameters" in obj["tools"][0]["function"]
+' 2>/dev/null && \
        ! echo "$body" | grep -Fq '"input_schema"'; then
         green "Agent OpenAI request body carries converted tools"; ((PASS++)) || true
     else
         red "Agent OpenAI request body carries converted tools"; echo "  Body: $body"; ((FAIL++)) || true
+    fi
+}
+
+test_agent_openai_tool_write() {
+    info "Test 11b: Agent e2e OpenAI tool call"
+    local output target_file plain_output
+    target_file="/tmp/bash-agent-write-test.txt"
+    rm -f "$target_file"
+    output=$("$AGENT" -p openai --base-url "$BASE/v1" -m test --api-key test -v 'WRITE_FILE_MARKER' 2>&1) || true
+    plain_output=$(printf '%s' "$output" | sed 's/\x1B\[[0-9;]*[[:alpha:]]//g')
+    if [[ -f "$target_file" ]] && \
+       grep -q $'line1\nline2\nline3' "$target_file" && \
+       echo "$plain_output" | grep -Fq 'Write(/tmp/bash-agent-write-test.txt) [' && \
+       echo "$plain_output" | grep -Fq 'Done.'; then
+        green "Agent e2e OpenAI tool call"; ((PASS++)) || true
+    else
+        red "Agent e2e OpenAI tool call"; echo "  Output: $output"; echo "  File: $(cat "$target_file" 2>/dev/null || true)"; ((FAIL++)) || true
+    fi
+    rm -f "$target_file"
+}
+
+test_agent_tool_result_persist_order() {
+    info "Test 11c: assistant tool_use persisted before following tool_result"
+    local output session_id conv_file
+    session_id="persist-order-openai"
+    conv_file="$BASH_AGENT_HOME/.bash-agent/projects/$(cd "$ROOT_DIR" && project_key)/$session_id/conversation.jsonl"
+    rm -rf "$(dirname "$conv_file")/$session_id"
+    output=$("$AGENT" --session "$session_id" -p openai --base-url "$BASE/v1" -m test --api-key test 'WRITE_FILE_MARKER' 2>&1) || true
+    if [[ -f "$conv_file" ]] && /usr/bin/python3 - "$conv_file" <<'PY' >/dev/null 2>&1
+import json, sys
+lines = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+for i in range(len(lines) - 1):
+    cur, nxt = lines[i], lines[i + 1]
+    if cur.get("role") == "assistant" and any(b.get("type") == "tool_use" for b in cur.get("content", [])):
+        if nxt.get("role") == "user" and nxt.get("content") and all(b.get("type") == "tool_result" for b in nxt["content"]):
+            sys.exit(0)
+sys.exit(1)
+PY
+    then
+        green "assistant tool_use persisted before following tool_result"; ((PASS++)) || true
+    else
+        red "assistant tool_use persisted before following tool_result"; echo "  Output: $output"; echo "  Conversation: $(cat "$conv_file" 2>/dev/null || true)"; ((FAIL++)) || true
     fi
 }
 
@@ -721,9 +768,41 @@ test_agent_grep() {
     rm -rf "$target_dir"
 }
 
-# Test 20a: Read with offset/limit
+test_agent_glob_no_match() {
+    info "Test 20: Agent.sh glob no-match"
+    local output target_dir
+    target_dir="/tmp/bash-agent-glob-nomatch-test"
+    rm -rf "$target_dir"
+    mkdir -p "$target_dir"
+    printf 'a\n' > "$target_dir/alpha.txt"
+    output=$("$AGENT" -p claude --base-url "$BASE/v1" -m test --api-key test 'GLOB_NO_MATCH_MARKER' 2>&1) || true
+    if echo "$output" | grep -q "Glob no-match complete."; then
+        green "Agent glob no-match"; ((PASS++)) || true
+    else
+        red "Agent glob no-match"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+    rm -rf "$target_dir"
+}
+
+test_agent_grep_no_match() {
+    info "Test 20a: Agent.sh grep no-match"
+    local output target_dir
+    target_dir="/tmp/bash-agent-grep-nomatch-test"
+    rm -rf "$target_dir"
+    mkdir -p "$target_dir"
+    printf 'other line\n' > "$target_dir/alpha.txt"
+    output=$("$AGENT" -p claude --base-url "$BASE/v1" -m test --api-key test 'GREP_NO_MATCH_MARKER' 2>&1) || true
+    if echo "$output" | grep -q "Grep no-match complete."; then
+        green "Agent grep no-match"; ((PASS++)) || true
+    else
+        red "Agent grep no-match"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+    rm -rf "$target_dir"
+}
+
+# Test 20b: Read with offset/limit
 test_agent_read_offset_limit() {
-    info "Test 20a: Agent.sh Read with offset/limit"
+    info "Test 20b: Agent.sh Read with offset/limit"
     local output target_file
     target_file="/tmp/bash-agent-read-offset-limit.txt"
     rm -f "$target_file"
@@ -737,9 +816,9 @@ test_agent_read_offset_limit() {
     rm -f "$target_file"
 }
 
-# Test 20b: Bash with per-call timeout
+# Test 20c: Bash with per-call timeout
 test_agent_bash_timeout() {
-    info "Test 20b: Agent.sh Bash with timeout parameter"
+    info "Test 20c: Agent.sh Bash with timeout parameter"
     local output
     output=$("$AGENT" -p claude --base-url "$BASE/v1" -m test --api-key test 'BASH_TIMEOUT_MARKER' 2>&1) || true
     if echo "$output" | grep -q "Bash timeout complete."; then
@@ -749,9 +828,9 @@ test_agent_bash_timeout() {
     fi
 }
 
-# Test 20c: Grep with context parameter
+# Test 20d: Grep with context parameter
 test_agent_grep_context() {
-    info "Test 20c: Agent.sh Grep with context parameter"
+    info "Test 20d: Agent.sh Grep with context parameter"
     local output target_dir
     target_dir="/tmp/bash-agent-grep-context-test"
     rm -rf "$target_dir"
@@ -993,6 +1072,20 @@ test_agent_multiple_tool_calls() {
         green "Agent multiple tool calls"; ((PASS++)) || true
     else
         red "Agent multiple tool calls"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+    rm -f "$target_file"
+}
+
+test_agent_multiple_tool_calls_openai() {
+    info "Test 27a: Agent.sh multiple tool calls in one turn (OpenAI)"
+    local output target_file
+    target_file="/tmp/bash-agent-multi-read.txt"
+    printf 'multi-read-content\n' > "$target_file"
+    output=$("$AGENT" -p openai --base-url "$BASE/v1" -m test --api-key test 'MULTI_TOOL_MARKER' 2>&1) || true
+    if echo "$output" | grep -q "Multi-tool complete."; then
+        green "Agent multiple tool calls (OpenAI)"; ((PASS++)) || true
+    else
+        red "Agent multiple tool calls (OpenAI)"; echo "  Output: $output"; ((FAIL++)) || true
     fi
     rm -f "$target_file"
 }
@@ -2347,6 +2440,8 @@ test_transport_body_tools
 test_agent_e2e_claude
 test_agent_e2e_openai
 test_agent_openai_request_body
+test_agent_openai_tool_write
+test_agent_tool_result_persist_order
 test_agent_skill_injection
 test_agent_skill_injection_from_repo_skills_dir
 test_agent_skill_index
@@ -2359,6 +2454,8 @@ test_agent_read_tool_arg_parsing
 test_agent_read_file_long_result
 test_agent_glob
 test_agent_grep
+test_agent_glob_no_match
+test_agent_grep_no_match
 test_agent_read_offset_limit
 test_agent_bash_timeout
 test_agent_grep_context
@@ -2380,6 +2477,7 @@ test_agent_stream_tool_call
 test_agent_stream_usage_event
 test_agent_tool_result_multiline_url
 test_agent_multiple_tool_calls
+test_agent_multiple_tool_calls_openai
 test_agent_write_file_unicode
 test_json_escape_unicode_multiline
 test_json_extract_top_level_member

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -459,21 +459,27 @@ test_agent_e2e_openai() {
 test_agent_openai_request_body() {
     info "Test 11a: Agent OpenAI request body carries converted tools"
     "$AGENT" -p openai --base-url "$BASE/v1" -m test --api-key test 'Hello' >/dev/null 2>&1 || true
-    local req body
+    local req check_output
     req=$(curl -fsS "$BASE/last-request")
-    body=$(printf '%s' "$req" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["body"])')
-    if printf '%s' "$body" | /usr/bin/python3 -c '
+    check_output=$(printf '%s' "$req" | /usr/bin/python3 -c '
 import json, sys
-obj = json.loads(sys.stdin.read())
-assert obj["messages"][0]["role"] == "system"
-assert len(obj.get("tools", [])) > 0
-assert obj["tools"][0]["type"] == "function"
-assert "parameters" in obj["tools"][0]["function"]
-' 2>/dev/null && \
-       ! echo "$body" | grep -Fq '"input_schema"'; then
+req = json.load(sys.stdin)
+obj = json.loads(req["body"])
+assert obj["messages"][0]["role"] == "system", "first message role is not system"
+tools = obj.get("tools", [])
+assert tools, "tools array is empty"
+assert tools[0]["type"] == "function", "first tool type is not function"
+assert "parameters" in tools[0]["function"], "first tool missing function.parameters"
+for i, tool in enumerate(tools):
+    assert "input_schema" not in tool, f"tool[{i}] still has top-level input_schema"
+    fn = tool.get("function", {})
+    assert "input_schema" not in fn, f"tool[{i}].function still has input_schema"
+print("ok")
+' 2>&1)
+    if [[ "$check_output" == "ok" ]]; then
         green "Agent OpenAI request body carries converted tools"; ((PASS++)) || true
     else
-        red "Agent OpenAI request body carries converted tools"; echo "  Body: $body"; ((FAIL++)) || true
+        red "Agent OpenAI request body carries converted tools"; echo "  Check: $check_output"; ((FAIL++)) || true
     fi
 }
 


### PR DESCRIPTION
  ## 变更内容

  这次主要修复 C 版本在 OpenAI 兼容路径和工具结果处理上的两类问题：

  1. OpenAI 工具调用链不完整，真实兼容端下会出现不触发工具、工具调用后崩溃、或后续请求失败
  2. C 版部分工具结果处理与 Bash/Go/Rust 不一致，空结果和写回失败路径存在实现缺陷

  ## 具体修复

  ### 1. 修复 C 版 OpenAI Chat 请求/响应兼容链
  - 修复 Claude body -> OpenAI body 转换中的 JSON 构造错误
  - 补齐 C 版 OpenAI SSE 兼容层
    - 在 transport 层内部将 OpenAI chunk 转成统一事件
    - `tool_calls` 按 `index` 聚合，再向上发完整 tool call
  - 修复长会话 follow-up/tool_result 路径在 OpenAI 模式下的兼容问题
  - 同时将 Go 版 OpenAI 多 tool call 分片聚合改为按 `index` 处理，和 Rust/C 保持一致

  ### 2. 修复 C 版工具结果处理
  - 修复 `Glob` / `Grep` 空输出时对 `buf.data[0]` 的空指针解引用
  - 将 `StrBuf -> ToolResult.output` 的收尾提成公共 helper，避免同类问题重复出现
  - 对齐 Bash 主版本语义：
    - `Glob` / `Grep` no-match 返回空字符串，不强行返回 `(no matches)`

  ### 3. 修复 C 版 Edit 写回失败路径
  - `tool_edit()` 原来即使 `util_write_file()` 失败也会继续生成 diff 并返回成功
  - 现在写回失败会直接返回：
    - `Error: cannot write file`

  ### 4. 对齐 C 版持久化顺序
  - C 版原来先写 assistant(tool_use)，再执行工具，再写 tool_result
  - 现在改成和 Bash / Go / Rust 一致：
    - 先执行工具
    - 再写 assistant(tool_use)
    - 再写 tool_result
  - 避免工具执行中途崩溃时留下半截 conversation 状态

  ## 测试补充

  新增/补强了这几类回归：

  - OpenAI request body 转换检查
  - OpenAI tool call e2e
  - OpenAI 多工具同轮调用 e2e
  - `Glob` no-match e2e
  - `Grep` no-match e2e
  - assistant `tool_use` 与后续 `tool_result` 的持久化顺序检查

  mock server 也同步补强，支持更真实的 OpenAI `delta.tool_calls` 分片。

  ## 验证

  已验证：

  - `make build-c`
  - `/bin/zsh -lc 'AGENT=./dist/cagent bash tests/test.sh 9904'`

  结果：

  - `130 passed, 0 failed`

  补充说明：

  - 这次提交里也包含当前工作区这条问题链上已经完成的 C/OpenAI/tool/test 对齐改动，不再拆成更小的几段提交。
  - Go / Rust 我有检查同类问题：
    - Go 的 OpenAI 多 tool call 聚合缺口已经一并修复
    - Rust 这条 `index` 聚合逻辑原本就是正确的