### PR TITLE
修复 compact 后 current_turn_count 被错误重置的问题

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -2384,13 +2384,11 @@ int agent_compact_context(Agent *agent, const char *trigger) {
     /* 截断 conversation */
     store_conv_trim_tail(agent->paths.conversation, keep);
 
-    /* 更新 stats（与 bash 版一致：compact_request_count+1, current_turn_count=remaining,
-     * 累加 compact 的 token 消耗到 total_* — 对齐 agent_record_usage "compact"） */
+    /* 更新 stats（compact_request_count+1，累加 compact 的 token 消耗到 total_*）
+     * 注意：不再重置 current_turn_count — 它应始终保持 session 累计计数 */
     {
-        int remaining = store_conv_user_turn_count(agent->paths.conversation);
         store_stats_set_int_file(agent->paths.stats, "compact_request_count",
             store_stats_get_file_int(agent->paths.stats, "compact_request_count") + 1);
-        store_stats_set_int_file(agent->paths.stats, "current_turn_count", remaining);
         /* 累加 compact 的 token 消耗（对齐 bash 版 agent_record_usage） */
         store_stats_set_int_file(agent->paths.stats, "total_input_tokens",
             store_stats_get_file_int(agent->paths.stats, "total_input_tokens") + compact_in);

--- a/go/agent.go
+++ b/go/agent.go
@@ -471,9 +471,7 @@ func (a *Agent) CompactContext(ctx context.Context, trigger string) (bool, error
 		_ = a.store.UpdateCompactStats(summaryUsage)
 	}
 
-	// 重置 turn count 为剩余 user turn 数（与 bash 版一致）
-	remainingTurns, _ := a.store.ConvUserTurnCount()
-	_ = a.store.SetTurnCount(remainingTurns)
+	// 注意：不再重置 current_turn_count — 它应始终保持 session 累计计数
 
 	return true, nil
 }

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -1533,10 +1533,10 @@ impl Agent {
         store::store_summary_set(&self.paths, &summary)?;
         self.conv.trim_keep_last(k)?;
 
-        // Recalculate turn count based on remaining conversation history
-        if let Ok(remaining_turns) = self.conv.count_user_inputs() {
+        // 注意：不再重置 current_turn_count — 它应始终保持 session 累计计数
+        // 只更新 last_updated 和 terminal title
+        if let Ok(_) = self.conv.count_user_inputs() {
             store::store_stats_update(&self.paths.stats, |stats| {
-                Self::set_stat_usize(stats, "current_turn_count", remaining_turns as usize);
                 stats.insert(
                     "last_updated".to_string(),
                     Value::String(chrono_now_rfc3339()),

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1130,9 +1130,7 @@ agent_compact_context() {
         store_conv_trim_tail "$keep_lines"
     fi
     rm -f "$tmp_dropped"
-    local remaining_turns
-    remaining_turns=$(store_conv_user_turn_count)
-    store_stats_update current_turn_count=$remaining_turns
+    # 注意：不再重置 current_turn_count — 它应始终保持 session 累计计数
     return 0
 }
 


### PR DESCRIPTION
## 问题描述
在 `agent_compact_context` 函数中，`current_turn_count` 被**错误重置**为 0，导致：

- 会话轮次计数在压缩后清零，破坏了 session 全局计数的连续性
- 后续的轮次统计和 token 估算基于错误的计数基准
- 违反了 `current_turn_count` 应该作为**session 全局累计计数**的设计原则

## 根本原因
`current_turn_count` 应该在整个 session 生命周期内**单调递增**，记录从会话开始到当前的**总轮次数**，而不是记录"自上次压缩以来的轮次数"。

## 解决方案
**移除重置逻辑**，并添加明确的注释说明：

```bash
# 注意：不再重置 current_turn_count
# 它应始终保持 session 累计计数（从 1 开始），而非自上次 compact 以来的计数
```

## 影响范围
修复应用于**所有运行时版本**：
- ✅ Bash: `src/agent.sh`
- ✅ Go: `go/agent.go`
- ✅ Rust: `rust/src/agent.rs`
- ✅ C: `c/agent.c`

## 验证方法
1. 启动一个长会话（超过 compact 阈值）
2. 触发 context compact（通常在 16 轮左右）
3. 检查 compact 后的 `current_turn_count` **继续递增**，而非重置为 1
4. 验证 token 估算和轮次显示保持正确

## 相关文件
- `CHANGELOG.md`：记录修复详情
- 所有运行时的 `agent_compact_context` 函数
```

**简短版（可选）**
```markdown
## 修复
移除 `agent_compact_context` 中对 `current_turn_count` 的错误重置逻辑，保持其作为 session 全局累计计数。

## 影响范围
Bash / Go / Rust / C 四个运行时版本

## 验证
长会话 compact 后，轮次计数继续递增，不重置为 1