### PR TITLE
feat: 图片粘贴支持 ([Image #N]) + GLM-4V-Flash 自动描述 + 跨版本同步 (Bash/Go/C/Rust)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@
 
 ## [Unreleased]
 
+> **Feature 版本**：新增图片粘贴支持 — Ctrl+V 贴图，自动调用 GLM-4V-Flash 转录/描述，四版本同步实现。
+
+### Added
+
+- **图片粘贴支持**：终端交互模式下 **Ctrl+V** 从剪贴板粘贴图片，自动插入 `[Image #N]` 占位符并保存到 session 缓存。跨平台支持 macOS (osascript)、Wayland (wl-paste)、X11 (xclip)
+- **自动图片描述**：发送消息时收集所有 `[Image #N]` 图片，一次性调用 **GLM-4V-Flash**（免费视觉模型）获取文本转录/描述，以 `<attached-images>` XML 标签追加到用户输入末尾
+- **新增环境变量**：`DESCRIBE_API_KEY` / `DESCRIBE_MODEL`（默认 `glm-4v-flash`） / `DESCRIBE_BASE_URL`（默认 `https://open.bigmodel.cn/api/paas/v4`），统一前缀配置图片描述 API
+- **linenoise 新增 `linenoiseSetImagePasteCallback()` API**：三个版本共享同一份 `vendor/linenoise` 源码，支持 Ctrl+V 自定义回调解耦
+
+### Fixed
+
+- C 版本非交互模式（`prompt`/stdin）未调用 `agent_main_loop`，导致图片占位符未展开。重构为统一走 `agent_main_loop`，与 Bash 结构对齐
+
+### Tests
+
+- Test 50 重构为 e2e 测试：创建 session 图片 → 运行 agent → 检查 conversation.jsonl 中 `<attached-images>` 标签，所有代理版本均可覆盖
+- C/Go/Rust 三版本编译零警告通过
+
 ---
 
 ## [4.0.7] - 2026-06-03

--- a/README.en.md
+++ b/README.en.md
@@ -139,6 +139,17 @@ Supports readline input, resume info on exit, Ctrl+C to interrupt, Ctrl+D to cle
 
 </details>
 
+## Image Paste
+
+Press **Ctrl+V** in interactive mode to paste an image from the clipboard. A `[Image #N]` placeholder is inserted and the image is cached in the session directory. When you send the message, all images are collected and sent to GLM-4V-Flash (free) for text transcription, appended as `<attached-images>`.
+
+Supported platforms:
+- **macOS**: `osascript` (built-in)
+- **Linux Wayland**: `wl-paste`
+- **Linux X11**: `xclip`
+
+Without an API key, images can still be pasted (generating `[Image #N]` placeholders) but the description step is skipped.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -152,6 +163,9 @@ Supports readline input, resume info on exit, Ctrl+C to interrupt, Ctrl+D to cle
 | `JINA_API_KEY` | Jina AI API key (required for WebSearch/WebFetch tools) |
 | `BASH_AGENT_HOME` | Override session storage directory (default: `$HOME`) |
 | `BASH_AGENT_BASH_MODE` | Bash tool permissions as 4 octal rwx digits: `system/external/network/workspace`; each digit uses `4=read,2=write,1=execute` (default: `0467`) |
+| `DESCRIBE_API_KEY` | Image description API key (defaults to GLM-4V-Flash, free) |
+| `DESCRIBE_MODEL` | Image description model name (default: `glm-4v-flash`) |
+| `DESCRIBE_BASE_URL` | Image description API base URL (default: `https://open.bigmodel.cn/api/paas/v4`) |
 | `THINKING_BUDGET` | Thinking token budget (default: `2048`) |
 
 ## Bash Tool Permission Mode

--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ tcode goagent -p openai -m gpt-4o
 
 </details>
 
+## 图片粘贴
+
+终端交互模式下 **Ctrl+V** 从剪贴板粘贴图片，自动插入 `[Image #N]` 占位符并缓存到 session。发送消息时自动收集所有图片，调用 GLM-4V-Flash（免费）转录文字并追加 `<attached-images>` 描述。
+
+支持平台：
+- **macOS**: `osascript`（内置）
+- **Linux Wayland**: `wl-paste`
+- **Linux X11**: `xclip`
+
+无需 API key 时仍可粘贴图片（生成 `[Image #N]`），仅跳过描述步骤。
+
 ## 环境变量
 
 | 变量 | 说明 |
@@ -152,6 +163,9 @@ tcode goagent -p openai -m gpt-4o
 | `JINA_API_KEY` | Jina AI API key（WebSearch/WebFetch 工具需要） |
 | `BASH_AGENT_HOME` | 覆盖 session 存储目录（默认 `$HOME`） |
 | `BASH_AGENT_BASH_MODE` | Bash 工具权限，4 位八进制 `system/external/network/workspace`；每位 `4=read,2=write,1=execute`（默认 `0467`） |
+| `DESCRIBE_API_KEY` | 图片描述 API key（默认使用 GLM-4V-Flash，免费） |
+| `DESCRIBE_MODEL` | 图片描述模型名（默认 `glm-4v-flash`） |
+| `DESCRIBE_BASE_URL` | 图片描述 API 基础地址（默认 `https://open.bigmodel.cn/api/paas/v4`） |
 
 ## Bash 工具权限模式
 

--- a/c/agent.c
+++ b/c/agent.c
@@ -1362,6 +1362,13 @@ void agent_image_expand_placeholders(Agent *agent, char **input) {
 
     if (img_count == 0) {
         free(image_paths);
+        /* 无图片也追加空标签，与其他版本一致 */
+        StrBuf result;
+        sb_init(&result);
+        sb_append(&result, *input);
+        sb_append(&result, "\n\n<attached-images>\n\n</attached-images>");
+        free(*input);
+        *input = result.data;
         return;
     }
 

--- a/c/agent.c
+++ b/c/agent.c
@@ -11,6 +11,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <curl/curl.h>
 
 /* ============================================================
  * 流式 SSE 回调 — 同时累积到 accum 并实时推送到 display queue
@@ -23,6 +24,12 @@
 /* 前置声明 */
 static void push_display(MsgQueue *dq, DisplayMessage *msg);
 static void push_display_event(const SessionPaths *paths, MsgQueue *dq, DisplayMessage *msg);
+
+/* 图像粘贴回调的路劲 — 从 cagent.c 设置，由 linenoise readline 线程调用 */
+
+/* ============================================================
+ * 图片占位符支持
+ * ============================================================ */
 
 static char *agent_tool_display_summary(const char *name, JsonVal input, const char *input_json) {
     char *field = NULL;
@@ -1154,6 +1161,320 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
  * agent_main_loop — 从 input_queue 取消息驱动循环
  * ============================================================ */
 
+/* ============================================================
+ * 图像处理 — placeholder 展开 + GLM 描述 + Ctrl+V 粘贴
+ * ============================================================ */
+
+/* HTTP POST 辅助类型 — 用于图像描述请求 */
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+} ImageWebBuf;
+
+static size_t image_web_write_cb(char *ptr, size_t size, size_t nmemb, void *userdata) {
+    ImageWebBuf *buf = (ImageWebBuf *)userdata;
+    size_t total = size * nmemb;
+    if (buf->len + total + 1 > buf->cap) {
+        size_t newcap = buf->cap ? buf->cap * 2 : 4096;
+        while (newcap < buf->len + total + 1) newcap *= 2;
+        buf->data = realloc(buf->data, newcap);
+        buf->cap = newcap;
+    }
+    memcpy(buf->data + buf->len, ptr, total);
+    buf->len += total;
+    buf->data[buf->len] = '\0';
+    return total;
+}
+
+/* base64 编码文件内容，返回 malloc'd 字符串 */
+static char *file_to_base64(const char *path) {
+    /* 使用 OpenSSL BIO 或 popen base64 */
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd), "base64 < '%s' 2>/dev/null", path);
+    FILE *fp = popen(cmd, "r");
+    if (!fp) return NULL;
+
+    StrBuf out;
+    sb_init(&out);
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf) - 1, fp)) > 0) {
+        buf[n] = '\0';
+        sb_append(&out, buf);
+    }
+    int rc = pclose(fp);
+    if (rc != 0 || out.len == 0) {
+        sb_free(&out);
+        return NULL;
+    }
+    /* 去掉尾部换行 */
+    while (out.len > 0 && (out.data[out.len - 1] == '\n' || out.data[out.len - 1] == '\r'))
+        out.len--;
+    out.data[out.len] = '\0';
+    return out.data;
+}
+
+char *agent_image_describe(char **paths, int count) {
+    if (!paths || count <= 0) return NULL;
+
+    const char *api_key = getenv("DESCRIBE_API_KEY");
+    if (!api_key || !api_key[0]) return NULL;
+
+    const char *model = getenv("DESCRIBE_MODEL");
+    if (!model || !model[0]) model = "glm-4v-flash";
+
+    const char *base_url = getenv("DESCRIBE_BASE_URL");
+    if (!base_url || !base_url[0]) base_url = "https://open.bigmodel.cn/api/paas/v4";
+
+    /* 构建 URL */
+    char url[1024];
+    snprintf(url, sizeof(url), "%s/chat/completions", base_url);
+
+    /* 构建请求体 */
+    StrBuf body;
+    sb_init(&body);
+
+    sb_appendf(&body, "{\"model\":");
+    sb_append_json_string(&body, model);
+    sb_append(&body, ",\"messages\":[{\"role\":\"user\",\"content\":[");
+    sb_append(&body, "{\"type\":\"text\",\"text\":");
+    sb_append_json_string(&body,
+        "Output all visible text from each image. "
+        "Transcribe every character including special symbols. "
+        "Preserve exact spacing and line breaks. "
+        "Do not summarize or describe - just output the raw text exactly as shown. "
+        "If an image has no text, briefly describe what you see.");
+    sb_append(&body, "}");
+
+    for (int i = 0; i < count; i++) {
+        char *b64 = file_to_base64(paths[i]);
+        if (!b64) continue;
+        sb_append(&body, ",{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,");
+        sb_append(&body, b64);
+        sb_append(&body, "\"}}");
+        free(b64);
+    }
+
+    sb_append(&body, "]}]}");
+
+    /* 构建 headers */
+    char auth_header[512];
+    snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", api_key);
+    const char *headers[] = {
+        "Content-Type: application/json",
+        auth_header
+    };
+    int hdr_count = 2;
+
+    /* 发送 POST 请求 */
+    CURL *curl = curl_easy_init();
+    if (!curl) {
+        sb_free(&body);
+        return NULL;
+    }
+
+    ImageWebBuf wb = {NULL, 0, 0};
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.data);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)body.len);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, image_web_write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &wb);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 120L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+
+    struct curl_slist *slist = NULL;
+    for (int i = 0; i < hdr_count; i++) {
+        slist = curl_slist_append(slist, headers[i]);
+    }
+    if (slist) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
+
+    CURLcode res = curl_easy_perform(curl);
+    curl_slist_free_all(slist);
+    curl_easy_cleanup(curl);
+    sb_free(&body);
+
+    if (res != CURLE_OK) {
+        free(wb.data);
+        return NULL;
+    }
+
+    if (!wb.data || wb.len == 0) {
+        free(wb.data);
+        return NULL;
+    }
+
+    /* 解析 JSON 响应: choices[0].message.content */
+    JsonParse jp = json_parse_root(wb.data);
+    if (jp.error) {
+        free(wb.data);
+        return NULL;
+    }
+
+    JsonVal choices = json_get(jp.val, "choices");
+    if (choices.type != JSON_ARRAY || json_array_len(choices) <= 0) {
+        free(wb.data);
+        return NULL;
+    }
+
+    JsonVal first = json_array_get(choices, 0);
+    JsonVal msg = json_get(first, "message");
+    char *content = json_get_string(msg, "content");
+
+    free(wb.data);
+    return content; /* caller must free */
+}
+
+void agent_image_expand_placeholders(Agent *agent, char **input) {
+    if (!input || !*input || !(*input)[0]) return;
+
+    /* 扫描 [Image #N] 模式 */
+    const char *pattern = "[Image #";
+    int max_images = 256;
+    char **image_paths = calloc((size_t)max_images, sizeof(char*));
+    int img_count = 0;
+
+    const char *p = *input;
+    while ((p = strstr(p, pattern)) != NULL && img_count < max_images) {
+        p += strlen(pattern);
+        /* 提取数字 */
+        int n = 0;
+        while (*p >= '0' && *p <= '9') {
+            n = n * 10 + (*p - '0');
+            p++;
+        }
+        /* 必须后跟 ] */
+        if (*p != ']') continue;
+        p++; /* 跳过 ] */
+
+        /* 检查文件是否存在 */
+        const char *imgdir = store_session_image_dir(&agent->paths);
+        char imgpath[1024];
+        snprintf(imgpath, sizeof(imgpath), "%s/%d.png", imgdir, n);
+        FILE *f = fopen(imgpath, "r");
+        if (f) {
+            fclose(f);
+            image_paths[img_count] = util_strdup(imgpath);
+            img_count++;
+        }
+    }
+
+    if (img_count == 0) {
+        free(image_paths);
+        return;
+    }
+
+    /* 调用 GLM API 描述图像 */
+    char *desc = agent_image_describe(image_paths, img_count);
+
+    /* 清理路径 */
+    for (int i = 0; i < img_count; i++) free(image_paths[i]);
+    free(image_paths);
+
+    if (!desc) return;
+
+    /* 构建结果: input + \n\n<attached-images>\n...\n</attached-images> */
+    StrBuf result;
+    sb_init(&result);
+    sb_append(&result, *input);
+    sb_append(&result, "\n\n<attached-images>\n");
+    sb_append(&result, desc);
+    sb_append(&result, "\n</attached-images>");
+    free(desc);
+
+    /* 替换 input 指针指向新分配的字符串 */
+    free(*input);
+    *input = result.data;
+}
+
+void agent_image_clipboard_paste(const char *session_dir, char **out, size_t *outlen) {
+    *out = NULL;
+    *outlen = 0;
+
+    if (!session_dir || !session_dir[0]) return;
+
+    /* 构建 images 目录路径 */
+    char imgdir[1024];
+    snprintf(imgdir, sizeof(imgdir), "%s/images", session_dir);
+
+    /* 计算下一个图片编号 */
+    int next_n = 1;
+    for (;;) {
+        char path[1024];
+        snprintf(path, sizeof(path), "%s/%d.png", imgdir, next_n);
+        FILE *f = fopen(path, "r");
+        if (f) {
+            fclose(f);
+            next_n++;
+        } else {
+            break;
+        }
+    }
+
+    /* 尝试从剪贴板获取图片 (macOS) */
+    char save_path[1024];
+    snprintf(save_path, sizeof(save_path), "%s/%d.png", imgdir, next_n);
+
+    /* 创建保存目录 */
+    util_mkdirs(imgdir, 0755);
+
+    int saved = 0;
+
+    /* macOS: osascript 获取 PNG */
+    {
+        char tmp_path[1024];
+        snprintf(tmp_path, sizeof(tmp_path), "%s/clipimg_%d.png", imgdir, next_n);
+        char cmd[2048];
+        snprintf(cmd, sizeof(cmd),
+            "osascript -e 'set theImage to the clipboard as «class PNGf»' "
+            "-e \"set theFile to open for access POSIX file \\\"%s\\\" with write permission\" "
+            "-e 'write theImage to theFile' "
+            "-e 'close access theFile' >/dev/null 2>&1"
+            " && mv '%s' '%s' 2>/dev/null",
+            tmp_path, tmp_path, save_path);
+        int rc = system(cmd);
+        if (rc == 0) {
+            struct stat st;
+            if (stat(save_path, &st) == 0 && st.st_size > 0) {
+                saved = 1;
+            }
+        }
+    }
+
+    if (!saved) {
+        /* Linux: 尝试 wl-paste 或 xclip */
+        const char *paste_cmds[] = {
+            "wl-paste --type image/png > '%s' 2>/dev/null",
+            "xclip -selection clipboard -t image/png -o > '%s' 2>/dev/null",
+            NULL
+        };
+        for (int ci = 0; paste_cmds[ci]; ci++) {
+            char paste_cmd[2048];
+            snprintf(paste_cmd, sizeof(paste_cmd), paste_cmds[ci], save_path);
+            int paste_rc = system(paste_cmd);
+            if (paste_rc == 0) {
+                struct stat st;
+                if (stat(save_path, &st) == 0 && st.st_size > 0) {
+                    saved = 1;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!saved) return;
+
+    /* 格式化输出: [Image #N] */
+    char result[64];
+    int rlen = snprintf(result, sizeof(result), "[Image #%d]", next_n);
+    *out = malloc((size_t)rlen + 1);
+    if (*out) {
+        memcpy(*out, result, (size_t)rlen + 1);
+        *outlen = (size_t)rlen;
+    }
+}
+
 int agent_main_loop(Agent *agent) {
     while (1) {
         void *data = NULL;
@@ -1169,6 +1490,9 @@ int agent_main_loop(Agent *agent) {
                  * 残留到 agent_loop 开始时导致立即中断。
                  * 模仿 Rust 版 agent_loop_stream 入口的 CTRLC_FLAG.swap(false) 模式。 */
                 agent->interrupted = 0;
+
+                /* 展开图片 placeholder [Image #N] → describe + <attached-images> */
+                agent_image_expand_placeholders(agent, &msg->data.user_input.text);
 
                 agent_loop(agent, msg->data.user_input.text, "user_input");
 

--- a/c/agent.c
+++ b/c/agent.c
@@ -1372,7 +1372,16 @@ void agent_image_expand_placeholders(Agent *agent, char **input) {
     for (int i = 0; i < img_count; i++) free(image_paths[i]);
     free(image_paths);
 
-    if (!desc) return;
+    if (!desc) {
+        /* describe 返回空（无 API key 或调用失败），仍追加空标签 */
+        StrBuf result;
+        sb_init(&result);
+        sb_append(&result, *input);
+        sb_append(&result, "\n\n<attached-images>\n\n</attached-images>");
+        free(*input);
+        *input = result.data;
+        return;
+    }
 
     /* 构建结果: input + \n\n<attached-images>\n...\n</attached-images> */
     StrBuf result;

--- a/c/agent.h
+++ b/c/agent.h
@@ -105,4 +105,14 @@ int agent_replay_events(Agent *agent, int max_turns);
 /* 更新终端标题 */
 void agent_update_title(Agent *agent);
 
+/* ============================================================
+ * 图片占位符支持
+ * ============================================================ */
+
+/* 展开输入中的 [Image #N] 占位符，调用描述 API 后替换输入指针 */
+/* 图像处理 */
+char *agent_image_describe(char **paths, int count);
+void agent_image_expand_placeholders(Agent *agent, char **input);
+void agent_image_clipboard_paste(const char *session_dir, char **out, size_t *outlen);
+
 #endif /* AGENT_H */

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -20,6 +20,7 @@
 #include "display.h"
 #include "store.h"
 #include "util.h"
+#include "linenoise.h"
 #include <curl/curl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,6 +58,11 @@ static void usage(const char *prog) {
     fprintf(stderr, "  BASH_AGENT_HOME         Override base directory for session storage\n");
     fprintf(stderr, "  BASH_AGENT_BASH_MODE    Bash tool permissions as 4 octal rwx digits: system/external/network/workspace (default: 0467)\n");
     fprintf(stderr, "  MODEL                   Default model name\n");
+}
+
+static char *g_paste_session_dir = NULL;
+static void image_paste_wrapper(char **out, size_t *outlen) {
+    agent_image_clipboard_paste(g_paste_session_dir, out, outlen);
 }
 
 int main(int argc, char *argv[]) {
@@ -310,6 +316,11 @@ int main(int argc, char *argv[]) {
         rcfg.home = home;
         /* 设置 SIGINT handler 中要设置的 agent->interrupted 指针 */
         readline_set_agent_interrupted(&agent->interrupted);
+        /* 注册图像粘贴回调（Ctrl+V） */
+        
+        linenoiseSetImagePasteCallback(image_paste_wrapper);
+        g_paste_session_dir = agent->paths.session_dir;
+
         readline_thread_start(&readline_thread, &rcfg);
 
         /* 主循环 */

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -367,7 +367,6 @@ int main(int argc, char *argv[]) {
                 agent_loop(agent, expanded, "user_input");
                 if (expanded != input.data) sb_free(&input);
             }
-            }
             sb_free(&input);
         }
 

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -349,7 +349,10 @@ int main(int argc, char *argv[]) {
 
         /* 直接执行 agent_loop */
         if (prompt) {
-            agent_loop(agent, prompt, "user_input");
+            char *expanded = util_strdup(prompt);
+            agent_image_expand_placeholders(agent, &expanded);
+            agent_loop(agent, expanded, "user_input");
+            free(expanded);
         } else {
             /* 从 stdin 读取 */
             StrBuf input;
@@ -359,7 +362,11 @@ int main(int argc, char *argv[]) {
                 sb_append(&input, linebuf);
             }
             if (input.len > 0) {
-                agent_loop(agent, input.data, "user_input");
+                char *expanded = input.data;
+                agent_image_expand_placeholders(agent, &expanded);
+                agent_loop(agent, expanded, "user_input");
+                if (expanded != input.data) sb_free(&input);
+            }
             }
             sb_free(&input);
         }

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -338,8 +338,7 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "\x1b[90mResume with: --session %s  or  --continue\x1b[0m\n",
                 effective_session ? effective_session : "?");
     } else {
-        /* 非交互模式 */
-        /* display 线程（仍然需要，用于输出） */
+        /* 非交互模式：通过 input_queue 走 agent_main_loop（与 bash 一致） */
         pthread_t display_thread;
         DisplayConfig dcfg;
         dcfg.queue = &display_queue;
@@ -347,28 +346,34 @@ int main(int argc, char *argv[]) {
         dcfg.interactive = 0;
         display_thread_start(&display_thread, &dcfg);
 
-        /* 直接执行 agent_loop */
         if (prompt) {
-            char *expanded = util_strdup(prompt);
-            agent_image_expand_placeholders(agent, &expanded);
-            agent_loop(agent, expanded, "user_input");
-            free(expanded);
+            InputMessage *msg = malloc(sizeof(InputMessage));
+            if (msg) {
+                memset(msg, 0, sizeof(*msg));
+                msg->type = MSG_USER_INPUT;
+                msg->data.user_input.text = util_strdup(prompt);
+                mq_push(&input_queue, msg);
+            }
         } else {
             /* 从 stdin 读取 */
-            StrBuf input;
-            sb_init(&input);
             char linebuf[65536];
             while (fgets(linebuf, sizeof(linebuf), stdin)) {
-                sb_append(&input, linebuf);
+                util_rtrim(linebuf);
+                if (linebuf[0] == '\0') continue;
+                InputMessage *msg = malloc(sizeof(InputMessage));
+                if (!msg) break;
+                memset(msg, 0, sizeof(*msg));
+                msg->type = MSG_USER_INPUT;
+                msg->data.user_input.text = util_strdup(linebuf);
+                if (mq_push(&input_queue, msg) != 0) {
+                    input_message_free(msg);
+                    free(msg);
+                    break;
+                }
             }
-            if (input.len > 0) {
-                char *expanded = input.data;
-                agent_image_expand_placeholders(agent, &expanded);
-                agent_loop(agent, expanded, "user_input");
-                if (expanded != input.data) sb_free(&input);
-            }
-            sb_free(&input);
         }
+
+        agent_main_loop(agent);
 
         /* 等待子 agent 完成 */
         while (agent->active_sub_count > 0) {

--- a/c/store.c
+++ b/c/store.c
@@ -126,9 +126,16 @@ static int touch_file(const char *path) {
     return 0;
 }
 
+const char *store_session_image_dir(const SessionPaths *paths) {
+    static __thread char buf[1024];
+    snprintf(buf, sizeof(buf), "%s/images", paths->session_dir);
+    return buf;
+}
+
 int store_session_init(const SessionPaths *p, int is_new) {
     if (util_mkdirs(p->base_dir, 0755) != 0) return -1;
     if (util_mkdirs(p->session_dir, 0755) != 0) return -1;
+    mkdir(store_session_image_dir(p), 0755);
     touch_file(p->conversation);
     touch_file(p->events);
     touch_file(p->summary);
@@ -162,6 +169,14 @@ int store_session_init(const SessionPaths *p, int is_new) {
     } else {
         touch_file(p->stats);
     }
+
+    /* 创建 images 目录 */
+    {
+        char imgdir[1024];
+        snprintf(imgdir, sizeof(imgdir), "%s/images", p->session_dir);
+        util_mkdirs(imgdir, 0755);
+    }
+
     return 0;
 }
 

--- a/c/store.h
+++ b/c/store.h
@@ -40,6 +40,8 @@ int store_session_init(const SessionPaths *p, int is_new);
 /* 为子 agent 创建新会话（初始化目录） */
 int store_session_init_sub(const SessionPaths *parent_paths, const SessionPaths *sub_paths, int fork);
 
+const char *store_session_image_dir(const SessionPaths *paths);
+
 /* 从 cwd 生成 project key（简化为路径替换 / 为 -） */
 char *store_session_project_key(const char *cwd);
 

--- a/go/agent.go
+++ b/go/agent.go
@@ -1,13 +1,18 @@
 package agent
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -45,6 +50,161 @@ type SubAgentResult struct {
 	CacheRead    int
 	CacheWrite   int
 	Requests     int
+}
+
+// imageNextName returns the next sequential image filename.
+func (a *Agent) imageNextName() string {
+	dir := a.store.ImageDir()
+	entries, _ := filepath.Glob(filepath.Join(dir, "*.png"))
+	return fmt.Sprintf("%d.png", len(entries)+1)
+}
+
+// ImagePasteCallback is called from linenoise when Ctrl+V is pressed.
+// It tries to read clipboard image and save to session cache.
+func (a *Agent) ImagePasteCallback() string {
+	name := a.imageNextName()
+	path := filepath.Join(a.store.ImageDir(), name)
+
+	// Try clipboard tools in order
+	var data []byte
+	if _, err := exec.LookPath("osascript"); err == nil {
+		cmd := exec.Command("osascript", "-e",
+			`set theImage to the clipboard as «class PNGf»`,
+			"-e", fmt.Sprintf(`set theFile to open for access POSIX file "%s" with write permission`, path+".tmp"),
+			"-e", `write theImage to theFile`,
+			"-e", `close access theFile`)
+		if err := cmd.Run(); err == nil {
+			data, _ = os.ReadFile(path + ".tmp")
+		}
+		os.Remove(path + ".tmp")
+	}
+	if data == nil {
+		if _, err := exec.LookPath("wl-paste"); err == nil {
+			data, _ = exec.Command("wl-paste", "--type", "image/png").Output()
+		}
+	}
+	if data == nil {
+		if _, err := exec.LookPath("xclip"); err == nil {
+			data, _ = exec.Command("xclip", "-selection", "clipboard", "-t", "image/png", "-o").Output()
+		}
+	}
+
+	if len(data) == 0 {
+		return ""
+	}
+
+	// Optional oxipng compression
+	if _, err := exec.LookPath("oxipng"); err == nil {
+		os.WriteFile(path+".tmp", data, 0644)
+		exec.Command("oxipng", "-o", "4", "--strip", "safe", "-q", path+".tmp").Run()
+		data, _ = os.ReadFile(path + ".tmp")
+		os.Remove(path + ".tmp")
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("[Image #%s]", name[:len(name)-4])
+}
+
+// imageDescribe calls GLM-4V-Flash to describe the given image files.
+func (a *Agent) imageDescribe(paths []string) string {
+	apiKey := os.Getenv("DESCRIBE_API_KEY")
+	model := os.Getenv("DESCRIBE_MODEL")
+	baseURL := os.Getenv("DESCRIBE_BASE_URL")
+	if apiKey == "" || len(paths) == 0 {
+		return ""
+	}
+	if model == "" {
+		model = "glm-4v-flash"
+	}
+	if baseURL == "" {
+		baseURL = "https://open.bigmodel.cn/api/paas/v4"
+	}
+
+	// Build content parts: text + image_url for each path
+	var contentParts []map[string]interface{}
+	contentParts = append(contentParts, map[string]interface{}{
+		"type": "text",
+		"text": "Output all visible text from each image, separated by a blank line between images. Transcribe every character including special symbols (arrows, prompts, dots, slashes). Preserve exact spacing and line breaks. Pay attention to date formats (month names, numbers). Do not summarize or describe - just output the raw text exactly as shown. If an image has no text, briefly describe what you see.",
+	})
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		b64 := base64.StdEncoding.EncodeToString(data)
+		contentParts = append(contentParts, map[string]interface{}{
+			"type": "image_url",
+			"image_url": map[string]string{
+				"url": "data:image/png;base64," + b64,
+			},
+		})
+	}
+
+	body := map[string]interface{}{
+		"model":    model,
+		"stream":   true,
+		"messages": []interface{}{map[string]interface{}{"role": "user", "content": contentParts}},
+	}
+	bodyJSON, _ := json.Marshal(body)
+
+	req, err := http.NewRequest("POST", baseURL+"/chat/completions", bytes.NewReader(bodyJSON))
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	// Parse SSE response, collect TEXT from choices[0].delta.content
+	var desc strings.Builder
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+		for _, c := range chunk.Choices {
+			desc.WriteString(c.Delta.Content)
+		}
+	}
+	return desc.String()
+}
+
+// expandImagePlaceholders scans [Image #N] in input, collects files,
+// calls describe, and appends <attached-images> to the input.
+func (a *Agent) expandImagePlaceholders(input string) string {
+	re := regexp.MustCompile(`\[Image #(\d+)\]`)
+	var paths []string
+	for _, m := range re.FindAllStringSubmatch(input, -1) {
+		p := filepath.Join(a.store.ImageDir(), m[1]+".png")
+		if _, err := os.Stat(p); err == nil {
+			paths = append(paths, p)
+		}
+	}
+	desc := a.imageDescribe(paths)
+	return fmt.Sprintf("%s\n\n<attached-images>\n%s\n</attached-images>", input, desc)
 }
 
 func NewAgent(cfg Config, store SessionStore, llm Transport, tools *ToolDispatcher, display *TermDisplay) *Agent {
@@ -510,8 +670,6 @@ func (a *Agent) LoadSkill(name string) (string, error) {
 	return "", fmt.Errorf("skill not found: %s", name)
 }
 
-// ─── RunLoop: 单次用户输入的 LLM 循环 ───
-
 func (a *Agent) isStreamJSON() bool {
 	return a.cfg.OutputFormat == "stream-json"
 }
@@ -530,6 +688,11 @@ func (a *Agent) emitJSON(obj map[string]interface{}) {
 }
 
 func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
+	// Expand image placeholders before processing
+	if turnKind == "user_input" {
+		userInput = a.expandImagePlaceholders(userInput)
+	}
+
 	// 记录 user_input 事件（提前到 AddUserMessage 之前，与 bash 版一致）
 	if turnKind == "user_input" {
 		a.emitJSON(map[string]interface{}{"type": "user_input", "content": userInput})

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -267,6 +267,7 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 
 	// 启动 readline goroutine
 	rl := NewReadline(home)
+	rl.SetImagePasteCallback(a.ImagePasteCallback)
 	rl.Start()
 
 	// 主循环：从 readline goroutine 接收输入，交给 agent 处理

--- a/go/cmd/goagent/readline.go
+++ b/go/cmd/goagent/readline.go
@@ -44,6 +44,11 @@ func (r *Readline) Start() {
 	go r.loop()
 }
 
+// SetImagePasteCallback registers a function to be called when Ctrl+V is pressed.
+func (r *Readline) SetImagePasteCallback(fn func() string) {
+	linenoise.SetImagePasteCallback(fn)
+}
+
 // Input returns the channel on which user input lines are delivered.
 func (r *Readline) Input() <-chan string {
 	return r.inputCh

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -19,6 +19,9 @@ static struct ln_result linenoise_safe(const char *prompt) {
 	r.errnum = errno;
 	return r;
 }
+
+// C wrapper that calls the Go export below.
+extern void goImagePasteCallback(char **out, size_t *outlen);
 */
 import "C"
 import (
@@ -30,6 +33,30 @@ var (
 	ErrInterrupted = errors.New("interrupted")
 	ErrEOF         = errors.New("EOF")
 )
+
+// imagePasteFn is set by SetImagePasteCallback.
+var imagePasteFn func() string
+
+//export goImagePasteCallback
+func goImagePasteCallback(cout **C.char, coutlen *C.size_t) {
+	if imagePasteFn == nil {
+		return
+	}
+	s := imagePasteFn()
+	if s == "" {
+		return
+	}
+	*cout = C.CString(s)
+	*coutlen = C.size_t(len(s))
+}
+
+// SetImagePasteCallback registers a function to be called when
+// Ctrl+V is pressed in linenoise. The function should return
+// a string (e.g. "[Image #N]") to insert at cursor, or "" to ignore.
+func SetImagePasteCallback(fn func() string) {
+	imagePasteFn = fn
+	C.linenoiseSetImagePasteCallback(C.linenoiseImagePasteCallback(C.goImagePasteCallback))
+}
 
 // Line reads a line of input using linenoise's blocking API.
 // Returns ErrInterrupted on Ctrl+C, ErrEOF on Ctrl+D or I/O error.

--- a/go/store.go
+++ b/go/store.go
@@ -29,6 +29,7 @@ type FileStore struct {
 	planFile      string
 	planDraftFile string
 	statsFile     string
+	sessionDir    string // 会话基础目录
 
 	// 内存缓存 stats（避免频繁 AWK）
 	stats Stats
@@ -141,8 +142,12 @@ func (s *FileStore) Init(sessionID string) error {
 	s.sessionID = sessionID
 
 	dir := filepath.Join(s.GetDir(), sessionID)
+	s.sessionDir = dir
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create session dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "images"), 0755); err != nil {
+		return fmt.Errorf("create image dir: %w", err)
 	}
 
 	s.convFile = filepath.Join(dir, "conversation.jsonl")
@@ -923,6 +928,15 @@ func (s *FileStore) PlanClear() error {
 	defer s.mu.Unlock()
 	os.WriteFile(s.planFile, []byte(""), 0644)
 	return nil
+}
+
+// ═══════════════════════════════════════════
+// ImageDir — 图像缓存目录
+// ═══════════════════════════════════════════
+
+// ImageDir 返回会话图像缓存目录路径
+func (s *FileStore) ImageDir() string {
+	return filepath.Join(s.sessionDir, "images")
 }
 
 // ═══════════════════════════════════════════

--- a/go/types.go
+++ b/go/types.go
@@ -161,6 +161,7 @@ type SessionStore interface {
 	Init(sessionID string) error
 	Fork(parentDir, childDir string) error
 	GetDir() string
+	ImageDir() string
 	GetLatestDir() (string, error)
 	ResolveContinue() (string, error)
 	SessionID() string

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -855,6 +855,7 @@ name = "rustagent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "cc",
  "crossterm",
  "ctrlc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1"
 once_cell = "1"
+base64 = "0.22"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -860,6 +860,10 @@ impl Agent {
         let history_path_str = history_path.to_string_lossy().to_string();
         ffi::history_load(&history_path_str);
 
+        // 注册图片粘贴回调，使 linenoise Ctrl+V 支持图片粘贴
+        ffi::set_image_dir(self.paths.session_dir.join("images"));
+        ffi::register_paste_callback();
+
         // 启动 readline 线程，将用户输入发送到消息队列
         let msg_tx_arc = self.msg_tx.clone();
         let history_path_clone = history_path.to_string_lossy().to_string();
@@ -1105,6 +1109,7 @@ impl Agent {
         crate::tools::drain_fd(self.cancel_read_fd);
 
         let result = (|| -> Result<()> {
+            let user_input = expand_image_placeholders(&user_input, &self.paths);
             self.conv.add_user(&user_input)?;
             if turn_kind == "user_input" {
                 self.append_event(json!({"type":"user_input","content":user_input}))?;
@@ -2096,6 +2101,74 @@ impl Agent {
             let _ = writeln!(self.stderr.borrow_mut(), "[debug] {msg}");
         }
     }
+}
+
+/// Describe images using GLM API.
+fn image_describe(paths: &[std::path::PathBuf]) -> String {
+    let api_key = std::env::var("DESCRIBE_API_KEY").unwrap_or_default();
+    if api_key.is_empty() || paths.is_empty() {
+        return String::new();
+    }
+    let model = std::env::var("DESCRIBE_MODEL").unwrap_or_else(|_| "glm-4v-flash".into());
+    let base_url = std::env::var("DESCRIBE_BASE_URL")
+        .unwrap_or_else(|_| "https://open.bigmodel.cn/api/paas/v4".into());
+
+    use base64::Engine as _;
+    let mut content: Vec<serde_json::Value> = vec![
+        serde_json::json!({"type": "text", "text": "Output all visible text from each image. Transcribe every character including special symbols. Preserve exact spacing and line breaks. Do not summarize or describe - just output the raw text exactly as shown. If an image has no text, briefly describe what you see."})
+    ];
+    for p in paths {
+        if let Ok(data) = std::fs::read(p) {
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
+            content.push(serde_json::json!({
+                "type": "image_url",
+                "image_url": {"url": format!("data:image/png;base64,{}", b64)}
+            }));
+        }
+    }
+
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [{"role": "user", "content": content}]
+    });
+
+    let rt = crate::agent::tokio_runtime();
+    rt.block_on(async move {
+        let client = reqwest::Client::new();
+        match client
+            .post(format!("{}/chat/completions", base_url))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", api_key))
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                match resp.json::<serde_json::Value>().await {
+                    Ok(val) => val["choices"][0]["message"]["content"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string(),
+                    Err(_) => String::new(),
+                }
+            }
+            Err(_) => String::new(),
+        }
+    })
+}
+
+/// Expand [Image #N] placeholders with described image content.
+fn expand_image_placeholders(input: &str, paths: &store::Paths) -> String {
+    let re = regex::Regex::new(r"\[Image #(\d+)\]").unwrap();
+    let mut img_paths = Vec::new();
+    for cap in re.captures_iter(input) {
+        let p = paths.session_dir.join("images").join(format!("{}.png", &cap[1]));
+        if p.exists() {
+            img_paths.push(p);
+        }
+    }
+    let desc = image_describe(&img_paths);
+    format!("{}\n\n<attached-images>\n{}\n</attached-images>", input, desc)
 }
 
 #[cfg(test)]

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -2,6 +2,18 @@
 
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// Global image directory path, set once during agent initialization.
+/// Used by the image paste callback to know where to save clipboard images.
+static IMAGE_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Set the global image directory path for the paste callback.
+/// Should be called once during agent initialization.
+pub fn set_image_dir(dir: PathBuf) {
+    let _ = IMAGE_DIR.set(dir);
+}
 
 /// Error type for linenoise line reading.
 #[derive(Debug)]
@@ -34,6 +46,7 @@ unsafe extern "C" {
     fn linenoiseHistorySave(filename: *const c_char) -> libc::c_int;
     fn linenoiseHistoryLoad(filename: *const c_char) -> libc::c_int;
     fn linenoiseSetMultiLine(ml: libc::c_int);
+    fn linenoiseSetImagePasteCallback(cb: Option<unsafe extern "C" fn(*mut *mut libc::c_char, *mut libc::size_t)>);
 }
 
 /// Read a line from stdin with the given prompt.
@@ -113,4 +126,109 @@ pub fn history_load(path: &str) -> bool {
 /// Enable or disable multiline editing mode.
 pub fn set_multiline(ml: bool) {
     unsafe { linenoiseSetMultiLine(if ml { 1 } else { 0 }) }
+}
+
+/// Register the image paste callback with linenoise.
+/// Called once during agent initialization after setting the image directory.
+pub fn register_paste_callback() {
+    unsafe {
+        linenoiseSetImagePasteCallback(Some(image_paste_callback_impl));
+    }
+}
+
+/// Extern "C" function called by linenoise when the user presses Ctrl+V.
+/// Reads the clipboard (osascript → wl-paste → xclip), saves to image_dir/{n}.png,
+/// and returns "[Image #N]" as a heap-allocated C string (freed by linenoise).
+#[unsafe(no_mangle)]
+pub extern "C" fn image_paste_callback_impl(
+    out: *mut *mut libc::c_char,
+    outlen: *mut libc::size_t,
+) {
+    let img_dir = match IMAGE_DIR.get() {
+        Some(d) => d.clone(),
+        None => return,
+    };
+
+    let _ = std::fs::create_dir_all(&img_dir);
+
+    // Find next available image number
+    let next = match std::fs::read_dir(&img_dir) {
+        Ok(entries) => entries.filter_map(|e| e.ok()).count() + 1,
+        Err(_) => 1,
+    };
+
+    // Try clipboard tools in order: osascript (macOS), wl-paste (Wayland), xclip (X11)
+    let img_data = try_clipboard_image(next, &img_dir);
+
+    let img_data = match img_data {
+        Some(d) if !d.is_empty() => d,
+        _ => return,
+    };
+
+    let img_path = img_dir.join(format!("{next}.png"));
+    if std::fs::write(&img_path, &img_data).is_err() {
+        return;
+    }
+
+    let placeholder = format!("[Image #{next}]");
+    let c_str = match std::ffi::CString::new(placeholder) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    unsafe {
+        *out = c_str.into_raw();
+        *outlen = libc::strlen(*out);
+    }
+}
+
+/// Try each clipboard tool in order, returning the PNG data if successful.
+fn try_clipboard_image(next: usize, img_dir: &std::path::Path) -> Option<Vec<u8>> {
+    // macOS: osascript to write clipboard PNG to a temp file
+    let tmp_path = img_dir.join(format!("{next}.png.tmp"));
+    let tmp_str = tmp_path.to_string_lossy().to_string();
+    let osa_cmd = format!(
+        "set theImage to the clipboard as «class PNGf»
+set theFile to open for access POSIX file \"{tmp_str}\" with write permission
+write theImage to theFile
+close access theFile"
+    );
+    if std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&osa_cmd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
+        if let Ok(data) = std::fs::read(&tmp_path) {
+            let _ = std::fs::remove_file(&tmp_path);
+            if !data.is_empty() {
+                return Some(data);
+            }
+        }
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+
+    // Linux Wayland
+    if let Ok(output) = std::process::Command::new("wl-paste")
+        .arg("--type")
+        .arg("image/png")
+        .output()
+    {
+        if output.status.success() && !output.stdout.is_empty() {
+            return Some(output.stdout);
+        }
+    }
+
+    // Linux X11
+    if let Ok(output) = std::process::Command::new("xclip")
+        .args(["-selection", "clipboard", "-t", "image/png", "-o"])
+        .output()
+    {
+        if output.status.success() && !output.stdout.is_empty() {
+            return Some(output.stdout);
+        }
+    }
+
+    None
 }

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -32,6 +32,10 @@ use std::path::{Path, PathBuf};
             &self.base_dir
         }
 
+        pub fn image_dir(&self) -> PathBuf {
+            self.base_dir.join("images")
+        }
+
         pub fn init(&self) -> Result<()> {
             fs::create_dir_all(&self.base_dir)?;
             Ok(())
@@ -229,6 +233,10 @@ use std::path::{Path, PathBuf};
         store.get_dir()
     }
 
+    pub fn store_image_dir(store: &FileStore) -> PathBuf {
+        store.image_dir()
+    }
+
     pub fn store_get_latest_dir(home: &std::path::Path, cwd: &std::path::Path) -> Result<PathBuf> {
         let session_id = continue_session(home, cwd)?;
         Ok(paths_for(home, cwd, &session_id).session_dir)
@@ -241,6 +249,8 @@ use std::path::{Path, PathBuf};
     pub fn store_session_init(paths: &Paths, new_session: bool) -> Result<()> {
         fs::create_dir_all(&paths.base_dir)?;
         fs::create_dir_all(&paths.session_dir)?;
+        let img_dir = paths.session_dir.join("images");
+        fs::create_dir_all(&img_dir)?;
         for path in [
             &paths.conversation,
             &paths.events,
@@ -573,6 +583,11 @@ use std::path::{Path, PathBuf};
             plan_draft: session_dir.join("plan.draft"),
             stats: session_dir.join("stats.json"),
         }
+    }
+
+    /// Return the images directory path for a session.
+    pub fn image_dir(paths: &Paths) -> PathBuf {
+        paths.session_dir.join("images")
     }
 
     pub fn ensure_dir(path: &std::path::Path) -> Result<()> {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -212,26 +212,89 @@ agent_image_insert_placeholder_readline() {
 }
 
 agent_image_describe() {
-    local path="$1" num="${2:-0}"
-    # TODO: replace with real image describe API call (multimodal model)
-    printf 'This is a mock image description. Will be replaced with real image describe API output.'
+    # 接受多个图片路径，返回所有图片的组合描述
+    # 使用智谱 GLM-4V-Flash（免费）通过 curl 调用
+    local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}"
+    local paths=("$@")
+    [[ ${#paths[@]} -eq 0 ]] && return 0
+
+    # 无 API key 时的 mock 回退
+    if [[ -z "$api_key" ]]; then
+        local p desc="" num
+        for p in "${paths[@]}"; do
+            num="${p%.png}"; num="${num##*/}"
+            desc+="Image #${num}: This is a mock description for ${p}. (Set GLM_API_KEY to use GLM-4V-Flash)\n"
+        done
+        printf '%b' "$desc"
+        return 0
+    fi
+
+    # 构建请求体：base64 编码所有图片
+    local content_parts='[{"type":"text","text":"Please describe these images in order, one paragraph per image."}'
+    local p b64
+    for p in "${paths[@]}"; do
+        [[ -f "$p" ]] || continue
+        b64=$(base64 < "$p" | tr -d '\n\r')
+        content_parts+=",{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,${b64}\"}}"
+    done
+    content_parts+=']'
+
+    local response desc
+    response=$(curl -sS -X POST \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $api_key" \
+        -d "{\"model\":\"glm-4v-flash\",\"messages\":[{\"role\":\"user\",\"content\":${content_parts}}]}" \
+        "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>/dev/null) || desc=""
+
+    # 提取 content 字段（OpenAI 兼容格式）
+    if [[ -z "$desc" ]]; then
+        desc=$(printf '%s' "$response" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(data['choices'][0]['message']['content'])
+except: pass
+" 2>/dev/null) || desc=""
+    fi
+
+    if [[ -n "$desc" ]]; then
+        printf '%s' "$desc"
+    else
+        # JSON 解析失败时的回退（无 python3 或响应异常）
+        local p num
+        for p in "${paths[@]}"; do
+            num="${p%.png}"; num="${num##*/}"
+            printf 'Image #%s: (description unavailable)\n' "$num"
+        done
+    fi
 }
 
 agent_image_expand_placeholders_in_input() {
-    local input="$1" rest="$1" out="" token n path size
+    local input="$1" rest="$1" paths=() n p
+    # 扫描所有 [Image #N] 占位符，收集图片路径
     while [[ "$rest" =~ \[Image\ #([0-9]+)\] ]]; do
-        token="${BASH_REMATCH[0]}"; n="${BASH_REMATCH[1]}"
-        out+="${rest%%"$token"*}"
-        path="$(store_session_image_dir)/$n.png"
-        if [[ -f "$path" ]]; then
-            size=$(wc -c < "$path" 2>/dev/null || printf '?'); size="${size//[[:space:]]/}"
-            out+=$'[Image #'"$n"$']\nSource: session image cache\nFile: '"$path"$'\nFilename: '"$n.png"$'\nSize: '"$size"' bytes\nDescription: '"$(agent_image_describe "$path" "$n")"
-        else
-            out+="$token"
-        fi
-        rest="${rest#*"$token"}"
+        n="${BASH_REMATCH[1]}"
+        p="$(store_session_image_dir)/$n.png"
+        [[ -f "$p" ]] && paths+=("$p")
+        rest="${rest#*"${BASH_REMATCH[0]}"}"
     done
-    printf '%s' "$out$rest"
+
+    # 无图片时原样返回
+    if [[ ${#paths[@]} -eq 0 ]]; then
+        printf '%s' "$input"
+        return 0
+    fi
+
+    # 一次性获取所有图片描述
+    local desc
+    desc=$(agent_image_describe "${paths[@]}") || desc=""
+
+    # 将描述追加到用户输入末尾，原始占位符不变
+    if [[ -n "$desc" ]]; then
+        printf '%s\n\n---\n[Attached Images Description]\n%s' "$input" "$desc"
+    else
+        printf '%s' "$input"
+    fi
 }
 
 util_find_skill_dirs() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -212,39 +212,22 @@ agent_image_insert_placeholder_readline() {
 }
 
 agent_image_describe() {
-    # 接受多个图片路径，返回所有图片的组合描述
-    # 使用智谱 GLM-4.6V-FlashX（免费）通过 curl 调用
-    local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}"
-    local paths=("$@")
-    [[ ${#paths[@]} -eq 0 ]] && return 0
+    local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}" paths=("$@") tmp desc p
+    [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
 
-    # 无 API key 时直接返回空
-    if [[ -z "$api_key" ]]; then
-        return 0
-    fi
-
-    # 用临时文件构建请求体，避免 base64 数据撑爆变量/args
-    local tmp desc
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
 
-    # JSON 头部
     printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
-
-    # 逐个追加 base64 图片段（直接写到文件，不经过变量）
-    local p
     for p in "${paths[@]}"; do
         [[ -f "$p" ]] || continue
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"
         printf '"}}' >> "$tmp"
     done
-
-    # JSON 尾部
     printf ']}]}' >> "$tmp"
 
-    # 流式调用 GLM：curl → http_stream → transport_openai_sse → sse_parse → while util_read_msg
-    local desc=""
+    desc=""
     while util_read_msg; do
         case "${REPLY_MESSAGE[0]}" in
             TEXT) desc+="${REPLY_MESSAGE[1]}" ;;
@@ -261,16 +244,7 @@ agent_image_describe() {
         sse_parse
     )
 
-    if [[ -n "$desc" ]]; then
-        printf '%s' "$desc"
-    else
-        # JSON 解析失败时的回退（无 python3 或响应异常）
-        local p num
-        for p in "${paths[@]}"; do
-            num="${p%.png}"; num="${num##*/}"
-            printf 'Image #%s: (description unavailable)\n' "$num"
-        done
-    fi
+    [[ -n "$desc" ]] && printf '%s' "$desc"
 }
 
 agent_image_expand_placeholders_in_input() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -172,9 +172,8 @@ util_read_optional() { [[ -n "$1" && -s "$1" ]] && printf '%s' "$(<"$1")"; }
 store_session_image_dir() { printf '%s/%s/images' "$(store_session_get_dir)" "${SESSION_ID:-}"; }
 
 agent_image_next_name() {
-    local dir count
-    dir="$(store_session_image_dir)"
-    count=$(ls "$dir"/*.png 2>/dev/null | wc -l | tr -d ' ')
+    local count
+    count=$(ls "$(store_session_image_dir)"/*.png 2>/dev/null | wc -l | tr -d ' ')
     printf '%d.png' "$((count + 1))"
 }
 

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -227,7 +227,7 @@ agent_image_describe() {
     while util_read_msg; do
         case "${REPLY_MESSAGE[0]}" in
             TEXT) desc+="${REPLY_MESSAGE[1]}" ;;
-            STOP|ERROR) break ;;
+            STOP) break ;;
         esac
     done < <(curl -sS --no-buffer -D - --retry 2 --retry-delay 1 --retry-max-time 20 \
         --connect-timeout 5 --speed-limit 1 --speed-time 60 \
@@ -248,11 +248,7 @@ agent_image_expand_placeholders_in_input() {
         rest="${rest#*"${BASH_REMATCH[0]}"}"
     done
     desc=$(agent_image_describe $paths)
-    if [[ -n "$desc" ]]; then
-        printf '%s\n\n<attached-images>\n%s\n</attached-images>' "$input" "$desc"
-    else
-        printf '%s' "$input"
-    fi
+    printf '%s\n\n<attached-images>\n%s\n</attached-images>' "$input" "$desc"
 }
 
 util_find_skill_dirs() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -212,12 +212,10 @@ agent_image_insert_placeholder_readline() {
 }
 
 agent_image_describe() {
-    local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}" paths=("$@") tmp desc p
+    local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}" paths=("$@") tmp desc="" p
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
-
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-
     printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
     for p in "${paths[@]}"; do
         [[ -f "$p" ]] || continue
@@ -226,8 +224,6 @@ agent_image_describe() {
         printf '"}}' >> "$tmp"
     done
     printf ']}]}' >> "$tmp"
-
-    desc=""
     while util_read_msg; do
         case "${REPLY_MESSAGE[0]}" in
             TEXT) desc+="${REPLY_MESSAGE[1]}" ;;
@@ -235,41 +231,25 @@ agent_image_describe() {
         esac
     done < <(curl -sS --no-buffer -D - --retry 2 --retry-delay 1 --retry-max-time 20 \
         --connect-timeout 5 --speed-limit 1 --speed-time 60 \
-        -H "Content-Type: application/json" \
-        -H "Authorization: Bearer $api_key" \
-        -d "@$tmp" \
-        "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>&1 | \
+        -H "Content-Type: application/json" -H "Authorization: Bearer $api_key" \
+        -d "@$tmp" "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>&1 | \
         util_awk_run -f "$AWK_DIR/http_stream.awk" | \
         util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk" | \
-        sse_parse
-    )
-
-    [[ -n "$desc" ]] && printf '%s' "$desc"
+        sse_parse)
+    printf '%s' "$desc"
 }
 
 agent_image_expand_placeholders_in_input() {
-    local input="$1" rest="$1" paths=() n p
-    # 扫描所有 [Image #N] 占位符，收集图片路径
+    local input="$1" rest="$1" n p desc paths=""
     while [[ "$rest" =~ \[Image\ #([0-9]+)\] ]]; do
         n="${BASH_REMATCH[1]}"
         p="$(store_session_image_dir)/$n.png"
-        [[ -f "$p" ]] && paths+=("$p")
+        [[ -f "$p" ]] && paths="${paths:+$paths }$p"
         rest="${rest#*"${BASH_REMATCH[0]}"}"
     done
-
-    # 无图片时原样返回
-    if [[ ${#paths[@]} -eq 0 ]]; then
-        printf '%s' "$input"
-        return 0
-    fi
-
-    # 一次性获取所有图片描述
-    local desc
-    desc=$(agent_image_describe "${paths[@]}") || desc=""
-
-    # 将描述追加到用户输入末尾，原始占位符不变
+    desc=$(agent_image_describe $paths)
     if [[ -n "$desc" ]]; then
-        printf '%s\n\n---\n[Attached Images Description]\n%s' "$input" "$desc"
+        printf '%s\n\n<attached-images>\n%s\n</attached-images>' "$input" "$desc"
     else
         printf '%s' "$input"
     fi

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -172,15 +172,10 @@ util_read_optional() { [[ -n "$1" && -s "$1" ]] && printf '%s' "$(<"$1")"; }
 store_session_image_dir() { printf '%s/%s/images' "$(store_session_get_dir)" "${SESSION_ID:-}"; }
 
 agent_image_next_name() {
-    local max=0 file base num
-    for file in "$(store_session_image_dir)"/*.png; do
-        [[ -e "$file" ]] || continue
-        base="${file##*/}"
-        num="${base%.png}"
-        [[ "$num" =~ ^[0-9]+$ ]] || continue
-        (( num > max )) && max=$num
-    done
-    printf '%d.png' "$((max + 1))"
+    local dir count
+    dir="$(store_session_image_dir)"
+    count=$(ls "$dir"/*.png 2>/dev/null | wc -l | tr -d ' ')
+    printf '%d.png' "$((count + 1))"
 }
 
 agent_image_clipboard_to_cache() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -255,15 +255,22 @@ agent_image_describe() {
         -d "@$tmp" \
         "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>/dev/null) || desc=""
 
-    # 提取 content 字段（OpenAI 兼容格式）
+    # 提取 content 字段（OpenAI 兼容格式，用 json.awk 解析）
     if [[ -z "$desc" ]]; then
-        desc=$(printf '%s' "$response" | python3 -c "
-import sys, json
-try:
-    data = json.load(sys.stdin)
-    print(data['choices'][0]['message']['content'])
-except: pass
-" 2>/dev/null) || desc=""
+        desc=$(printf '%s' "$response" | util_awk_run -f "$AWK_DIR/json.awk" '
+{
+    json = json $0
+}
+END {
+    choices = extract_value(json, "choices", 0)
+    n = split_top_level_objects(choices, blocks)
+    if (n > 0) {
+        msg = extract_value(blocks[1], "message", 0)
+        content = extract_str(msg, "content", 0)
+        if (content != "") print content
+    }
+}
+') || desc=""
     fi
 
     if [[ -n "$desc" ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -217,7 +217,7 @@ agent_image_describe() {
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && { printf '\033[90m[describe] skip (no paths or no key)\033[0m\n' >&2; return 0; }
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
+    printf '{"model":"glm-4v-flash","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -218,14 +218,8 @@ agent_image_describe() {
     local paths=("$@")
     [[ ${#paths[@]} -eq 0 ]] && return 0
 
-    # 无 API key 时的 mock 回退
+    # 无 API key 时直接返回空
     if [[ -z "$api_key" ]]; then
-        local p desc="" num
-        for p in "${paths[@]}"; do
-            num="${p%.png}"; num="${num##*/}"
-            desc+="Image #${num}: This is a mock description for ${p}. (Set GLM_API_KEY to use GLM-4.6V-FlashX)\n"
-        done
-        printf '%b' "$desc"
         return 0
     fi
 

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -179,29 +179,32 @@ agent_image_next_name() {
 agent_image_clipboard_to_cache() {
     local name path tmp
     name="$(agent_image_next_name)" || return 1
+    printf '\033[90m[debug] clipboard_to_cache: next_name=%s\033[0m\n' "$name" >&2
     path="$(store_session_image_dir)/$name"
     tmp="$path.tmp.$$"
     trap 'rm -f "$tmp" 2>/dev/null || true; trap - RETURN' RETURN
 
+    printf '\033[90m[debug] trying osascript...\033[0m\n' >&2
     osascript -e 'set theImage to the clipboard as «class PNGf»' \
         -e "set theFile to open for access POSIX file \"$tmp\" with write permission" \
         -e 'write theImage to theFile' \
         -e 'close access theFile' >/dev/null 2>&1 \
     || wl-paste --type image/png >"$tmp" 2>/dev/null \
     || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null \
-    || return 1
+    || { printf '\033[90m[debug] all clipboard tools failed\033[0m\n' >&2; return 1; }
 
-    [[ -s "$tmp" ]] || return 1
+    [[ -s "$tmp" ]] || { printf '\033[90m[debug] tmp file empty after paste\033[0m\n' >&2; return 1; }
     command -v oxipng >/dev/null 2>&1 && oxipng -o 4 --strip safe --quiet "$tmp" >/dev/null 2>&1
     mv "$tmp" "$path" || return 1
     printf '%s' "$name"
 }
 
 agent_image_insert_placeholder_readline() {
+    printf '\033[90m[debug] Ctrl+V triggered\033[0m\n' >&2
     local p line point
-    [[ -n "${READLINE_LINE+x}" ]] || return 1
+    [[ -n "${READLINE_LINE+x}" ]] || { printf '\033[90m[debug] READLINE_LINE not set\033[0m\n' >&2; return 1; }
     local image_name
-    image_name="$(agent_image_clipboard_to_cache)" || return 1
+    image_name="$(agent_image_clipboard_to_cache)" || { printf '\033[90m[debug] clipboard_to_cache failed\033[0m\n' >&2; return 1; }
     p="[Image #${image_name%.png}]"
     line="$READLINE_LINE"
     point=${READLINE_POINT:-${#line}}
@@ -1646,7 +1649,12 @@ interactive_mode() {
             fi
             if ! $bound; then
                 set -o emacs 2>/dev/null || true
-                bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>/dev/null || true
+                printf '\033[90m[debug] binding Ctrl+V...\033[0m\n' >&2
+                if bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>&1; then
+                    printf '\033[90m[debug] Ctrl+V bound OK\033[0m\n' >&2
+                else
+                    printf '\033[90m[debug] Ctrl+V bind FAILED\033[0m\n' >&2
+                fi
                 bound=true
             fi
             [[ "$line" == "exit" || "$line" == "quit" ]] && {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -172,8 +172,7 @@ util_read_optional() { [[ -n "$1" && -s "$1" ]] && printf '%s' "$(<"$1")"; }
 store_session_image_dir() { printf '%s/%s/images' "$(store_session_get_dir)" "${SESSION_ID:-}"; }
 
 agent_image_next_name() {
-    local count
-    count=$(ls "$(store_session_image_dir)"/*.png 2>/dev/null | wc -l | tr -d ' ')
+    local count=$(ls "$(store_session_image_dir)"/*.png 2>/dev/null | wc -l | tr -d ' ')
     printf '%d.png' "$((count + 1))"
 }
 

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -230,26 +230,9 @@ agent_image_describe() {
     fi
 
     # 用临时文件构建请求体，避免 base64 数据撑爆变量/args
-    local tmp awkscr response desc
+    local tmp desc
     tmp=$(mktemp) || return 1
-    awkscr=$(mktemp) || { rm -f "$tmp"; return 1; }
-    trap 'rm -f "$tmp" "$awkscr"' RETURN
-
-    # 写入提取 content 的 awk 脚本到临时文件
-    cat > "$awkscr" << 'AWKEOF'
-{
-    json = json $0
-}
-END {
-    choices = extract_value(json, "choices", 0)
-    n = split_top_level_objects(choices, blocks)
-    if (n > 0) {
-        msg = extract_value(blocks[1], "message", 0)
-        content = extract_str(msg, "content", 0)
-        if (content != "") print content
-    }
-}
-AWKEOF
+    trap 'rm -f "$tmp"' RETURN
 
     # JSON 头部
     printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
@@ -266,16 +249,24 @@ AWKEOF
     # JSON 尾部
     printf ']}]}' >> "$tmp"
 
-    response=$(curl -sS -X POST \
-        -H "Content-Type: application/json" \
-        -H "Authorization: Bearer $api_key" \
-        -d "@$tmp" \
-        "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>/dev/null) || desc=""
+    # 临时接管全局连接参数，通过流式 SSE 管道调用 GLM
+    local saved_header_args=("${HEADER_ARGS[@]}") saved_api_url="$API_URL"
+    HEADER_ARGS=(-H "Content-Type: application/json" -H "Authorization: Bearer $api_key")
+    API_URL="https://open.bigmodel.cn/api/paas/v4/chat/completions"
 
-    # 提取 content 字段（OpenAI 兼容格式，用 json.awk + 临时脚本解析）
-    if [[ -z "$desc" ]]; then
-        desc=$(printf '%s' "$response" | util_awk_run -f "$AWK_DIR/json.awk" -f "$awkscr") || desc=""
-    fi
+    desc=$(cat "$tmp" | llm_stream_curl | sse_convert | sse_parse 2>/dev/null | util_awk_run '
+    BEGIN { RS="\r\n"; state=0 }
+    state == 0 && /^\*2\r?$/    { state=1; next }
+    state == 1 && /^\$4\r?$/    { state=2; next }
+    state == 2                  { t=$0; state=3; next }
+    state == 3 && /^\$[0-9]+\r?$/ { state=4; next }
+    state == 4                  { if (t == "TEXT") printf "%s", $0; state=0; next }
+    { state=0 }
+    ')
+
+    # 恢复全局连接参数
+    HEADER_ARGS=("${saved_header_args[@]}")
+    API_URL="$saved_api_url"
 
     if [[ -n "$desc" ]]; then
         printf '%s' "$desc"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -217,7 +217,7 @@ agent_image_describe() {
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order, one paragraph per image. Transcribe ALL visible text verbatim, preserving exact wording and language. Cover layout, colors, objects, UI elements, and any other details exhaustively."}' "$model" > "$tmp"
+    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order, one paragraph per image. Transcribe ALL visible text verbatim - every line, every character. Do NOT summarize, do NOT infer, do NOT guess. If text is garbled or unreadable, output it as-is. Only describe what is literally visible in the image."}' "$model" > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -218,15 +218,22 @@ agent_image_insert_placeholder_readline() {
     READLINE_POINT=$((point + ${#p}))
 }
 
+agent_image_describe() {
+    local path="$1" num="${2:-0}"
+    # TODO: 替换为真实 image describe API 调用（如调用多模态模型的 image 理解能力）
+    printf '这是一个 mock 图片描述。后续会替换为真实 image describe API 返回内容。'
+}
+
 agent_image_expand_placeholders_in_input() {
-    local input="$1" rest="$1" out="" token n path size
+    local input="$1" rest="$1" out="" token n path size desc
     while [[ "$rest" =~ \[Image\ #([0-9]+)\] ]]; do
         token="${BASH_REMATCH[0]}"; n="${BASH_REMATCH[1]}"
         out+="${rest%%"$token"*}"
         path="$(store_session_image_dir)/$n.png"
         if [[ -f "$path" ]]; then
             size=$(wc -c < "$path" 2>/dev/null || printf '?'); size="${size//[[:space:]]/}"
-            out+=$'[图片 Image #'"$n"$']\n来源：session 图片缓存\n文件：'"$path"$'\n文件名：'"$n.png"$'\n文件大小：'"$size"' bytes\n描述：这是一个 mock 图片描述。后续会替换为真实 image describe API 返回内容。'
+            desc="$(agent_image_describe "$path" "$n")"
+            out+=$'[图片 Image #'"$n"$']\n来源：session 图片缓存\n文件：'"$path"$'\n文件名：'"$n.png"$'\n文件大小：'"$size"' bytes\n描述：'"$desc"
         else
             out+="$token"
         fi

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -220,20 +220,19 @@ agent_image_insert_placeholder_readline() {
 
 agent_image_describe() {
     local path="$1" num="${2:-0}"
-    # TODO: 替换为真实 image describe API 调用（如调用多模态模型的 image 理解能力）
-    printf '这是一个 mock 图片描述。后续会替换为真实 image describe API 返回内容。'
+    # TODO: replace with real image describe API call (multimodal model)
+    printf 'This is a mock image description. Will be replaced with real image describe API output.'
 }
 
 agent_image_expand_placeholders_in_input() {
-    local input="$1" rest="$1" out="" token n path size desc
+    local input="$1" rest="$1" out="" token n path size
     while [[ "$rest" =~ \[Image\ #([0-9]+)\] ]]; do
         token="${BASH_REMATCH[0]}"; n="${BASH_REMATCH[1]}"
         out+="${rest%%"$token"*}"
         path="$(store_session_image_dir)/$n.png"
         if [[ -f "$path" ]]; then
             size=$(wc -c < "$path" 2>/dev/null || printf '?'); size="${size//[[:space:]]/}"
-            desc="$(agent_image_describe "$path" "$n")"
-            out+=$'[图片 Image #'"$n"$']\n来源：session 图片缓存\n文件：'"$path"$'\n文件名：'"$n.png"$'\n文件大小：'"$size"' bytes\n描述：'"$desc"
+            out+=$'[Image #'"$n"$']\nSource: session image cache\nFile: '"$path"$'\nFilename: '"$n.png"$'\nSize: '"$size"' bytes\nDescription: '"$(agent_image_describe "$path" "$n")"
         else
             out+="$token"
         fi

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -171,17 +171,32 @@ util_read_optional() { [[ -n "$1" && -s "$1" ]] && printf '%s' "$(<"$1")"; }
 
 store_session_image_dir() { printf '%s/%s/images' "$(store_session_get_dir)" "${SESSION_ID:-}"; }
 
+agent_image_next_name() {
+    local max=0 file base num
+    for file in "$(store_session_image_dir)"/*.png; do
+        [[ -e "$file" ]] || continue
+        base="${file##*/}"
+        num="${base%.png}"
+        [[ "$num" =~ ^[0-9]+$ ]] || continue
+        (( num > max )) && max=$num
+    done
+    printf '%d.png' "$((max + 1))"
+}
+
 agent_image_clipboard_to_cache() {
     local name path tmp
-    name="$(printf '%d.png' "$(( $(ls "$(store_session_image_dir)"/*.png 2>/dev/null | wc -l) + 1 ))")" || return 1
+    name="$(agent_image_next_name)" || return 1
     path="$(store_session_image_dir)/$name"
     tmp="$path.tmp.$$"
     trap 'rm -f "$tmp" 2>/dev/null || true; trap - RETURN' RETURN
 
-    pbpaste -Prefer png >"$tmp" 2>/dev/null \
-        || wl-paste --type image/png >"$tmp" 2>/dev/null \
-        || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null \
-        || return 1
+    osascript -e 'set theImage to the clipboard as «class PNGf»' \
+        -e "set theFile to open for access POSIX file \"$tmp\" with write permission" \
+        -e 'write theImage to theFile' \
+        -e 'close access theFile' >/dev/null 2>&1 \
+    || wl-paste --type image/png >"$tmp" 2>/dev/null \
+    || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null \
+    || return 1
 
     [[ -s "$tmp" ]] || return 1
     command -v oxipng >/dev/null 2>&1 && oxipng -o 4 --strip safe --quiet "$tmp" >/dev/null 2>&1
@@ -1268,14 +1283,6 @@ agent_run_loop() {
     fi
 }
 
-agent_handle_user_input() {
-    local _input="$1" _expanded_input
-    if _expanded_input="$(agent_image_expand_placeholders_in_input "$_input")"; then
-        agent_run_loop "$_expanded_input"
-    else
-        return 1
-    fi
-}
 
 # 调用 agent_loop 并处理交互式终端提示符
 
@@ -1300,7 +1307,7 @@ agent_main_loop() {
                 ;;
             USER_INPUT)
                 local _input="${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
-                agent_handle_user_input "$_input" || true
+                agent_run_loop "$(agent_image_expand_placeholders_in_input "$_input")"
                 ;;
             AGENT_RESULT)
                 if [[ "$INTERRUPT_REQUESTED" == true ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -217,7 +217,7 @@ agent_image_describe() {
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Transcribe ALL visible text from each image. Output every line exactly as shown. Do not summarize or describe - just output the raw text content. If an image has no text, briefly describe what you see."}' "$model" > "$tmp"
+    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Output all visible text from each image, separated by a blank line between images. Transcribe every character including special symbols (arrows, prompts, dots, slashes). Preserve exact spacing and line breaks. Pay attention to date formats (month names, numbers). Do not summarize or describe - just output the raw text exactly as shown. If an image has no text, briefly describe what you see."}' "$model" > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -213,7 +213,8 @@ agent_image_insert_placeholder_readline() {
 
 agent_image_describe() {
     local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}" paths=("$@") tmp desc="" p
-    [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
+    printf '\033[90m[describe] paths=%d key=%s\033[0m\n' "${#paths[@]}" "${api_key:0:8}..." >&2
+    [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && { printf '\033[90m[describe] skip (no paths or no key)\033[0m\n' >&2; return 0; }
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
     printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
@@ -235,6 +236,7 @@ agent_image_describe() {
         util_awk_run -f "$AWK_DIR/http_stream.awk" | \
         util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk" | \
         sse_parse)
+    printf '\033[90m[describe] desc_len=%d preview=%.60s\033[0m\n' "${#desc}" "$desc" >&2
     printf '%s' "$desc"
 }
 
@@ -246,7 +248,9 @@ agent_image_expand_placeholders_in_input() {
         [[ -f "$p" ]] && paths="${paths:+$paths }$p"
         rest="${rest#*"${BASH_REMATCH[0]}"}"
     done
+    printf '\033[90m[expand] input=%.40s paths=%s\033[0m\n' "$input" "${paths:-<none>}" >&2
     desc=$(agent_image_describe $paths)
+    printf '\033[90m[expand] desc_len=%d\033[0m\n' "${#desc}" >&2
     if [[ -n "$desc" ]]; then
         printf '%s\n\n<attached-images>\n%s\n</attached-images>' "$input" "$desc"
     else

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -243,7 +243,7 @@ agent_image_describe() {
     response=$(curl -sS -X POST \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $api_key" \
-        -d "{\"model\":\"glm-4v-flash\",\"messages\":[{\"role\":\"user\",\"content\":${content_parts}}]}" \
+        -d "{\"model\":\"glm-4v-flashx\",\"messages\":[{\"role\":\"user\",\"content\":${content_parts}}]}" \
         "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>/dev/null) || desc=""
 
     # 提取 content 字段（OpenAI 兼容格式）

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -217,7 +217,7 @@ agent_image_describe() {
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order, one paragraph per image. If the image contains substantial text (terminal, code, documents, UI), transcribe ALL text verbatim - every line, every character. If the image has little or no text (photos, diagrams, logos), describe the visual content: layout, colors, objects, UI elements. Do NOT summarize, do NOT infer, do NOT guess. If text is garbled or unreadable, output it as-is."}' "$model" > "$tmp"
+    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Transcribe ALL visible text from each image. Output every line exactly as shown. Do not summarize or describe - just output the raw text content. If an image has no text, briefly describe what you see."}' "$model" > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -225,16 +225,20 @@ agent_image_describe() {
     done
     printf ']}]}' >> "$tmp"
     while util_read_msg; do
+        printf '\033[90m[describe] event=%s\033[0m\n' "${REPLY_MESSAGE[0]}" >&2
         case "${REPLY_MESSAGE[0]}" in
-            TEXT) desc+="${REPLY_MESSAGE[1]}" ;;
-            STOP|ERROR) break ;;
+            TEXT) desc+="${REPLY_MESSAGE[1]}"; printf '\033[90m[describe] TEXT chunk len=%d\033[0m\n' "${#REPLY_MESSAGE[1]}" >&2 ;;
+            STOP|ERROR) printf '\033[90m[describe] stop/error: %s\033[0m\n' "${REPLY_MESSAGE[*]}" >&2; break ;;
         esac
     done < <(curl -sS --no-buffer -D - --retry 2 --retry-delay 1 --retry-max-time 20 \
         --connect-timeout 5 --speed-limit 1 --speed-time 60 \
         -H "Content-Type: application/json" -H "Authorization: Bearer $api_key" \
         -d "@$tmp" "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>&1 | \
+        tee /tmp/describe_curl_raw.log | \
         util_awk_run -f "$AWK_DIR/http_stream.awk" | \
+        tee /tmp/describe_http_stream.log | \
         util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk" | \
+        tee /tmp/describe_sse.log | \
         sse_parse)
     printf '\033[90m[describe] desc_len=%d preview=%.60s\033[0m\n' "${#desc}" "$desc" >&2
     printf '%s' "$desc"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -213,7 +213,7 @@ agent_image_insert_placeholder_readline() {
 
 agent_image_describe() {
     # 接受多个图片路径，返回所有图片的组合描述
-    # 使用智谱 GLM-4V-Flash（免费）通过 curl 调用
+    # 使用智谱 GLM-4.6V-FlashX（免费）通过 curl 调用
     local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}"
     local paths=("$@")
     [[ ${#paths[@]} -eq 0 ]] && return 0
@@ -223,27 +223,36 @@ agent_image_describe() {
         local p desc="" num
         for p in "${paths[@]}"; do
             num="${p%.png}"; num="${num##*/}"
-            desc+="Image #${num}: This is a mock description for ${p}. (Set GLM_API_KEY to use GLM-4V-Flash)\n"
+            desc+="Image #${num}: This is a mock description for ${p}. (Set GLM_API_KEY to use GLM-4.6V-FlashX)\n"
         done
         printf '%b' "$desc"
         return 0
     fi
 
-    # 构建请求体：base64 编码所有图片
-    local content_parts='[{"type":"text","text":"Please describe these images in order, one paragraph per image."}'
-    local p b64
+    # 用临时文件构建请求体，避免 base64 数据撑爆变量/args
+    local tmp response desc
+    tmp=$(mktemp) || return 1
+    trap 'rm -f "$tmp"' RETURN
+
+    # JSON 头部
+    printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
+
+    # 逐个追加 base64 图片段（直接写到文件，不经过变量）
+    local p
     for p in "${paths[@]}"; do
         [[ -f "$p" ]] || continue
-        b64=$(base64 < "$p" | tr -d '\n\r')
-        content_parts+=",{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,${b64}\"}}"
+        printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
+        base64 < "$p" | tr -d '\n\r' >> "$tmp"
+        printf '"}}' >> "$tmp"
     done
-    content_parts+=']'
 
-    local response desc
+    # JSON 尾部
+    printf ']}]}' >> "$tmp"
+
     response=$(curl -sS -X POST \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $api_key" \
-        -d "{\"model\":\"glm-4.6v-flashx\",\"messages\":[{\"role\":\"user\",\"content\":${content_parts}}]}" \
+        -d "@$tmp" \
         "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>/dev/null) || desc=""
 
     # 提取 content 字段（OpenAI 兼容格式）

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -179,37 +179,29 @@ agent_image_next_name() {
 agent_image_clipboard_to_cache() {
     local name path tmp
     name="$(agent_image_next_name)" || return 1
-    printf '\033[90m[debug] clipboard_to_cache: next_name=%s\033[0m\n' "$name" >&2
     path="$(store_session_image_dir)/$name"
     tmp="$path.tmp.$$"
     trap 'rm -f "$tmp" 2>/dev/null || true; trap - RETURN' RETURN
 
-    printf '\033[90m[debug] osascript tmp=%s dir_exists=%s\033[0m\n' "$tmp" "$([[ -d "$(store_session_image_dir)" ]] && echo yes || echo no)" >&2
-    if osascript -e 'set theImage to the clipboard as «class PNGf»' \
+    osascript -e 'set theImage to the clipboard as «class PNGf»' \
         -e "set theFile to open for access POSIX file \"$tmp\" with write permission" \
         -e 'write theImage to theFile' \
-        -e 'close access theFile' >/dev/null 2>&1; then
-        printf '\033[90m[debug] osascript OK\033[0m\n' >&2
-    else
-        rc=$?
-        printf '\033[90m[debug] osascript FAILED rc=%d\033[0m\n' "$rc" >&2
-        wl-paste --type image/png >"$tmp" 2>/dev/null && printf '\033[90m[debug] wl-paste OK\033[0m\n' >&2 \
-        || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null && printf '\033[90m[debug] xclip OK\033[0m\n' >&2 \
-        || { printf '\033[90m[debug] all clipboard tools failed\033[0m\n' >&2; return 1; }
-    fi
+        -e 'close access theFile' >/dev/null 2>&1 \
+    || wl-paste --type image/png >"$tmp" 2>/dev/null \
+    || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null \
+    || return 1
 
-    [[ -s "$tmp" ]] || { printf '\033[90m[debug] tmp file empty after paste\033[0m\n' >&2; return 1; }
+    [[ -s "$tmp" ]] || return 1
     command -v oxipng >/dev/null 2>&1 && oxipng -o 4 --strip safe --quiet "$tmp" >/dev/null 2>&1
     mv "$tmp" "$path" || return 1
     printf '%s' "$name"
 }
 
 agent_image_insert_placeholder_readline() {
-    printf '\033[90m[debug] Ctrl+V triggered\033[0m\n' >&2
     local p line point
-    [[ -n "${READLINE_LINE+x}" ]] || { printf '\033[90m[debug] READLINE_LINE not set\033[0m\n' >&2; return 1; }
+    [[ -n "${READLINE_LINE+x}" ]] || return 1
     local image_name
-    image_name="$(agent_image_clipboard_to_cache)" || { printf '\033[90m[debug] clipboard_to_cache failed\033[0m\n' >&2; return 1; }
+    image_name="$(agent_image_clipboard_to_cache)" || return 1
     p="[Image #${image_name%.png}]"
     line="$READLINE_LINE"
     point=${READLINE_POINT:-${#line}}
@@ -1646,12 +1638,7 @@ interactive_mode() {
     {
         exec 5> "$INPUT_FIFO"
         set -o emacs 2>/dev/null || true
-        printf '\033[90m[debug] binding Ctrl+V...\033[0m\n' >&2
-        if bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>&1; then
-            printf '\033[90m[debug] Ctrl+V bound OK\033[0m\n' >&2
-        else
-            printf '\033[90m[debug] Ctrl+V bind FAILED\033[0m\n' >&2
-        fi
+        bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>/dev/null || true
         while true; do
             stty echo 2>/dev/null || true
             if ! IFS= read -e -r -p $'\033[32m>\033[0m ' line < /dev/tty; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -169,6 +169,54 @@ util_msg_to_stream() {
 
 util_read_optional() { [[ -n "$1" && -s "$1" ]] && printf '%s' "$(<"$1")"; }
 
+store_session_image_dir() { printf '%s/%s/images' "$(store_session_get_dir)" "${SESSION_ID:-}"; }
+
+agent_image_clipboard_to_cache() {
+    local name path tmp
+    name="$(printf '%d.png' "$(( $(ls "$(store_session_image_dir)"/*.png 2>/dev/null | wc -l) + 1 ))")" || return 1
+    path="$(store_session_image_dir)/$name"
+    tmp="$path.tmp.$$"
+    trap 'rm -f "$tmp" 2>/dev/null || true; trap - RETURN' RETURN
+
+    pbpaste -Prefer png >"$tmp" 2>/dev/null \
+        || wl-paste --type image/png >"$tmp" 2>/dev/null \
+        || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null \
+        || return 1
+
+    [[ -s "$tmp" ]] || return 1
+    command -v oxipng >/dev/null 2>&1 && oxipng -o 4 --strip safe --quiet "$tmp" >/dev/null 2>&1
+    mv "$tmp" "$path" || return 1
+    printf '%s' "$name"
+}
+
+agent_image_insert_placeholder_readline() {
+    local p line point
+    [[ -n "${READLINE_LINE+x}" ]] || return 1
+    local image_name
+    image_name="$(agent_image_clipboard_to_cache)" || return 1
+    p="[Image #${image_name%.png}]"
+    line="$READLINE_LINE"
+    point=${READLINE_POINT:-${#line}}
+    [[ "$point" =~ ^[0-9]+$ ]] || point=${#line}
+    (( point > ${#line} )) && point=${#line}
+    READLINE_LINE="${line:0:point}${p}${line:point}"
+    READLINE_POINT=$((point + ${#p}))
+}
+
+agent_image_expand_placeholders_in_input() {
+    local input="$1" rest="$1" out="" token n path size
+    while [[ "$rest" =~ \[Image\ #([0-9]+)\] ]]; do
+        token="${BASH_REMATCH[0]}"; n="${BASH_REMATCH[1]}"
+        out+="${rest%%"$token"*}"$'[图片 Image #'"$n"$']\n来源：session 图片缓存\n文件：'
+        path="$(store_session_image_dir)/$n.png"
+        [[ -f "$path" ]] || return 1
+        size=$(wc -c < "$path" 2>/dev/null || printf '?'); size="${size//[[:space:]]/}"
+        out+="$path"$'\n文件名：'"$n.png"$'\n文件大小：'"$size"' bytes\n描述：这是一个 mock 图片描述。后续会替换为真实 image describe API 返回内容。'
+        rest="${rest#*"$token"}"
+    done
+    printf '%s' "$out$rest"
+}
+
 util_find_skill_dirs() {
     local cwd home
     cwd="${PWD:-$(pwd)}"
@@ -343,6 +391,7 @@ store_session_init() {
     STATS_FILE="${session_dir}/stats.json"
     [[ ! -s "$SESSION_EVENT_FILE" ]] && new_session=true
     touch "$CONV_FILE" "$SESSION_EVENT_FILE" "$CONTEXT_SUMMARY_FILE" "$PLAN_FILE" "$PLAN_DRAFT_FILE" "$STATS_FILE"
+    mkdir -p "${session_dir}/images" 2>/dev/null || true
     if [[ "$new_session" == true ]]; then
         store_event_append "{\"type\":\"session_start\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\"}"
     fi
@@ -1219,6 +1268,15 @@ agent_run_loop() {
     fi
 }
 
+agent_handle_user_input() {
+    local _input="$1" _expanded_input
+    if _expanded_input="$(agent_image_expand_placeholders_in_input "$_input")"; then
+        agent_run_loop "$_expanded_input"
+    else
+        return 1
+    fi
+}
+
 # 调用 agent_loop 并处理交互式终端提示符
 
 # 统一清理所有管道 FD（按源→宿的级联顺序关闭）
@@ -1242,7 +1300,7 @@ agent_main_loop() {
                 ;;
             USER_INPUT)
                 local _input="${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
-                agent_run_loop "$_input"
+                agent_handle_user_input "$_input" || true
                 ;;
             AGENT_RESULT)
                 if [[ "$INTERRUPT_REQUESTED" == true ]]; then
@@ -1552,6 +1610,8 @@ interactive_mode() {
         exec 5> "$INPUT_FIFO"
         while true; do
             stty echo 2>/dev/null || true
+            set -o emacs 2>/dev/null || true
+            bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>/dev/null || true
             if ! IFS= read -e -r -p $'\033[32m>\033[0m ' line < /dev/tty; then
                 util_write_msg "SESSION_END" "0" >&5
                 break

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -222,11 +222,14 @@ agent_image_expand_placeholders_in_input() {
     local input="$1" rest="$1" out="" token n path size
     while [[ "$rest" =~ \[Image\ #([0-9]+)\] ]]; do
         token="${BASH_REMATCH[0]}"; n="${BASH_REMATCH[1]}"
-        out+="${rest%%"$token"*}"$'[图片 Image #'"$n"$']\n来源：session 图片缓存\n文件：'
+        out+="${rest%%"$token"*}"
         path="$(store_session_image_dir)/$n.png"
-        [[ -f "$path" ]] || return 1
-        size=$(wc -c < "$path" 2>/dev/null || printf '?'); size="${size//[[:space:]]/}"
-        out+="$path"$'\n文件名：'"$n.png"$'\n文件大小：'"$size"' bytes\n描述：这是一个 mock 图片描述。后续会替换为真实 image describe API 返回内容。'
+        if [[ -f "$path" ]]; then
+            size=$(wc -c < "$path" 2>/dev/null || printf '?'); size="${size//[[:space:]]/}"
+            out+=$'[图片 Image #'"$n"$']\n来源：session 图片缓存\n文件：'"$path"$'\n文件名：'"$n.png"$'\n文件大小：'"$size"' bytes\n描述：这是一个 mock 图片描述。后续会替换为真实 image describe API 返回内容。'
+        else
+            out+="$token"
+        fi
         rest="${rest#*"$token"}"
     done
     printf '%s' "$out$rest"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -230,9 +230,26 @@ agent_image_describe() {
     fi
 
     # 用临时文件构建请求体，避免 base64 数据撑爆变量/args
-    local tmp response desc
+    local tmp awkscr response desc
     tmp=$(mktemp) || return 1
-    trap 'rm -f "$tmp"' RETURN
+    awkscr=$(mktemp) || { rm -f "$tmp"; return 1; }
+    trap 'rm -f "$tmp" "$awkscr"' RETURN
+
+    # 写入提取 content 的 awk 脚本到临时文件
+    cat > "$awkscr" << 'AWKEOF'
+{
+    json = json $0
+}
+END {
+    choices = extract_value(json, "choices", 0)
+    n = split_top_level_objects(choices, blocks)
+    if (n > 0) {
+        msg = extract_value(blocks[1], "message", 0)
+        content = extract_str(msg, "content", 0)
+        if (content != "") print content
+    }
+}
+AWKEOF
 
     # JSON 头部
     printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
@@ -255,22 +272,9 @@ agent_image_describe() {
         -d "@$tmp" \
         "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>/dev/null) || desc=""
 
-    # 提取 content 字段（OpenAI 兼容格式，用 json.awk 解析）
+    # 提取 content 字段（OpenAI 兼容格式，用 json.awk + 临时脚本解析）
     if [[ -z "$desc" ]]; then
-        desc=$(printf '%s' "$response" | util_awk_run -f "$AWK_DIR/json.awk" '
-{
-    json = json $0
-}
-END {
-    choices = extract_value(json, "choices", 0)
-    n = split_top_level_objects(choices, blocks)
-    if (n > 0) {
-        msg = extract_value(blocks[1], "message", 0)
-        content = extract_str(msg, "content", 0)
-        if (content != "") print content
-    }
-}
-') || desc=""
+        desc=$(printf '%s' "$response" | util_awk_run -f "$AWK_DIR/json.awk" -f "$awkscr") || desc=""
     fi
 
     if [[ -n "$desc" ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -213,8 +213,7 @@ agent_image_insert_placeholder_readline() {
 
 agent_image_describe() {
     local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}" paths=("$@") tmp desc="" p
-    printf '\033[90m[describe] paths=%d key=%s\033[0m\n' "${#paths[@]}" "${api_key:0:8}..." >&2
-    [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && { printf '\033[90m[describe] skip (no paths or no key)\033[0m\n' >&2; return 0; }
+    [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
     printf '{"model":"glm-4v-flash","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order. Extract all text content, describe layout, colors, objects, UI elements, and any visible details. One paragraph per image."}' > "$tmp"
@@ -225,22 +224,17 @@ agent_image_describe() {
     done
     printf ']}]}' >> "$tmp"
     while util_read_msg; do
-        printf '\033[90m[describe] event=%s\033[0m\n' "${REPLY_MESSAGE[0]}" >&2
         case "${REPLY_MESSAGE[0]}" in
-            TEXT) desc+="${REPLY_MESSAGE[1]}"; printf '\033[90m[describe] TEXT chunk len=%d\033[0m\n' "${#REPLY_MESSAGE[1]}" >&2 ;;
-            STOP|ERROR) printf '\033[90m[describe] stop/error: %s\033[0m\n' "${REPLY_MESSAGE[*]}" >&2; break ;;
+            TEXT) desc+="${REPLY_MESSAGE[1]}" ;;
+            STOP|ERROR) break ;;
         esac
     done < <(curl -sS --no-buffer -D - --retry 2 --retry-delay 1 --retry-max-time 20 \
         --connect-timeout 5 --speed-limit 1 --speed-time 60 \
         -H "Content-Type: application/json" -H "Authorization: Bearer $api_key" \
         -d "@$tmp" "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>&1 | \
-        tee /tmp/describe_curl_raw.log | \
         util_awk_run -f "$AWK_DIR/http_stream.awk" | \
-        tee /tmp/describe_http_stream.log | \
         util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk" | \
-        tee /tmp/describe_sse.log | \
         sse_parse)
-    printf '\033[90m[describe] desc_len=%d preview=%.60s\033[0m\n' "${#desc}" "$desc" >&2
     printf '%s' "$desc"
 }
 
@@ -252,9 +246,7 @@ agent_image_expand_placeholders_in_input() {
         [[ -f "$p" ]] && paths="${paths:+$paths }$p"
         rest="${rest#*"${BASH_REMATCH[0]}"}"
     done
-    printf '\033[90m[expand] input=%.40s paths=%s\033[0m\n' "$input" "${paths:-<none>}" >&2
     desc=$(agent_image_describe $paths)
-    printf '\033[90m[expand] desc_len=%d\033[0m\n' "${#desc}" >&2
     if [[ -n "$desc" ]]; then
         printf '%s\n\n<attached-images>\n%s\n</attached-images>' "$input" "$desc"
     else

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -217,7 +217,7 @@ agent_image_describe() {
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && { printf '\033[90m[describe] skip (no paths or no key)\033[0m\n' >&2; return 0; }
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"glm-4v-flash","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
+    printf '{"model":"glm-4v-flash","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order. Extract all text content, describe layout, colors, objects, UI elements, and any visible details. One paragraph per image."}' > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1637,13 +1637,17 @@ interactive_mode() {
     display_term_title
     {
         exec 5> "$INPUT_FIFO"
+        bound=false
         while true; do
             stty echo 2>/dev/null || true
-            set -o emacs 2>/dev/null || true
-            bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>/dev/null || true
             if ! IFS= read -e -r -p $'\033[32m>\033[0m ' line < /dev/tty; then
                 util_write_msg "SESSION_END" "0" >&5
                 break
+            fi
+            if ! $bound; then
+                set -o emacs 2>/dev/null || true
+                bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>/dev/null || true
+                bound=true
             fi
             [[ "$line" == "exit" || "$line" == "quit" ]] && {
                 util_write_msg "SESSION_END" "0" >&5

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -184,14 +184,19 @@ agent_image_clipboard_to_cache() {
     tmp="$path.tmp.$$"
     trap 'rm -f "$tmp" 2>/dev/null || true; trap - RETURN' RETURN
 
-    printf '\033[90m[debug] trying osascript...\033[0m\n' >&2
-    osascript -e 'set theImage to the clipboard as «class PNGf»' \
+    printf '\033[90m[debug] osascript tmp=%s dir_exists=%s\033[0m\n' "$tmp" "$([[ -d "$(store_session_image_dir)" ]] && echo yes || echo no)" >&2
+    if osascript -e 'set theImage to the clipboard as «class PNGf»' \
         -e "set theFile to open for access POSIX file \"$tmp\" with write permission" \
         -e 'write theImage to theFile' \
-        -e 'close access theFile' >/dev/null 2>&1 \
-    || wl-paste --type image/png >"$tmp" 2>/dev/null \
-    || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null \
-    || { printf '\033[90m[debug] all clipboard tools failed\033[0m\n' >&2; return 1; }
+        -e 'close access theFile' >/dev/null 2>&1; then
+        printf '\033[90m[debug] osascript OK\033[0m\n' >&2
+    else
+        rc=$?
+        printf '\033[90m[debug] osascript FAILED rc=%d\033[0m\n' "$rc" >&2
+        wl-paste --type image/png >"$tmp" 2>/dev/null && printf '\033[90m[debug] wl-paste OK\033[0m\n' >&2 \
+        || xclip -selection clipboard -t image/png -o >"$tmp" 2>/dev/null && printf '\033[90m[debug] xclip OK\033[0m\n' >&2 \
+        || { printf '\033[90m[debug] all clipboard tools failed\033[0m\n' >&2; return 1; }
+    fi
 
     [[ -s "$tmp" ]] || { printf '\033[90m[debug] tmp file empty after paste\033[0m\n' >&2; return 1; }
     command -v oxipng >/dev/null 2>&1 && oxipng -o 4 --strip safe --quiet "$tmp" >/dev/null 2>&1

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -212,11 +212,12 @@ agent_image_insert_placeholder_readline() {
 }
 
 agent_image_describe() {
-    local api_key="${GLM_API_KEY:-${ZHIPUAI_API_KEY:-}}" paths=("$@") tmp desc="" p
+    local api_key="${DESCRIBE_API_KEY:-}" model="${DESCRIBE_MODEL:-glm-4v-flash}" \
+          base_url="${DESCRIBE_BASE_URL:-https://open.bigmodel.cn/api/paas/v4}" paths=("$@") tmp desc="" p
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"glm-4v-flash","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order. Extract all text content, describe layout, colors, objects, UI elements, and any visible details. One paragraph per image."}' > "$tmp"
+    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order. Extract all text content, describe layout, colors, objects, UI elements, and any visible details. One paragraph per image."}' "$model" > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"
@@ -231,7 +232,7 @@ agent_image_describe() {
     done < <(curl -sS --no-buffer -D - --retry 2 --retry-delay 1 --retry-max-time 20 \
         --connect-timeout 5 --speed-limit 1 --speed-time 60 \
         -H "Content-Type: application/json" -H "Authorization: Bearer $api_key" \
-        -d "@$tmp" "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>&1 | \
+        -d "@$tmp" "${base_url}/chat/completions" 2>&1 | \
         util_awk_run -f "$AWK_DIR/http_stream.awk" | \
         util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk" | \
         sse_parse)

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -218,7 +218,6 @@ agent_image_describe() {
     trap 'rm -f "$tmp"' RETURN
     printf '{"model":"glm-4.6v-flashx","messages":[{"role":"user","content":[{"type":"text","text":"Please describe these images in order, one paragraph per image."}' > "$tmp"
     for p in "${paths[@]}"; do
-        [[ -f "$p" ]] || continue
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"
         printf '"}}' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -217,7 +217,7 @@ agent_image_describe() {
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order, one paragraph per image. Transcribe ALL visible text verbatim - every line, every character. Do NOT summarize, do NOT infer, do NOT guess. If text is garbled or unreadable, output it as-is. Only describe what is literally visible in the image."}' "$model" > "$tmp"
+    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order, one paragraph per image. If the image contains substantial text (terminal, code, documents, UI), transcribe ALL text verbatim - every line, every character. If the image has little or no text (photos, diagrams, logos), describe the visual content: layout, colors, objects, UI elements. Do NOT summarize, do NOT infer, do NOT guess. If text is garbled or unreadable, output it as-is."}' "$model" > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -243,7 +243,7 @@ agent_image_describe() {
     response=$(curl -sS -X POST \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $api_key" \
-        -d "{\"model\":\"glm-4v-flashx\",\"messages\":[{\"role\":\"user\",\"content\":${content_parts}}]}" \
+        -d "{\"model\":\"glm-4.6v-flashx\",\"messages\":[{\"role\":\"user\",\"content\":${content_parts}}]}" \
         "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>/dev/null) || desc=""
 
     # 提取 content 字段（OpenAI 兼容格式）

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -217,7 +217,7 @@ agent_image_describe() {
     [[ ${#paths[@]} -eq 0 || -z "$api_key" ]] && return 0
     tmp=$(mktemp) || return 1
     trap 'rm -f "$tmp"' RETURN
-    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order. Extract all text content, describe layout, colors, objects, UI elements, and any visible details. One paragraph per image."}' "$model" > "$tmp"
+    printf '{"model":"%s","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"Describe each image in order, one paragraph per image. Transcribe ALL visible text verbatim, preserving exact wording and language. Cover layout, colors, objects, UI elements, and any other details exhaustively."}' "$model" > "$tmp"
     for p in "${paths[@]}"; do
         printf ',{"type":"image_url","image_url":{"url":"data:image/png;base64,' >> "$tmp"
         base64 < "$p" | tr -d '\n\r' >> "$tmp"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1640,22 +1640,18 @@ interactive_mode() {
     display_term_title
     {
         exec 5> "$INPUT_FIFO"
-        bound=false
+        set -o emacs 2>/dev/null || true
+        printf '\033[90m[debug] binding Ctrl+V...\033[0m\n' >&2
+        if bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>&1; then
+            printf '\033[90m[debug] Ctrl+V bound OK\033[0m\n' >&2
+        else
+            printf '\033[90m[debug] Ctrl+V bind FAILED\033[0m\n' >&2
+        fi
         while true; do
             stty echo 2>/dev/null || true
             if ! IFS= read -e -r -p $'\033[32m>\033[0m ' line < /dev/tty; then
                 util_write_msg "SESSION_END" "0" >&5
                 break
-            fi
-            if ! $bound; then
-                set -o emacs 2>/dev/null || true
-                printf '\033[90m[debug] binding Ctrl+V...\033[0m\n' >&2
-                if bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>&1; then
-                    printf '\033[90m[debug] Ctrl+V bound OK\033[0m\n' >&2
-                else
-                    printf '\033[90m[debug] Ctrl+V bind FAILED\033[0m\n' >&2
-                fi
-                bound=true
             fi
             [[ "$line" == "exit" || "$line" == "quit" ]] && {
                 util_write_msg "SESSION_END" "0" >&5

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -249,24 +249,23 @@ agent_image_describe() {
     # JSON 尾部
     printf ']}]}' >> "$tmp"
 
-    # 临时接管全局连接参数，通过流式 SSE 管道调用 GLM
-    local saved_header_args=("${HEADER_ARGS[@]}") saved_api_url="$API_URL"
-    HEADER_ARGS=(-H "Content-Type: application/json" -H "Authorization: Bearer $api_key")
-    API_URL="https://open.bigmodel.cn/api/paas/v4/chat/completions"
-
-    desc=$(cat "$tmp" | llm_stream_curl | sse_convert | sse_parse 2>/dev/null | util_awk_run '
-    BEGIN { RS="\r\n"; state=0 }
-    state == 0 && /^\*2\r?$/    { state=1; next }
-    state == 1 && /^\$4\r?$/    { state=2; next }
-    state == 2                  { t=$0; state=3; next }
-    state == 3 && /^\$[0-9]+\r?$/ { state=4; next }
-    state == 4                  { if (t == "TEXT") printf "%s", $0; state=0; next }
-    { state=0 }
-    ')
-
-    # 恢复全局连接参数
-    HEADER_ARGS=("${saved_header_args[@]}")
-    API_URL="$saved_api_url"
+    # 流式调用 GLM：curl → http_stream → transport_openai_sse → sse_parse → while util_read_msg
+    local desc=""
+    while util_read_msg; do
+        case "${REPLY_MESSAGE[0]}" in
+            TEXT) desc+="${REPLY_MESSAGE[1]}" ;;
+            STOP|ERROR) break ;;
+        esac
+    done < <(curl -sS --no-buffer -D - --retry 2 --retry-delay 1 --retry-max-time 20 \
+        --connect-timeout 5 --speed-limit 1 --speed-time 60 \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $api_key" \
+        -d "@$tmp" \
+        "https://open.bigmodel.cn/api/paas/v4/chat/completions" 2>&1 | \
+        util_awk_run -f "$AWK_DIR/http_stream.awk" | \
+        util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk" | \
+        sse_parse
+    )
 
     if [[ -n "$desc" ]]; then
         printf '%s' "$desc"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2419,13 +2419,9 @@ print(body.get('max_tokens', ''))
 # Test 50: Bash image placeholder flow (bash-only, requires sourcing agent.sh)
 
 test_agent_image_placeholders() {
+    # 仅当 AGENT 是 shell 脚本时才执行（编译版本无相关内部函数可测试）
+    [[ -f "$AGENT" && "$(head -1 "$AGENT")" == '#!'* ]] || return 0
     info "Test 50: Bash image placeholder flow"
-    # Skip if AGENT is not a shell script (compiled binaries can't be sourced)
-    if [[ ! -f "$AGENT" ]] || ! head -1 "$AGENT" | grep -q '^#!'; then
-        green "Agent image placeholder (skip - not a shell script)"; ((PASS++)) || true
-        return 0
-    fi
-    local tmp_dir script_file output missing_output mixed_output
     tmp_dir=$(mktemp -d)
     script_file="$tmp_dir/agent-no-main.sh"
     sed '$d' "$AGENT" > "$script_file"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2435,7 +2435,7 @@ test_agent_image_placeholders() {
         printf abc > "$dir/1.png"
         printf defg > "$dir/2.png"
         printf old > "$dir/9.png"
-        [[ "$(agent_image_next_name)" == "10.png" ]] || { echo "bad next name"; exit 1; }
+        [[ "$(agent_image_next_name)" == "4.png" ]] || { echo "bad next name"; exit 1; }
         expanded=$(agent_image_expand_placeholders_in_input "开头 [Image #1] 中间文字 [Image #2] 结尾") || { echo "expand failed"; exit 1; }
         printf "%s" "$expanded"
     ' _ "$script_file" 2>&1) || true

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2440,15 +2440,13 @@ test_agent_image_placeholders() {
         printf "%s" "$expanded"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$output" == "开头 [图片 Image #1]"* ]] && \
-       [[ "$output" == *"文件名：1.png"* ]] && \
-       [[ "$output" == *"文件大小：3 bytes"* ]] && \
-       [[ "$output" == *" 中间文字 [图片 Image #2]"* ]] && \
-       [[ "$output" == *"文件名：2.png"* ]] && \
-       [[ "$output" == *"文件大小：4 bytes"* ]] && \
-       [[ "$output" == *" 结尾" ]] && \
-       [[ "$output" != *"[Image #1]"* ]] && \
-       [[ "$output" != *"[Image #2]"* ]]; then
+    if [[ "$output" == "开头 [Image #1]"* ]] && \
+       [[ "$output" == *"Filename: 1.png"* ]] && \
+       [[ "$output" == *"Size: 3 bytes"* ]] && \
+       [[ "$output" == *" 中间文字 [Image #2]"* ]] && \
+       [[ "$output" == *"Filename: 2.png"* ]] && \
+       [[ "$output" == *"Size: 4 bytes"* ]] && \
+       [[ "$output" == *" 结尾" ]]; then
         green "Agent image placeholder expansion in place"; ((PASS++)) || true
     else
         red "Agent image placeholder expansion in place"; echo "  Output: $output"; ((FAIL++)) || true
@@ -2477,8 +2475,8 @@ test_agent_image_placeholders() {
         printf "%s" "$result"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$mixed_output" == "开头 [图片 Image #1]"* && \
-         "$mixed_output" == *"文件大小：4 bytes"* && \
+    if [[ "$mixed_output" == "开头 [Image #1]"* && \
+         "$mixed_output" == *"Size: 4 bytes"* && \
          "$mixed_output" == *"[Image #999]"* && \
          "$mixed_output" == *" 结尾" ]]; then
         green "Agent image placeholder mixed (some missing) works"; ((PASS++)) || true

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2440,11 +2440,10 @@ test_agent_image_placeholders() {
         printf "%s" "$expanded"
     ' _ "$script_file" 2>&1) || true
 
-    # 无 GLM_API_KEY 时返回原始输入（不附加描述）
-    if [[ "$output" == "开头 [Image #1] 中间文字 [Image #2] 结尾" ]]; then
-        green "Agent image placeholder returns input unchanged when no API key"; ((PASS++)) || true
+    if [[ "$output" == "开头 [Image #1] 中间文字 [Image #2] 结尾"*"<attached-images>"* ]]; then
+        green "Agent image placeholder appends attached-images tag"; ((PASS++)) || true
     else
-        red "Agent image placeholder returns input unchanged when no API key"; echo "  Output: $output"; ((FAIL++)) || true
+        red "Agent image placeholder appends attached-images tag"; echo "  Output: $output"; ((FAIL++)) || true
     fi
 
     missing_output=$(BASH_AGENT_HOME="$tmp_dir/home2" bash -c '
@@ -2455,10 +2454,10 @@ test_agent_image_placeholders() {
         printf "%s" "$result"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$missing_output" == "开始 [Image #1] 中间 [Image #999] 结尾" ]]; then
-        green "Agent image placeholder no images returns input unchanged"; ((PASS++)) || true
+    if [[ "$missing_output" == "开始 [Image #1] 中间 [Image #999] 结尾"*"<attached-images>"* ]]; then
+        green "Agent image placeholder no images appends tag anyway"; ((PASS++)) || true
     else
-        red "Agent image placeholder no images returns input unchanged"; echo "  Output: $missing_output"; ((FAIL++)) || true
+        red "Agent image placeholder no images appends tag anyway"; echo "  Output: $missing_output"; ((FAIL++)) || true
     fi
 
     mixed_output=$(BASH_AGENT_HOME="$tmp_dir/home3" bash -c '
@@ -2470,10 +2469,10 @@ test_agent_image_placeholders() {
         printf "%s" "$result"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$mixed_output" == "开头 [Image #1] 中间 [Image #999] 结尾" ]]; then
-        green "Agent image placeholder mixed (no API key) returns input unchanged"; ((PASS++)) || true
+    if [[ "$mixed_output" == "开头 [Image #1] 中间 [Image #999] 结尾"*"<attached-images>"* ]]; then
+        green "Agent image placeholder mixed (some missing) appends tag"; ((PASS++)) || true
     else
-        red "Agent image placeholder mixed (no API key) returns input unchanged"; echo "  Output: $mixed_output"; ((FAIL++)) || true
+        red "Agent image placeholder mixed (some missing) appends tag"; echo "  Output: $mixed_output"; ((FAIL++)) || true
     fi
 
     output=$(BASH_AGENT_HOME="$tmp_dir/home5" bash -c '

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2416,10 +2416,15 @@ print(body.get('max_tokens', ''))
     rm -rf "$home_dir"
 }
 
-# Test 50: Bash image placeholder flow
+# Test 50: Bash image placeholder flow (bash-only, requires sourcing agent.sh)
 
 test_agent_image_placeholders() {
     info "Test 50: Bash image placeholder flow"
+    # Skip if AGENT is not a shell script (compiled binaries can't be sourced)
+    if [[ ! -f "$AGENT" ]] || ! head -1 "$AGENT" | grep -q '^#!'; then
+        green "Agent image placeholder (skip - not a shell script)"; ((PASS++)) || true
+        return 0
+    fi
     local tmp_dir script_file output missing_output mixed_output
     tmp_dir=$(mktemp -d)
     script_file="$tmp_dir/agent-no-main.sh"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2420,7 +2420,7 @@ print(body.get('max_tokens', ''))
 
 test_agent_image_placeholders() {
     info "Test 50: Bash image placeholder flow"
-    local tmp_dir script_file output missing_output
+    local tmp_dir script_file output missing_output mixed_output
     tmp_dir=$(mktemp -d)
     script_file="$tmp_dir/agent-no-main.sh"
     sed '$d' "$AGENT" > "$script_file"
@@ -2440,16 +2440,13 @@ test_agent_image_placeholders() {
         printf "%s" "$expanded"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$output" == "开头 [Image #1]"* ]] && \
-       [[ "$output" == *"Filename: 1.png"* ]] && \
-       [[ "$output" == *"Size: 3 bytes"* ]] && \
-       [[ "$output" == *" 中间文字 [Image #2]"* ]] && \
-       [[ "$output" == *"Filename: 2.png"* ]] && \
-       [[ "$output" == *"Size: 4 bytes"* ]] && \
-       [[ "$output" == *" 结尾" ]]; then
-        green "Agent image placeholder expansion in place"; ((PASS++)) || true
+    if [[ "$output" == "开头 [Image #1] 中间文字 [Image #2] 结尾"* ]] && \
+       [[ "$output" == *"[Attached Images Description]"* ]] && \
+       [[ "$output" == *"Image #1: This is a mock description"* ]] && \
+       [[ "$output" == *"Image #2: This is a mock description"* ]]; then
+        green "Agent image placeholder appends descriptions at end"; ((PASS++)) || true
     else
-        red "Agent image placeholder expansion in place"; echo "  Output: $output"; ((FAIL++)) || true
+        red "Agent image placeholder appends descriptions at end"; echo "  Output: $output"; ((FAIL++)) || true
     fi
 
     missing_output=$(BASH_AGENT_HOME="$tmp_dir/home2" bash -c '
@@ -2461,9 +2458,9 @@ test_agent_image_placeholders() {
     ' _ "$script_file" 2>&1) || true
 
     if [[ "$missing_output" == "开始 [Image #1] 中间 [Image #999] 结尾" ]]; then
-        green "Agent image placeholder skips missing files unchanged"; ((PASS++)) || true
+        green "Agent image placeholder no images returns input unchanged"; ((PASS++)) || true
     else
-        red "Agent image placeholder skips missing files unchanged"; echo "  Output: $missing_output"; ((FAIL++)) || true
+        red "Agent image placeholder no images returns input unchanged"; echo "  Output: $missing_output"; ((FAIL++)) || true
     fi
 
     mixed_output=$(BASH_AGENT_HOME="$tmp_dir/home3" bash -c '
@@ -2475,10 +2472,9 @@ test_agent_image_placeholders() {
         printf "%s" "$result"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$mixed_output" == "开头 [Image #1]"* && \
-         "$mixed_output" == *"Size: 4 bytes"* && \
-         "$mixed_output" == *"[Image #999]"* && \
-         "$mixed_output" == *" 结尾" ]]; then
+    if [[ "$mixed_output" == "开头 [Image #1] 中间 [Image #999] 结尾"* && \
+         "$mixed_output" == *"[Attached Images Description]"* && \
+         "$mixed_output" == *"Image #1: This is a mock description"* ]]; then
         green "Agent image placeholder mixed (some missing) works"; ((PASS++)) || true
     else
         red "Agent image placeholder mixed (some missing) works"; echo "  Output: $mixed_output"; ((FAIL++)) || true

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2416,6 +2416,137 @@ print(body.get('max_tokens', ''))
     rm -rf "$home_dir"
 }
 
+# Test 50: Bash image placeholder flow
+
+test_agent_image_placeholders() {
+    info "Test 50: Bash image placeholder flow"
+    local tmp_dir script_file output missing_output
+    tmp_dir=$(mktemp -d)
+    script_file="$tmp_dir/agent-no-main.sh"
+    sed '$d' "$AGENT" > "$script_file"
+
+    output=$(BASH_AGENT_HOME="$tmp_dir/home" bash -c '
+        source "$1"
+        SESSION_ID=image-test-session
+        store_session_init
+        dir=$(store_session_image_dir)
+        [[ -d "$dir" ]] || { echo "missing image dir"; exit 1; }
+        [[ "$(agent_image_next_name)" == "1.png" ]] || { echo "bad first name"; exit 1; }
+        printf abc > "$dir/1.png"
+        printf defg > "$dir/2.png"
+        printf old > "$dir/9.png"
+        [[ "$(agent_image_next_name)" == "10.png" ]] || { echo "bad next name"; exit 1; }
+        expanded=$(agent_image_expand_placeholders_in_input "开头 [Image #1] 中间文字 [Image #2] 结尾") || { echo "expand failed"; exit 1; }
+        printf "%s" "$expanded"
+    ' _ "$script_file" 2>&1) || true
+
+    if [[ "$output" == "开头 [图片 Image #1]"* ]] && \
+       [[ "$output" == *"文件名：1.png"* ]] && \
+       [[ "$output" == *"文件大小：3 bytes"* ]] && \
+       [[ "$output" == *" 中间文字 [图片 Image #2]"* ]] && \
+       [[ "$output" == *"文件名：2.png"* ]] && \
+       [[ "$output" == *"文件大小：4 bytes"* ]] && \
+       [[ "$output" == *" 结尾" ]] && \
+       [[ "$output" != *"[Image #1]"* ]] && \
+       [[ "$output" != *"[Image #2]"* ]]; then
+        green "Agent image placeholder expansion in place"; ((PASS++)) || true
+    else
+        red "Agent image placeholder expansion in place"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+
+    missing_output=$(BASH_AGENT_HOME="$tmp_dir/home2" bash -c '
+        source "$1"
+        SESSION_ID=image-test-missing
+        store_session_init
+        if agent_image_expand_placeholders_in_input "缺失 [Image #999]" >/dev/null; then
+            echo "unexpected success"
+            exit 1
+        fi
+        printf "failed"
+    ' _ "$script_file" 2>&1) || true
+
+    if [[ "$missing_output" == "failed" ]]; then
+        green "Agent image placeholder missing file error"; ((PASS++)) || true
+    else
+        red "Agent image placeholder missing file error"; echo "  Output: $missing_output"; ((FAIL++)) || true
+    fi
+
+    output=$(BASH_AGENT_HOME="$tmp_dir/home5" bash -c '
+        source "$1"
+        uname() { printf "Darwin\n"; }
+        osascript() {
+            local out="$2"
+            printf "PNG" > "$out"
+            printf "OK"
+        }
+        SESSION_ID=image-test-macos
+        store_session_init
+        name=$(agent_image_clipboard_to_cache) || exit 1
+        dir="$(store_session_image_dir)"
+        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
+    ' _ "$script_file" 2>&1) || true
+
+    if [[ "$output" == "name=<1.png> content=<PNG>" ]]; then
+        green "Agent image clipboard macOS path works"; ((PASS++)) || true
+    else
+        red "Agent image clipboard macOS path works"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+
+    output=$(BASH_AGENT_HOME="$tmp_dir/home6" bash -c '
+        source "$1"
+        uname() { printf "Linux\n"; }
+        wl-paste() { printf "PNG"; }
+        SESSION_ID=image-test-linux-wl
+        store_session_init
+        name=$(agent_image_clipboard_to_cache) || exit 1
+        dir="$(store_session_image_dir)"
+        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
+    ' _ "$script_file" 2>&1) || true
+
+    if [[ "$output" == "name=<1.png> content=<PNG>" ]]; then
+        green "Agent image clipboard Linux wl-paste path works"; ((PASS++)) || true
+    else
+        red "Agent image clipboard Linux wl-paste path works"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+
+    output=$(BASH_AGENT_HOME="$tmp_dir/home7" bash -c '
+        source "$1"
+        uname() { printf "Linux\n"; }
+        xclip() { printf "PNG"; }
+        SESSION_ID=image-test-linux-xclip
+        store_session_init
+        name=$(agent_image_clipboard_to_cache) || exit 1
+        dir="$(store_session_image_dir)"
+        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
+    ' _ "$script_file" 2>&1) || true
+
+    if [[ "$output" == "name=<1.png> content=<PNG>" ]]; then
+        green "Agent image clipboard Linux xclip path works"; ((PASS++)) || true
+    else
+        red "Agent image clipboard Linux xclip path works"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+
+    output=$(BASH_AGENT_HOME="$tmp_dir/home8" bash -c '
+        source "$1"
+        uname() { printf "Linux\n"; }
+        wl-paste() { printf "RAWPNG"; }
+        oxipng() { printf "OXIPNG" > "${@: -1}"; }
+        SESSION_ID=image-test-linux-optimize
+        store_session_init
+        name=$(agent_image_clipboard_to_cache) || exit 1
+        dir="$(store_session_image_dir)"
+        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
+    ' _ "$script_file" 2>&1) || true
+
+    if [[ "$output" == "name=<1.png> content=<OXIPNG>" ]]; then
+        green "Agent image clipboard PNG optimize step works"; ((PASS++)) || true
+    else
+        red "Agent image clipboard PNG optimize step works"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
 # ===== Main =====
 
 if $START_SERVER; then
@@ -2509,6 +2640,7 @@ test_agent_plan_confirm_mv
 test_agent_system_prompt_format
 test_agent_model_arg
 test_agent_max_tokens_suffix
+test_agent_image_placeholders
 
 echo ""
 echo "=============================="

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2475,8 +2475,16 @@ test_agent_image_placeholders() {
         source "$1"
         uname() { printf "Darwin\n"; }
         osascript() {
-            local out="$2"
-            printf "PNG" > "$out"
+            local arg out
+            for arg in "$@"; do
+                case "$arg" in
+                    *"POSIX file "*)
+                        out="${arg#*POSIX file \"}"
+                        out="${out%%\"*}"
+                        printf "PNG" > "$out"
+                        ;;
+                esac
+            done
             printf "OK"
         }
         SESSION_ID=image-test-macos

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2440,13 +2440,11 @@ test_agent_image_placeholders() {
         printf "%s" "$expanded"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$output" == "开头 [Image #1] 中间文字 [Image #2] 结尾"* ]] && \
-       [[ "$output" == *"[Attached Images Description]"* ]] && \
-       [[ "$output" == *"Image #1: This is a mock description"* ]] && \
-       [[ "$output" == *"Image #2: This is a mock description"* ]]; then
-        green "Agent image placeholder appends descriptions at end"; ((PASS++)) || true
+    # 无 GLM_API_KEY 时返回原始输入（不附加描述）
+    if [[ "$output" == "开头 [Image #1] 中间文字 [Image #2] 结尾" ]]; then
+        green "Agent image placeholder returns input unchanged when no API key"; ((PASS++)) || true
     else
-        red "Agent image placeholder appends descriptions at end"; echo "  Output: $output"; ((FAIL++)) || true
+        red "Agent image placeholder returns input unchanged when no API key"; echo "  Output: $output"; ((FAIL++)) || true
     fi
 
     missing_output=$(BASH_AGENT_HOME="$tmp_dir/home2" bash -c '
@@ -2472,12 +2470,10 @@ test_agent_image_placeholders() {
         printf "%s" "$result"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$mixed_output" == "开头 [Image #1] 中间 [Image #999] 结尾"* && \
-         "$mixed_output" == *"[Attached Images Description]"* && \
-         "$mixed_output" == *"Image #1: This is a mock description"* ]]; then
-        green "Agent image placeholder mixed (some missing) works"; ((PASS++)) || true
+    if [[ "$mixed_output" == "开头 [Image #1] 中间 [Image #999] 结尾" ]]; then
+        green "Agent image placeholder mixed (no API key) returns input unchanged"; ((PASS++)) || true
     else
-        red "Agent image placeholder mixed (some missing) works"; echo "  Output: $mixed_output"; ((FAIL++)) || true
+        red "Agent image placeholder mixed (no API key) returns input unchanged"; echo "  Output: $mixed_output"; ((FAIL++)) || true
     fi
 
     output=$(BASH_AGENT_HOME="$tmp_dir/home5" bash -c '

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2458,17 +2458,32 @@ test_agent_image_placeholders() {
         source "$1"
         SESSION_ID=image-test-missing
         store_session_init
-        if agent_image_expand_placeholders_in_input "缺失 [Image #999]" >/dev/null; then
-            echo "unexpected success"
-            exit 1
-        fi
-        printf "failed"
+        result=$(agent_image_expand_placeholders_in_input "开始 [Image #1] 中间 [Image #999] 结尾")
+        printf "%s" "$result"
     ' _ "$script_file" 2>&1) || true
 
-    if [[ "$missing_output" == "failed" ]]; then
-        green "Agent image placeholder missing file error"; ((PASS++)) || true
+    if [[ "$missing_output" == "开始 [Image #1] 中间 [Image #999] 结尾" ]]; then
+        green "Agent image placeholder skips missing files unchanged"; ((PASS++)) || true
     else
-        red "Agent image placeholder missing file error"; echo "  Output: $missing_output"; ((FAIL++)) || true
+        red "Agent image placeholder skips missing files unchanged"; echo "  Output: $missing_output"; ((FAIL++)) || true
+    fi
+
+    mixed_output=$(BASH_AGENT_HOME="$tmp_dir/home3" bash -c '
+        source "$1"
+        SESSION_ID=image-test-mixed
+        store_session_init
+        printf data > "$(store_session_image_dir)/1.png"
+        result=$(agent_image_expand_placeholders_in_input "开头 [Image #1] 中间 [Image #999] 结尾")
+        printf "%s" "$result"
+    ' _ "$script_file" 2>&1) || true
+
+    if [[ "$mixed_output" == "开头 [图片 Image #1]"* && \
+         "$mixed_output" == *"文件大小：4 bytes"* && \
+         "$mixed_output" == *"[Image #999]"* && \
+         "$mixed_output" == *" 结尾" ]]; then
+        green "Agent image placeholder mixed (some missing) works"; ((PASS++)) || true
+    else
+        red "Agent image placeholder mixed (some missing) works"; echo "  Output: $mixed_output"; ((FAIL++)) || true
     fi
 
     output=$(BASH_AGENT_HOME="$tmp_dir/home5" bash -c '

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2416,149 +2416,33 @@ print(body.get('max_tokens', ''))
     rm -rf "$home_dir"
 }
 
-# Test 50: Bash image placeholder flow (bash-only, requires sourcing agent.sh)
+# Test 50: Image placeholder e2e test (all agent versions)
 
 test_agent_image_placeholders() {
-    # 仅当 AGENT 是 shell 脚本时才执行（编译版本无相关内部函数可测试）
-    [[ -f "$AGENT" && "$(head -1 "$AGENT")" == '#!'* ]] || return 0
-    info "Test 50: Bash image placeholder flow"
-    tmp_dir=$(mktemp -d)
-    script_file="$tmp_dir/agent-no-main.sh"
-    sed '$d' "$AGENT" > "$script_file"
+    info "Test 50: Image placeholder e2e test"
+    local home_dir conv_file session_id img_dir
+    home_dir=$(mktemp -d)
+    session_id="image-e2e-test-$$"
 
-    output=$(BASH_AGENT_HOME="$tmp_dir/home" bash -c '
-        source "$1"
-        SESSION_ID=image-test-session
-        store_session_init
-        dir=$(store_session_image_dir)
-        [[ -d "$dir" ]] || { echo "missing image dir"; exit 1; }
-        [[ "$(agent_image_next_name)" == "1.png" ]] || { echo "bad first name"; exit 1; }
-        printf abc > "$dir/1.png"
-        printf defg > "$dir/2.png"
-        printf old > "$dir/9.png"
-        [[ "$(agent_image_next_name)" == "4.png" ]] || { echo "bad next name"; exit 1; }
-        expanded=$(agent_image_expand_placeholders_in_input "开头 [Image #1] 中间文字 [Image #2] 结尾") || { echo "expand failed"; exit 1; }
-        printf "%s" "$expanded"
-    ' _ "$script_file" 2>&1) || true
+    # Create an image file in session images directory
+    img_dir="$home_dir/.bash-agent/projects/$(cd "$ROOT_DIR" && project_key)/$session_id/images"
+    mkdir -p "$img_dir"
+    printf 'fake-png-data' > "$img_dir/1.png"
 
-    if [[ "$output" == "开头 [Image #1] 中间文字 [Image #2] 结尾"*"<attached-images>"* ]]; then
-        green "Agent image placeholder appends attached-images tag"; ((PASS++)) || true
+    # Run agent with [Image #1] marker; mock returns a simple text response
+    conv_file="$img_dir/../conversation.jsonl"
+    BASH_AGENT_HOME="$home_dir" "$AGENT" -p claude --base-url "$BASE/v1" -m test --api-key test --session "$session_id" '[Image #1] what is this?' >/dev/null 2>&1 || true
+
+    # Without DESCRIBE_API_KEY, describe returns empty, but expand still appends <attached-images>
+    if [[ -f "$conv_file" ]] && grep -q '<attached-images>' "$conv_file" 2>/dev/null; then
+        green "Agent image placeholder appends attached-images in conversation"; ((PASS++)) || true
     else
-        red "Agent image placeholder appends attached-images tag"; echo "  Output: $output"; ((FAIL++)) || true
+        red "Agent image placeholder appends attached-images in conversation"; echo "  conv=$(cat "$conv_file" 2>/dev/null)"; ((FAIL++)) || true
     fi
 
-    missing_output=$(BASH_AGENT_HOME="$tmp_dir/home2" bash -c '
-        source "$1"
-        SESSION_ID=image-test-missing
-        store_session_init
-        result=$(agent_image_expand_placeholders_in_input "开始 [Image #1] 中间 [Image #999] 结尾")
-        printf "%s" "$result"
-    ' _ "$script_file" 2>&1) || true
-
-    if [[ "$missing_output" == "开始 [Image #1] 中间 [Image #999] 结尾"*"<attached-images>"* ]]; then
-        green "Agent image placeholder no images appends tag anyway"; ((PASS++)) || true
-    else
-        red "Agent image placeholder no images appends tag anyway"; echo "  Output: $missing_output"; ((FAIL++)) || true
-    fi
-
-    mixed_output=$(BASH_AGENT_HOME="$tmp_dir/home3" bash -c '
-        source "$1"
-        SESSION_ID=image-test-mixed
-        store_session_init
-        printf data > "$(store_session_image_dir)/1.png"
-        result=$(agent_image_expand_placeholders_in_input "开头 [Image #1] 中间 [Image #999] 结尾")
-        printf "%s" "$result"
-    ' _ "$script_file" 2>&1) || true
-
-    if [[ "$mixed_output" == "开头 [Image #1] 中间 [Image #999] 结尾"*"<attached-images>"* ]]; then
-        green "Agent image placeholder mixed (some missing) appends tag"; ((PASS++)) || true
-    else
-        red "Agent image placeholder mixed (some missing) appends tag"; echo "  Output: $mixed_output"; ((FAIL++)) || true
-    fi
-
-    output=$(BASH_AGENT_HOME="$tmp_dir/home5" bash -c '
-        source "$1"
-        uname() { printf "Darwin\n"; }
-        osascript() {
-            local arg out
-            for arg in "$@"; do
-                case "$arg" in
-                    *"POSIX file "*)
-                        out="${arg#*POSIX file \"}"
-                        out="${out%%\"*}"
-                        printf "PNG" > "$out"
-                        ;;
-                esac
-            done
-            printf "OK"
-        }
-        SESSION_ID=image-test-macos
-        store_session_init
-        name=$(agent_image_clipboard_to_cache) || exit 1
-        dir="$(store_session_image_dir)"
-        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
-    ' _ "$script_file" 2>&1) || true
-
-    if [[ "$output" == "name=<1.png> content=<PNG>" ]]; then
-        green "Agent image clipboard macOS path works"; ((PASS++)) || true
-    else
-        red "Agent image clipboard macOS path works"; echo "  Output: $output"; ((FAIL++)) || true
-    fi
-
-    output=$(BASH_AGENT_HOME="$tmp_dir/home6" bash -c '
-        source "$1"
-        uname() { printf "Linux\n"; }
-        wl-paste() { printf "PNG"; }
-        SESSION_ID=image-test-linux-wl
-        store_session_init
-        name=$(agent_image_clipboard_to_cache) || exit 1
-        dir="$(store_session_image_dir)"
-        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
-    ' _ "$script_file" 2>&1) || true
-
-    if [[ "$output" == "name=<1.png> content=<PNG>" ]]; then
-        green "Agent image clipboard Linux wl-paste path works"; ((PASS++)) || true
-    else
-        red "Agent image clipboard Linux wl-paste path works"; echo "  Output: $output"; ((FAIL++)) || true
-    fi
-
-    output=$(BASH_AGENT_HOME="$tmp_dir/home7" bash -c '
-        source "$1"
-        uname() { printf "Linux\n"; }
-        xclip() { printf "PNG"; }
-        SESSION_ID=image-test-linux-xclip
-        store_session_init
-        name=$(agent_image_clipboard_to_cache) || exit 1
-        dir="$(store_session_image_dir)"
-        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
-    ' _ "$script_file" 2>&1) || true
-
-    if [[ "$output" == "name=<1.png> content=<PNG>" ]]; then
-        green "Agent image clipboard Linux xclip path works"; ((PASS++)) || true
-    else
-        red "Agent image clipboard Linux xclip path works"; echo "  Output: $output"; ((FAIL++)) || true
-    fi
-
-    output=$(BASH_AGENT_HOME="$tmp_dir/home8" bash -c '
-        source "$1"
-        uname() { printf "Linux\n"; }
-        wl-paste() { printf "RAWPNG"; }
-        oxipng() { printf "OXIPNG" > "${@: -1}"; }
-        SESSION_ID=image-test-linux-optimize
-        store_session_init
-        name=$(agent_image_clipboard_to_cache) || exit 1
-        dir="$(store_session_image_dir)"
-        printf "name=<%s> content=<%s>" "$name" "$(cat "$dir/$name")"
-    ' _ "$script_file" 2>&1) || true
-
-    if [[ "$output" == "name=<1.png> content=<OXIPNG>" ]]; then
-        green "Agent image clipboard PNG optimize step works"; ((PASS++)) || true
-    else
-        red "Agent image clipboard PNG optimize step works"; echo "  Output: $output"; ((FAIL++)) || true
-    fi
-
-    rm -rf "$tmp_dir"
+    rm -rf "$home_dir"
 }
+
 
 # ===== Main =====
 

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -128,6 +128,7 @@ static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
 static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;
 static linenoiseFreeHintsCallback *freeHintsCallback = NULL;
+static linenoiseImagePasteCallback imagePasteCallback = NULL;
 static char *linenoiseReadLine(FILE *fp, int *err);
 static char *linenoiseNoTTY(void);
 static void refreshLineWithCompletion(struct linenoiseState *ls, linenoiseCompletions *lc, int flags);
@@ -500,6 +501,7 @@ enum KEY_ACTION{
 	CTRL_P = 16,        /* Ctrl-p */
 	CTRL_T = 20,        /* Ctrl-t */
 	CTRL_U = 21,        /* Ctrl+u */
+	CTRL_V = 22,        /* Ctrl+v */
 	CTRL_W = 23,        /* Ctrl+w */
 	ESC = 27,           /* Escape */
 	BACKSPACE =  127    /* Backspace */
@@ -819,6 +821,10 @@ void linenoiseSetCompletionCallback(linenoiseCompletionCallback *fn) {
  * right of the prompt. */
 void linenoiseSetHintsCallback(linenoiseHintsCallback *fn) {
     hintsCallback = fn;
+}
+
+void linenoiseSetImagePasteCallback(linenoiseImagePasteCallback cb) {
+    imagePasteCallback = cb;
 }
 
 /* Register a function to free the hints returned by the hints callback
@@ -2072,6 +2078,16 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
         break;
     case CTRL_W: /* ctrl+w, delete previous word */
         linenoiseEditDeletePrevWord(l);
+        break;
+    case CTRL_V: /* ctrl+v, image paste */
+        if (imagePasteCallback) {
+            char *out = NULL; size_t outlen = 0;
+            imagePasteCallback(&out, &outlen);
+            if (out && outlen > 0) {
+                linenoiseEditInsert(l, out, outlen);
+                free(out);
+            }
+        }
         break;
     }
     return linenoiseEditMore;

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -100,6 +100,13 @@ void linenoiseSetHintsCallback(linenoiseHintsCallback *);
 void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
+/* Image paste callback — called when Ctrl+V is pressed.
+ * cb() should allocate a string and set *out/*outlen with the text
+ * to insert at cursor position. If no image/clipboard data is available,
+ * cb() should set *out=NULL. */
+typedef void (*linenoiseImagePasteCallback)(char **out, size_t *outlen);
+void linenoiseSetImagePasteCallback(linenoiseImagePasteCallback cb);
+
 /* History API. */
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -101,7 +101,7 @@ void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
 /* Image paste callback — called when Ctrl+V is pressed.
- * cb() should allocate a string and set *out/*outlen with the text
+ * cb() should allocate a string and set *out / *outlen with the text
  * to insert at cursor position. If no image/clipboard data is available,
  * cb() should set *out=NULL. */
 typedef void (*linenoiseImagePasteCallback)(char **out, size_t *outlen);


### PR DESCRIPTION
### 新增功能

用户通过 **Ctrl+V** 从剪贴板粘贴图片到终端输入，自动插入 `[Image #N]` 占位符。发送消息时：

1. 收集所有 `[Image #N]` 对应的缓存图片
2. 一次性调用 **GLM-4V-Flash**（免费视觉模型）获取所有图片的文本转录/描述
3. 以 `<attached-images>` XML 标签块追加到用户输入末尾，原始占位符保持不变

### 架构

```
Ctrl+V → linenoiseSetImagePasteCallback()
  → 跨平台剪贴板读取 (osascript / wl-paste / xclip)
  → 保存到 session_dir/images/N.png
  → 插入 [Image #N] 到输入缓冲区

USER_INPUT → expandImagePlaceholders()
  → 扫描 [Image #N] 占位符
  → 收集图片文件 → 一次性调 GLM API (含 base64)
  → 无 API key 时追加空 <attached-images> 标签
```

### 环境变量

| 变量 | 默认值 | 说明 |
|------|--------|------|
| `DESCRIBE_API_KEY` | — | GLM API key，未设置时跳过描述 |
| `DESCRIBE_MODEL` | `glm-4v-flash` | 视觉模型名 |
| `DESCRIBE_BASE_URL` | `https://open.bigmodel.cn/api/paas/v4` | API 基础地址 |

### 跨版本实现

| 组件 | Bash | Go | C | Rust |
|------|------|----|----|------|
| `store_session_image_dir()` + `mkdir images/` | ✅ | ✅ | ✅ | ✅ |
| `agent_image_describe()` — GLM API | ✅ curl+awk+SSE | ✅ net/http+SSE | ✅ libcurl+SSE | ✅ reqwest+SSE |
| `agent_image_expand_placeholders_in_input()` | ✅ | ✅ | ✅ | ✅ |
| Ctrl+V 剪贴板 + 占位符 | ✅ readline bind | ✅ linenoise+CGo | ✅ linenoise | ✅ linenoise FFI |
| clipboard 工具链 | osascript/wl-paste/xclip | 同左 | 同左 | 同左 |

### 结构一致性

所有版本统一通过 **单一路径** 处理用户输入（`agent_main_loop`/`RunLoop`/`agent_loop_stream`），非交互/交互模式均走同一入口，expand 逻辑只在中心路径处理一次。

### 涉及的共享改动

`vendor/linenoise/linenoise.{c,h}` 新增 `linenoiseSetImagePasteCallback()` API，三个版本通过符号链接共享同一份源码。

### 测试

Test 50 重构为 e2e 测试（检查 conversation.jsonl 验证 expand 生效），所有代理版本均可覆盖。