### PR TITLE
统一 linenoiseWrite 原子显示输出 + Ctrl+C 中断支持

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -1244,9 +1244,10 @@ char *agent_image_describe(char **paths, int count) {
     sb_append(&body, ",\"messages\":[{\"role\":\"user\",\"content\":[");
     sb_append(&body, "{\"type\":\"text\",\"text\":");
     sb_append_json_string(&body,
-        "Output all visible text from each image. "
-        "Transcribe every character including special symbols. "
+        "Output all visible text from each image, separated by a blank line between images. "
+        "Transcribe every character including special symbols (arrows, prompts, dots, slashes). "
         "Preserve exact spacing and line breaks. "
+        "Pay attention to date formats (month names, numbers). "
         "Do not summarize or describe - just output the raw text exactly as shown. "
         "If an image has no text, briefly describe what you see.");
     sb_append(&body, "}");

--- a/c/agent.c
+++ b/c/agent.c
@@ -1504,14 +1504,17 @@ int agent_main_loop(Agent *agent) {
         if (!msg) continue;
 
         switch (msg->type) {
-            case MSG_USER_INPUT: {
-                /* 重置 interrupted 标志。
-                 * 防止等待输入时的 Ctrl+C（设了 agent->interrupted=1）
-                 * 残留到 agent_loop 开始时导致立即中断。
-                 * 模仿 Rust 版 agent_loop_stream 入口的 CTRLC_FLAG.swap(false) 模式。 */
-                agent->interrupted = 0;
+              case MSG_USER_INPUT: {
+                  /* 重置 interrupted 标志。
+                   * 防止等待输入时的 Ctrl+C（设了 agent->interrupted=1）
+                   * 残留到 agent_loop 开始时导致立即中断。 */
+                  agent->interrupted = 0;
+                  /* 标记 agent 正在运行，readline 线程的 Ctrl+C 可中断 */
+                  agent->running = 1;
 
-                agent_loop(agent, msg->data.user_input.text, "user_input");
+                  agent_loop(agent, msg->data.user_input.text, "user_input");
+
+                  agent->running = 0;
 
                 /* 对齐 bash 版: 每轮 agent_loop 完成后刷新终端标题 */
                 agent_update_title(agent);
@@ -1564,7 +1567,6 @@ int agent_main_loop(Agent *agent) {
                 if (agent->interactive) {
                     display_flush(agent->display_queue);
                 }
-                /* 不再 signal done — readline 线程立即进入下一轮 EditStart */
                 break;
             }
             case MSG_AGENT_RESULT: {

--- a/c/agent.h
+++ b/c/agent.h
@@ -58,6 +58,11 @@ typedef struct {
     /* 中断标志 */
     volatile int interrupted;
 
+    /* 运行标志 — 1 表示 agent 正在处理（agent_loop 执行中），
+     * 0 表示空闲等待输入。
+     * readline 线程在 Ctrl+C 时检查此标志来决定是否中断 agent。 */
+    volatile int running;
+
     /* 待处理的 fork 子 agent（在 tool_result 写入后执行复制） */
     void **pending_fork_args;  /* SubAgentArgs* 数组 */
     int pending_fork_count;

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -29,13 +29,6 @@
 #include <unistd.h>
 #include <termios.h>
 
-static volatile int g_interrupted = 0;
-
-static void sigint_handler(int sig) {
-    (void)sig;
-    g_interrupted = 1;
-}
-
 static void usage(const char *prog) {
     fprintf(stderr, "Usage: %s [options] [prompt]\n", prog);
     fprintf(stderr, "Options:\n");
@@ -234,8 +227,6 @@ int main(int argc, char *argv[]) {
         effective_session = session_new_id();
     }
 
-    /* 设置 SIGINT handler */
-    signal(SIGINT, sigint_handler);
 
     /* 创建消息队列 */
     MsgQueue input_queue, display_queue;
@@ -317,8 +308,8 @@ int main(int argc, char *argv[]) {
         rcfg.input_queue = &input_queue;
         rcfg.interactive = 1;
         rcfg.home = home;
-        /* 设置 SIGINT handler 中要设置的 agent->interrupted 指针 */
-        readline_set_agent_interrupted(&agent->interrupted);
+        /* 设置 agent 的 interrupted 和 running 指针，供 Ctrl+C 中断使用 */
+        readline_set_agent_interrupted(&agent->interrupted, &agent->running);
         /* 注册图像粘贴回调（Ctrl+V） */
         
         linenoiseSetImagePasteCallback(image_paste_wrapper);

--- a/c/display.c
+++ b/c/display.c
@@ -10,6 +10,7 @@
 typedef struct {
     char last_char[8];      /* 最后一个字符（UTF-8 安全） */
     int prev_was_thinking;
+    int output_col;         /* assistant 尾行显示列（MVP：ANSI=0，ASCII=1，非 ASCII=2） */
 } DisplayState;
 
 static void ds_init(DisplayState *ds) {
@@ -17,6 +18,43 @@ static void ds_init(DisplayState *ds) {
     ds->last_char[0] = '\n';
     ds->last_char[1] = '\0';
     ds->prev_was_thinking = 0;
+}
+
+static void ds_update_output_col(DisplayState *ds, const char *text) {
+    if (!text || !*text) return;
+    int esc = 0;
+    for (const unsigned char *p = (const unsigned char *)text; *p; ) {
+        unsigned char c = *p;
+        if (esc) {
+            if (c >= 0x40 && c <= 0x7e) esc = 0;
+            p++;
+            continue;
+        }
+        if (c == 0x1b && p[1] == '[') {
+            esc = 1;
+            p += 2;
+            continue;
+        }
+        if (c == '\r') {
+            ds->output_col = 0;
+            p++;
+            continue;
+        }
+        if (c == '\n') {
+            ds->output_col = 0;
+            p++;
+            continue;
+        }
+        if (c < 0x80) {
+            ds->output_col++;
+            p++;
+        } else {
+            ds->output_col += 2;
+            if (c < 0xE0) p += 2;
+            else if (c < 0xF0) p += 3;
+            else p += 4;
+        }
+    }
 }
 
 static void ds_update_last_char(DisplayState *ds, const char *text) {
@@ -57,6 +95,7 @@ static void ensure_newline(DisplayState *ds, FILE *out) {
         fputc('\n', out);
         ds->last_char[0] = '\n';
         ds->last_char[1] = '\0';
+        ds->output_col = 0;
     }
 }
 
@@ -163,8 +202,9 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
     }
 
     /* human 模式 */
-    /* Hide linenoise prompt before writing to stdout */
-    if (interactive) readline_display_hide();
+    /* Hide linenoise prompt before writing to stdout; keep readline lock held
+     * until after Show so EditFeed cannot mutate terminal state concurrently. */
+    if (interactive) readline_display_begin();
 
     switch (msg->type) {
         case DISPLAY_THINKING:
@@ -172,10 +212,12 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
             if (interactive && ds->last_char[0] == '\n') {
                 fprintf(out, "\r\033[K");
                 ds->last_char[0] = '\0';
+                ds->output_col = 0;
             }
             if (msg->content) {
                 fprintf(out, "\x1b[90m%s\x1b[0m", msg->content);
                 fflush(out);
+                ds_update_output_col(ds, msg->content);
                 ds_update_last_char(ds, msg->content);
             }
             ds->prev_was_thinking = 1;
@@ -186,14 +228,17 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
             if (interactive && ds->last_char[0] == '\n') {
                 fprintf(out, "\r\033[K");
                 ds->last_char[0] = '\0';
+                ds->output_col = 0;
             }
             if (msg->content) {
                 /* Insert newline when transitioning from thinking to text */
                 if (ds->prev_was_thinking && ds->last_char[0] != '\n') {
                     fputc('\n', out);
                     ds->last_char[0] = '\n';
+                    ds->output_col = 0;
                 }
                 write_human(out, msg->content);
+                ds_update_output_col(ds, msg->content);
                 ds_update_last_char(ds, msg->content);
             }
             ds->prev_was_thinking = 0;
@@ -201,9 +246,8 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
 
         case DISPLAY_TOOL_CALL: {
             ensure_newline(ds, out);
-            const char *name = msg->tool_name ? msg->tool_name : "unknown";
             const char *summary = msg->content ? msg->content : "";
-            fprintf(out, "\x1b[33m[tool] %s(%s)\x1b[0m\n", name, summary);
+            fprintf(out, "\x1b[33m[tool] %s\x1b[0m\n", summary);
             fflush(out);
             ds->last_char[0] = '\n';
             ds->prev_was_thinking = 0;
@@ -215,11 +259,28 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
                 if (ds->prev_was_thinking && ds->last_char[0] != '\n') {
                     fputc('\n', out);
                     ds->last_char[0] = '\n';
+                    ds->output_col = 0;
                 }
                 ds->prev_was_thinking = 0;
-                fprintf(out, "%s\n", msg->content);
+                const char *tr_name = msg->tool_name ? msg->tool_name : "";
+                if (strcmp(tr_name, "Edit") == 0) {
+                    /* Edit: 全文 + 换行 */
+                    fprintf(out, "%s\n", msg->content);
+                } else if (strcmp(tr_name, "Read") == 0 || strcmp(tr_name, "Write") == 0) {
+                    /* Read/Write: 只显示第一行摘要 + 换行 */
+                    const char *nl = strchr(msg->content, '\n');
+                    if (nl) {
+                        fprintf(out, "%.*s\n", (int)(nl - msg->content), msg->content);
+                    } else {
+                        fprintf(out, "%s\n", msg->content);
+                    }
+                } else {
+                    /* 其他工具：全文 + 换行 */
+                    fprintf(out, "%s\n", msg->content);
+                }
                 fflush(out);
                 ds->last_char[0] = '\n';
+                ds->output_col = 0;
             }
             break;
 
@@ -309,8 +370,8 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
             break;
     }
 
-    /* Show linenoise prompt after writing to stdout */
-    if (interactive) readline_display_show();
+    /* Show linenoise prompt after writing to stdout and release lock */
+    if (interactive) readline_display_end(ds->output_col, ds->last_char[0] == '\n');
 }
 
 /* display 线程主函数 */

--- a/c/display.c
+++ b/c/display.c
@@ -5,12 +5,15 @@
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
+#include <wchar.h>
+#include <locale.h>
+#include <sys/ioctl.h>
 
 /* display 线程的显示状态 */
 typedef struct {
     char last_char[8];      /* 最后一个字符（UTF-8 安全） */
     int prev_was_thinking;
-    int output_col;         /* assistant 尾行显示列（MVP：ANSI=0，ASCII=1，非 ASCII=2） */
+    int output_col;         /* assistant 尾行显示列（ANSI=0，按 wcwidth 计算） */
 } DisplayState;
 
 static void ds_init(DisplayState *ds) {
@@ -22,6 +25,11 @@ static void ds_init(DisplayState *ds) {
 
 static void ds_update_output_col(DisplayState *ds, const char *text) {
     if (!text || !*text) return;
+    static int locale_inited = 0;
+    if (!locale_inited) {
+        setlocale(LC_CTYPE, "");
+        locale_inited = 1;
+    }
     int esc = 0;
     for (const unsigned char *p = (const unsigned char *)text; *p; ) {
         unsigned char c = *p;
@@ -49,12 +57,30 @@ static void ds_update_output_col(DisplayState *ds, const char *text) {
             ds->output_col++;
             p++;
         } else {
-            ds->output_col += 2;
-            if (c < 0xE0) p += 2;
-            else if (c < 0xF0) p += 3;
-            else p += 4;
+            wchar_t wc = 0;
+            int len = 1;
+            if (c < 0xE0) len = 2;
+            else if (c < 0xF0) len = 3;
+            else len = 4;
+            int w = mbtowc(&wc, (const char *)p, len);
+            if (w > 0) {
+                int cw = wcwidth(wc);
+                ds->output_col += (cw > 0) ? cw : 0;
+                p += w;
+            } else {
+                ds->output_col += 2;
+                p += len;
+            }
         }
     }
+}
+
+static int ds_physical_output_col(DisplayState *ds) {
+    struct winsize ws;
+    if (ioctl(1, TIOCGWINSZ, &ws) != 0 || ws.ws_col <= 0 || ds->output_col <= 0) {
+        return ds->output_col;
+    }
+    return ((ds->output_col - 1) % ws.ws_col) + 1;
 }
 
 static void ds_update_last_char(DisplayState *ds, const char *text) {
@@ -371,7 +397,7 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
     }
 
     /* Show linenoise prompt after writing to stdout and release lock */
-    if (interactive) readline_display_end(ds->output_col, ds->last_char[0] == '\n');
+    if (interactive) readline_display_end(ds_physical_output_col(ds), ds->last_char[0] == '\n');
 }
 
 /* display 线程主函数 */

--- a/c/display.c
+++ b/c/display.c
@@ -1,19 +1,15 @@
 #include "display.h"
-#include "readline.h"
+#include "linenoise.h"
 #include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
-#include <wchar.h>
-#include <locale.h>
-#include <sys/ioctl.h>
 
 /* display 线程的显示状态 */
 typedef struct {
     char last_char[8];      /* 最后一个字符（UTF-8 安全） */
     int prev_was_thinking;
-    int output_col;         /* assistant 尾行显示列（ANSI=0，按 wcwidth 计算） */
 } DisplayState;
 
 static void ds_init(DisplayState *ds) {
@@ -21,66 +17,6 @@ static void ds_init(DisplayState *ds) {
     ds->last_char[0] = '\n';
     ds->last_char[1] = '\0';
     ds->prev_was_thinking = 0;
-}
-
-static void ds_update_output_col(DisplayState *ds, const char *text) {
-    if (!text || !*text) return;
-    static int locale_inited = 0;
-    if (!locale_inited) {
-        setlocale(LC_CTYPE, "");
-        locale_inited = 1;
-    }
-    int esc = 0;
-    for (const unsigned char *p = (const unsigned char *)text; *p; ) {
-        unsigned char c = *p;
-        if (esc) {
-            if (c >= 0x40 && c <= 0x7e) esc = 0;
-            p++;
-            continue;
-        }
-        if (c == 0x1b && p[1] == '[') {
-            esc = 1;
-            p += 2;
-            continue;
-        }
-        if (c == '\r') {
-            ds->output_col = 0;
-            p++;
-            continue;
-        }
-        if (c == '\n') {
-            ds->output_col = 0;
-            p++;
-            continue;
-        }
-        if (c < 0x80) {
-            ds->output_col++;
-            p++;
-        } else {
-            wchar_t wc = 0;
-            int len = 1;
-            if (c < 0xE0) len = 2;
-            else if (c < 0xF0) len = 3;
-            else len = 4;
-            int w = mbtowc(&wc, (const char *)p, len);
-            if (w > 0) {
-                int cw = wcwidth(wc);
-                ds->output_col += (cw > 0) ? cw : 0;
-                p += w;
-            } else {
-                ds->output_col += 2;
-                p += len;
-            }
-        }
-    }
-}
-
-static int ds_physical_output_col(DisplayState *ds) {
-    struct winsize ws;
-    if (ioctl(1, TIOCGWINSZ, &ws) != 0 || ws.ws_col <= 0 || ds->output_col <= 0) {
-        return ds->output_col;
-    }
-    return ((ds->output_col - 1) % ws.ws_col) + 1;
 }
 
 static void ds_update_last_char(DisplayState *ds, const char *text) {
@@ -111,17 +47,11 @@ static int ends_with_newline(const char *s) {
 }
 #endif
 
-static void write_human(FILE *out, const char *text) {
-    fputs(text, out);
-    fflush(out);
-}
-
-static void ensure_newline(DisplayState *ds, FILE *out) {
+static void ensure_newline(DisplayState *ds) {
     if (ds->last_char[0] != '\n') {
-        fputc('\n', out);
+        linenoiseWrite("\n", 1);
         ds->last_char[0] = '\n';
         ds->last_char[1] = '\0';
-        ds->output_col = 0;
     }
 }
 
@@ -227,54 +157,43 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
         return;
     }
 
-    /* human 模式 */
-    /* Hide linenoise prompt before writing to stdout; keep readline lock held
-     * until after Show so EditFeed cannot mutate terminal state concurrently. */
-    if (interactive) readline_display_begin();
+    /* human 模式 — 每个 linenoisePrintf 调用内部原子地处理 Hide/Show */
+    (void)out;  /* stream-json 用 out；human 模式走 linenoisePrintf */
 
     switch (msg->type) {
         case DISPLAY_THINKING:
-            /* bash 版在每个消息显示前检查 last_char=='\n' 并执行 \r\033[K */
             if (interactive && ds->last_char[0] == '\n') {
-                fprintf(out, "\r\033[K");
+                linenoiseWrite("\r\033[K", 4);
                 ds->last_char[0] = '\0';
-                ds->output_col = 0;
             }
             if (msg->content) {
-                fprintf(out, "\x1b[90m%s\x1b[0m", msg->content);
-                fflush(out);
-                ds_update_output_col(ds, msg->content);
+                linenoisePrintf("\x1b[90m%s\x1b[0m", msg->content);
                 ds_update_last_char(ds, msg->content);
             }
             ds->prev_was_thinking = 1;
             break;
 
         case DISPLAY_TEXT:
-            /* bash 版在每个消息显示前检查 last_char=='\n' 并执行 \r\033[K */
             if (interactive && ds->last_char[0] == '\n') {
-                fprintf(out, "\r\033[K");
+                linenoiseWrite("\r\033[K", 4);
                 ds->last_char[0] = '\0';
-                ds->output_col = 0;
             }
             if (msg->content) {
-                /* Insert newline when transitioning from thinking to text */
                 if (ds->prev_was_thinking && ds->last_char[0] != '\n') {
-                    fputc('\n', out);
+                    linenoiseWrite("\n", 1);
                     ds->last_char[0] = '\n';
-                    ds->output_col = 0;
                 }
-                write_human(out, msg->content);
-                ds_update_output_col(ds, msg->content);
+                linenoiseWrite(msg->content, strlen(msg->content));
                 ds_update_last_char(ds, msg->content);
             }
             ds->prev_was_thinking = 0;
             break;
 
         case DISPLAY_TOOL_CALL: {
-            ensure_newline(ds, out);
+            ensure_newline(ds);
+            const char *name = msg->tool_name ? msg->tool_name : "unknown";
             const char *summary = msg->content ? msg->content : "";
-            fprintf(out, "\x1b[33m[tool] %s\x1b[0m\n", summary);
-            fflush(out);
+            linenoisePrintf("\x1b[33m[tool] %s(%s)\x1b[0m\n", name, summary);
             ds->last_char[0] = '\n';
             ds->prev_was_thinking = 0;
             break;
@@ -283,109 +202,92 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
         case DISPLAY_TOOL_RESULT:
             if (msg->content && msg->content[0]) {
                 if (ds->prev_was_thinking && ds->last_char[0] != '\n') {
-                    fputc('\n', out);
+                    linenoiseWrite("\n", 1);
                     ds->last_char[0] = '\n';
-                    ds->output_col = 0;
                 }
                 ds->prev_was_thinking = 0;
                 const char *tr_name = msg->tool_name ? msg->tool_name : "";
                 if (strcmp(tr_name, "Edit") == 0) {
-                    /* Edit: 全文 + 换行 */
-                    fprintf(out, "%s\n", msg->content);
+                    linenoisePrintf("%s\n", msg->content);
                 } else if (strcmp(tr_name, "Read") == 0 || strcmp(tr_name, "Write") == 0) {
-                    /* Read/Write: 只显示第一行摘要 + 换行 */
                     const char *nl = strchr(msg->content, '\n');
                     if (nl) {
-                        fprintf(out, "%.*s\n", (int)(nl - msg->content), msg->content);
+                        linenoiseWrite(msg->content, (size_t)(nl - msg->content));
+                        linenoiseWrite("\n", 1);
                     } else {
-                        fprintf(out, "%s\n", msg->content);
+                        linenoisePrintf("%s\n", msg->content);
                     }
                 } else {
-                    /* 其他工具：全文 + 换行 */
-                    fprintf(out, "%s\n", msg->content);
+                    linenoisePrintf("%s\n", msg->content);
                 }
-                fflush(out);
                 ds->last_char[0] = '\n';
-                ds->output_col = 0;
             }
             break;
 
         case DISPLAY_USAGE:
-            /* human 模式不显示 usage */
             break;
 
         case DISPLAY_STOP:
-            ensure_newline(ds, out);
+            ensure_newline(ds);
             if (msg->content && strcmp(msg->content, "interrupted") == 0) {
-                fprintf(out, "\x1b[36mInterrupted.\x1b[0m\n");
-                fflush(out);
+                linenoisePrintf("\x1b[36mInterrupted.\x1b[0m\n");
                 ds->last_char[0] = '\n';
             }
             break;
 
         case DISPLAY_ERROR:
-            ensure_newline(ds, out);
-            fprintf(stderr, "\x1b[31mError: %s\x1b[0m\n",
+            ensure_newline(ds);
+            linenoisePrintf("\x1b[31mError: %s\x1b[0m\n",
                     msg->content ? msg->content : "unknown");
-            fflush(stderr);
             ds->last_char[0] = '\n';
             break;
 
         case DISPLAY_SUB_AGENT_START:
-            /* bash 版不单独展示 start，靠 tool_result 显示。
-             * C 版也一样，不额外输出。 */
             break;
 
         case DISPLAY_CONTEXT_UPDATE:
-            ensure_newline(ds, out);
-            fprintf(out, "\x1b[36mContext compacted (%s).\x1b[0m\n",
+            ensure_newline(ds);
+            linenoisePrintf("\x1b[36mContext compacted (%s).\x1b[0m\n",
                     msg->tool_name ? msg->tool_name : "auto");
-            fflush(out);
             ds->last_char[0] = '\n';
             break;
 
         case DISPLAY_IMAGE_DESCRIBE: {
-            ensure_newline(ds, out);
+            ensure_newline(ds);
             const char *images = msg->tool_name ? msg->tool_name : "";
             const char *desc = msg->content ? msg->content : "";
             if (desc[0]) {
-                fprintf(out, "\x1b[36m📸 %s: %s\x1b[0m\n", images, desc);
+                linenoisePrintf("\x1b[36m📸 %s: %s\x1b[0m\n", images, desc);
             }
-            fflush(out);
             ds->last_char[0] = '\n';
             break;
         }
 
         case DISPLAY_SUB_AGENT_RESULT: {
-            /* 清空当前行，避免子 agent 残留的输出内容导致排版混乱
-             * bash 版同样有 \r\033[K 保护 */
             if (interactive && ds->last_char[0] == '\n') {
-                fprintf(out, "\r\033[K");
+                linenoiseWrite("\r\033[K", 4);
             }
-            ensure_newline(ds, out);
+            ensure_newline(ds);
             if (msg->tool_exit_code == 0) {
-                fprintf(out, "\x1b[35m[sub-agent %s] completed (in=%d, out=%d)\x1b[0m\n",
+                linenoisePrintf("\x1b[35m[sub-agent %s] completed (in=%d, out=%d)\x1b[0m\n",
                         msg->session_id ? msg->session_id : "?",
                         msg->in_tokens, msg->out_tokens);
             } else {
-                fprintf(out, "\x1b[31m[sub-agent %s] failed\x1b[0m\n",
+                linenoisePrintf("\x1b[31m[sub-agent %s] failed\x1b[0m\n",
                         msg->session_id ? msg->session_id : "?");
             }
-            /* thinking — 灰色，截断 120 字节（UTF-8 安全） */
             if (msg->tool_name && msg->tool_name[0]) {
                 int tlen = (int)util_utf8_truncate_len(msg->tool_name, 120);
-                fprintf(out, "\x1b[90m%.*s%s\x1b[0m\n",
+                linenoisePrintf("\x1b[90m%.*s%s\x1b[0m\n",
                         tlen, msg->tool_name,
                         strlen(msg->tool_name) > 120 ? "…" : "");
             }
-            /* text — 截断 120 字节（UTF-8 安全） */
             if (msg->content && msg->content[0]) {
                 int clen = (int)util_utf8_truncate_len(msg->content, 120);
-                fprintf(out, "%.*s%s\n",
+                linenoisePrintf("%.*s%s\n",
                         clen, msg->content,
                         strlen(msg->content) > 120 ? "…" : "");
             }
-            fflush(out);
             ds->last_char[0] = '\n';
             ds->prev_was_thinking = 0;
             break;
@@ -395,9 +297,6 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
             signal_flush(msg);
             break;
     }
-
-    /* Show linenoise prompt after writing to stdout and release lock */
-    if (interactive) readline_display_end(ds_physical_output_col(ds), ds->last_char[0] == '\n');
 }
 
 /* display 线程主函数 */

--- a/c/readline.c
+++ b/c/readline.c
@@ -47,12 +47,6 @@ static void sigint_handler(int sig) {
 /* display_begin/end are now in linenoise.c (alongside linenoiseWrite).
  * They share the same mutex and state. No duplicate declarations here. */
 
-/* Hide/Show are now handled internally by linenoiseWrite. */
-void readline_display_hide(void) {}
-void readline_display_show(void) {}
-
-
-
 /* ============================================================
  * History 文件路径构建
  *

--- a/c/readline.c
+++ b/c/readline.c
@@ -9,37 +9,36 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <termios.h>
 
 /* ============================================================
- * 全局 SIGINT 状态
+ * Ctrl+C / 中断状态
  *
- * 模仿 Rust 版的 CTRLC_FLAG 设计：
- * - 全局标志由 SIGINT handler 设置
- * - readline 线程用它区分 Ctrl+C（重新提示）和 Ctrl+D（退出）
- * - agent_loop 的 SSE 层检查它来中断 HTTP 请求
+ * 交互模式（linenoise raw mode）：
+ *   - ISIG 被禁用，Ctrl+C 产生 0x03 字节而非 SIGINT
+ *   - linenoise 捕获后返回 NULL + errno=EAGAIN
+ *   - 此时通过 g_agent_interrupted 设置 agent 的中断标志
+ *
+ * 非交互模式（fgets）：
+ *   - ISIG 开启，Ctrl+C 产生 SIGINT
+ *   - sigint_handler 设置 g_sigint_received，readline 循环检测后退出
  * ============================================================ */
 
 static volatile sig_atomic_t g_sigint_received = 0;
 
-/* agent 的 interrupted 指针— 在 readline_thread_start 之前由 cagent.c 设置 */
+/* agent 的 interrupted 和 running 指针 — 在 readline_thread_start 之前设置 */
 static volatile int *g_agent_interrupted = NULL;
+static const volatile int *g_agent_running = NULL;
 
-int readline_sigint_consumed(void) {
-    if (g_sigint_received) {
-        g_sigint_received = 0;
-        return 1;
-    }
-    return 0;
-}
-
-void readline_set_agent_interrupted(volatile int *flag) {
-    g_agent_interrupted = flag;
+void readline_set_agent_interrupted(volatile int *interrupted, const volatile int *running) {
+    g_agent_interrupted = interrupted;
+    g_agent_running = running;
 }
 
 static void sigint_handler(int sig) {
     (void)sig;
     g_sigint_received = 1;
-    /* 同时设置 agent 的 interrupted 标志，让 http_post_sse 中的 curl 被中断 */
+    /* 非交互模式下，直接设置 agent interrupted 标志 */
     if (g_agent_interrupted) {
         *(g_agent_interrupted) = 1;
     }
@@ -52,8 +51,77 @@ static void sigint_handler(int sig) {
 static pthread_mutex_t g_display_mutex = PTHREAD_MUTEX_INITIALIZER;
 static struct linenoiseState *g_current_ls = NULL;
 static int g_ls_active = 0; /* 1=linenoise 在编辑中 */
+static int g_prompt_detached = 0;  /* 上一轮输出没以 \n 结尾，prompt 被 push 到下一行 */
+static int g_output_col = 0;       /* 上一轮输出结束时的光标列位置 */
 
-/* display worker 调用：Hide 当前 prompt */
+/* ============================================================
+ * display worker 调用：开始一轮输出
+ *
+ * 流程：锁 mutex → Hide prompt → 如果 detached 则回退光标到 output_col → 开 OPOST
+ * 对应 Go 版 Readline.AcquireOutputLock
+ * ============================================================ */
+void readline_display_begin(void) {
+    pthread_mutex_lock(&g_display_mutex);
+    if (g_ls_active && g_current_ls) {
+        /* Hide prompt */
+        linenoiseHide(g_current_ls);
+
+        /* 如果上一轮输出没以 \n 结尾（prompt detached），光标回退到上一行的 output_col */
+        if (g_prompt_detached) {
+            fputs("\x1b[1A\r", stdout);
+            if (g_output_col > 0) {
+                fprintf(stdout, "\x1b[%dC", g_output_col);
+            }
+            fflush(stdout);
+            g_prompt_detached = 0;
+        }
+
+        /* 暂时恢复 OPOST，让 display 的 \n 自动 CR+LF */
+        struct termios tios;
+        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
+            tios.c_oflag |= OPOST;
+            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
+        }
+    }
+}
+
+/* ============================================================
+ * display worker 调用：结束一轮输出
+ *
+ * 流程：flush → 关 OPOST（恢复 raw mode）→ 如果没以 \n 结尾则 push prompt → 记录 output_col → Show → 解锁
+ * 对应 Go 版 AcquireOutputLock 返回的 unlock 函数
+ * ============================================================ */
+void readline_display_end(int output_col, int output_at_newline) {
+    if (g_ls_active && g_current_ls) {
+        /* 先 flush 所有 display 输出（在 OPOST 下 \n 已被正确转换） */
+        fflush(stdout);
+
+        /* 恢复 linenoise raw mode（关闭 OPOST），避免 Show 的输出被 OPOST 干扰 */
+        struct termios tios;
+        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
+            tios.c_oflag &= ~OPOST;
+            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
+        }
+
+        /* 如果输出没以 \n 结尾，push prompt 到下一行 */
+        if (!output_at_newline) {
+            fputs("\r\n", stdout);
+            fflush(stdout);
+            g_prompt_detached = 1;
+        } else {
+            g_prompt_detached = 0;
+        }
+
+        /* 记录本次输出的光标列位置，供下一轮 begin 回退用 */
+        g_output_col = output_col;
+
+        /* Show prompt */
+        linenoiseShow(g_current_ls);
+    }
+    pthread_mutex_unlock(&g_display_mutex);
+}
+
+/* display worker 调用：Hide 当前 prompt（兼容旧调用点） */
 void readline_display_hide(void) {
     pthread_mutex_lock(&g_display_mutex);
     if (g_ls_active && g_current_ls) {
@@ -164,11 +232,16 @@ static void *readline_thread_fn(void *arg) {
 
             linenoiseEditStop(&ls);
 
-            if (result == NULL) {
-                if (errno == EAGAIN) {
-                    /* Ctrl+C — linenoise 已显示 ^C 并换行，继续循环 */
-                    continue;
-                }
+              if (result == NULL) {
+                  if (errno == EAGAIN) {
+                      /* Ctrl+C — linenoise 已显示 ^C 并换行
+                       * 如果 agent 正在运行（agent_loop 执行中），
+                       * 设置 interrupted 标志让它中断当前 HTTP 请求 */
+                      if (g_agent_running && *g_agent_running && g_agent_interrupted) {
+                          *(g_agent_interrupted) = 1;
+                      }
+                      continue;
+                  }
                 /* Ctrl+D 或 I/O 错误 — 退出 */
                 fprintf(stderr, "\n");
                 break;

--- a/c/readline.c
+++ b/c/readline.c
@@ -44,100 +44,14 @@ static void sigint_handler(int sig) {
     }
 }
 
-/* ============================================================
- * 全局 linenoiseState 共享 — display worker 用它做 Hide/Show
- * ============================================================ */
+/* display_begin/end are now in linenoise.c (alongside linenoiseWrite).
+ * They share the same mutex and state. No duplicate declarations here. */
 
-static pthread_mutex_t g_display_mutex = PTHREAD_MUTEX_INITIALIZER;
-static struct linenoiseState *g_current_ls = NULL;
-static int g_ls_active = 0; /* 1=linenoise 在编辑中 */
-static int g_prompt_detached = 0;  /* 上一轮输出没以 \n 结尾，prompt 被 push 到下一行 */
-static int g_output_col = 0;       /* 上一轮输出结束时的光标列位置 */
+/* Hide/Show are now handled internally by linenoiseWrite. */
+void readline_display_hide(void) {}
+void readline_display_show(void) {}
 
-/* ============================================================
- * display worker 调用：开始一轮输出
- *
- * 流程：锁 mutex → Hide prompt → 如果 detached 则回退光标到 output_col → 开 OPOST
- * 对应 Go 版 Readline.AcquireOutputLock
- * ============================================================ */
-void readline_display_begin(void) {
-    pthread_mutex_lock(&g_display_mutex);
-    if (g_ls_active && g_current_ls) {
-        /* Hide prompt */
-        linenoiseHide(g_current_ls);
 
-        /* 如果上一轮输出没以 \n 结尾（prompt detached），光标回退到上一行的 output_col */
-        if (g_prompt_detached) {
-            fputs("\x1b[1A\r", stdout);
-            if (g_output_col > 0) {
-                fprintf(stdout, "\x1b[%dC", g_output_col);
-            }
-            fflush(stdout);
-            g_prompt_detached = 0;
-        }
-
-        /* 暂时恢复 OPOST，让 display 的 \n 自动 CR+LF */
-        struct termios tios;
-        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
-            tios.c_oflag |= OPOST;
-            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
-        }
-    }
-}
-
-/* ============================================================
- * display worker 调用：结束一轮输出
- *
- * 流程：flush → 关 OPOST（恢复 raw mode）→ 如果没以 \n 结尾则 push prompt → 记录 output_col → Show → 解锁
- * 对应 Go 版 AcquireOutputLock 返回的 unlock 函数
- * ============================================================ */
-void readline_display_end(int output_col, int output_at_newline) {
-    if (g_ls_active && g_current_ls) {
-        /* 先 flush 所有 display 输出（在 OPOST 下 \n 已被正确转换） */
-        fflush(stdout);
-
-        /* 恢复 linenoise raw mode（关闭 OPOST），避免 Show 的输出被 OPOST 干扰 */
-        struct termios tios;
-        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
-            tios.c_oflag &= ~OPOST;
-            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
-        }
-
-        /* 如果输出没以 \n 结尾，push prompt 到下一行 */
-        if (!output_at_newline) {
-            fputs("\r\n", stdout);
-            fflush(stdout);
-            g_prompt_detached = 1;
-        } else {
-            g_prompt_detached = 0;
-        }
-
-        /* 记录本次输出的光标列位置，供下一轮 begin 回退用 */
-        g_output_col = output_col;
-
-        /* Show prompt */
-        linenoiseShow(g_current_ls);
-    }
-    pthread_mutex_unlock(&g_display_mutex);
-}
-
-/* display worker 调用：Hide 当前 prompt（兼容旧调用点） */
-void readline_display_hide(void) {
-    pthread_mutex_lock(&g_display_mutex);
-    if (g_ls_active && g_current_ls) {
-        linenoiseHide(g_current_ls);
-    }
-    pthread_mutex_unlock(&g_display_mutex);
-}
-
-/* display worker 调用：Show 当前 prompt */
-void readline_display_show(void) {
-    pthread_mutex_lock(&g_display_mutex);
-    if (g_ls_active && g_current_ls) {
-        linenoiseShow(g_current_ls);
-    }
-    pthread_mutex_unlock(&g_display_mutex);
-}
 
 /* ============================================================
  * History 文件路径构建
@@ -211,10 +125,8 @@ static void *readline_thread_fn(void *arg) {
             }
 
             /* 注册到全局共享状态，让 display worker 可以 Hide/Show */
-            pthread_mutex_lock(&g_display_mutex);
-            g_current_ls = &ls;
-            g_ls_active = 1;
-            pthread_mutex_unlock(&g_display_mutex);
+            linenoiseRegisterState(&ls);
+            linenoiseSetActive(1);
 
             /* 循环读取输入 */
             char *result;
@@ -225,10 +137,8 @@ static void *readline_thread_fn(void *arg) {
             }
 
             /* 清除全局共享状态 */
-            pthread_mutex_lock(&g_display_mutex);
-            g_current_ls = NULL;
-            g_ls_active = 0;
-            pthread_mutex_unlock(&g_display_mutex);
+            linenoiseSetActive(0);
+            linenoiseRegisterState(NULL);
 
             linenoiseEditStop(&ls);
 

--- a/c/readline.h
+++ b/c/readline.h
@@ -21,13 +21,16 @@ typedef struct {
 /* 启动 readline 线程，返回 pthread_t */
 int readline_thread_start(pthread_t *thread, const ReadlineConfig *cfg);
 
-/* 检查并消费 SIGINT 标志 */
-int readline_sigint_consumed(void);
+/* 设置 agent 的 interrupted 和 running 指针
+ * interrupted: Ctrl+C 时设为 1，让 agent_loop 中断 HTTP 请求
+ * running: agent_loop 执行中为 1，readline 据此判断 Ctrl+C 是否应中断 */
+void readline_set_agent_interrupted(volatile int *interrupted, const volatile int *running);
 
-/* 设置 agent 的 interrupted 指针（SIGINT handler 中同时设置） */
-void readline_set_agent_interrupted(volatile int *flag);
+/* display worker 调用：在同一把锁内 Hide→输出→Show，避免与 EditFeed 并发 */
+void readline_display_begin(void);
+void readline_display_end(int output_col, int output_at_newline);
 
-/* display worker 调用：Hide/Show 当前 linenoise prompt */
+/* 兼容旧调用点 */
 void readline_display_hide(void);
 void readline_display_show(void);
 

--- a/c/readline.h
+++ b/c/readline.h
@@ -26,12 +26,4 @@ int readline_thread_start(pthread_t *thread, const ReadlineConfig *cfg);
  * running: agent_loop 执行中为 1，readline 据此判断 Ctrl+C 是否应中断 */
 void readline_set_agent_interrupted(volatile int *interrupted, const volatile int *running);
 
-/* display worker 调用：在同一把锁内 Hide→输出→Show，避免与 EditFeed 并发 */
-void readline_display_begin(void);
-void readline_display_end(int output_col, int output_at_newline);
-
-/* 兼容旧调用点 */
-void readline_display_hide(void);
-void readline_display_show(void);
-
 #endif /* READLINE_H */

--- a/go/agent.go
+++ b/go/agent.go
@@ -38,6 +38,10 @@ type Agent struct {
 	pendingSubAgents int    // 等待中的子 agent 数量
 	subResultCh      chan SubAgentResult
 	subMu            sync.Mutex
+	runMu            sync.Mutex
+	currentCancel    context.CancelFunc
+	currentInterrupt *atomic.Bool
+	running          atomic.Bool // 1 = agent 正在处理（RunLoop 执行中），0 = 空闲等待输入
 }
 
 type SubAgentResult struct {
@@ -238,6 +242,24 @@ func NewAgent(cfg Config, store SessionStore, llm Transport, tools *ToolDispatch
 	a.tools.SetPlanClear(a.HandlePlanClear)
 	a.tools.SetSkillLoader(a.LoadSkill)
 	return a
+}
+
+// Interrupt cancels the currently running agent turn. In raw terminal mode
+// Ctrl+C is read by linenoise as byte 0x03 rather than delivered as SIGINT,
+// so the readline goroutine calls this when it consumes Ctrl+C.
+// Mirrors C version: only interrupts when agent is running (agent_loop active).
+func (a *Agent) Interrupt() {
+	if !a.running.Load() {
+		return
+	}
+	a.runMu.Lock()
+	if a.currentInterrupt != nil {
+		a.currentInterrupt.Store(true)
+	}
+	if a.currentCancel != nil {
+		a.currentCancel()
+	}
+	a.runMu.Unlock()
 }
 
 func (a *Agent) EmitDisplay(ev Event) {
@@ -688,6 +710,10 @@ func (a *Agent) emitJSON(obj map[string]interface{}) {
 }
 
 func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
+	// 设置 running 标志：1 表示 agent 正在处理，readline 据此判断 Ctrl+C 是否应中断
+	a.running.Store(true)
+	defer a.running.Store(false)
+
 	// 记录 user_input 事件（使用原始文本，包含 [Image #N] 占位符）
 	if turnKind == "user_input" {
 		a.emitJSON(map[string]interface{}{"type": "user_input", "content": userInput})
@@ -736,6 +762,18 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 	var interrupted atomic.Bool
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	a.runMu.Lock()
+	a.currentInterrupt = &interrupted
+	a.currentCancel = cancel
+	a.runMu.Unlock()
+	defer func() {
+		a.runMu.Lock()
+		if a.currentInterrupt == &interrupted {
+			a.currentInterrupt = nil
+			a.currentCancel = nil
+		}
+		a.runMu.Unlock()
+	}()
 	sigCh := make(chan os.Signal, 1)
 	sigDone := make(chan struct{})
 	signal.Notify(sigCh, syscall.SIGINT)

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -270,9 +270,6 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 	rl.SetImagePasteCallback(a.ImagePasteCallback)
 	rl.Start()
 
-	// 让 display 持有 readline 的 hide/show 回调，用于输出保护
-	display.SetOutputLocker(rl.AcquireOutputLock)
-
 	// 主循环：从 readline goroutine 接收输入，交给 agent 处理
 	for input := range rl.Input() {
 		if err := a.RunLoop(ctx, input, "user_input"); err != nil {

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -268,6 +268,7 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 	// 启动 readline goroutine
 	rl := NewReadline(home)
 	rl.SetImagePasteCallback(a.ImagePasteCallback)
+	rl.SetInterruptCallback(a.Interrupt)
 	rl.Start()
 
 	// 主循环：从 readline goroutine 接收输入，交给 agent 处理

--- a/go/cmd/goagent/readline.go
+++ b/go/cmd/goagent/readline.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/lloyd/claude-code/bash-agent/go2/linenoise"
@@ -14,22 +13,10 @@ import (
 // Readline runs linenoise in a dedicated goroutine and communicates
 // with the agent main goroutine via channels.
 //
-// Architecture (linenoise Hide/Show approach):
-//
-//	[readline goroutine] --inputCh--> [agent main goroutine]
-//	   EditStart/EditFeed              RunLoop()
-//	   loops immediately               display: Hide→write→Show per chunk
-//
-// The readline goroutine never waits for the agent to finish.
-// The display worker uses Hide/Show to avoid prompt corruption.
+// Display output uses linenoiseWrite which handles Hide/OPOST/Show internally.
 type Readline struct {
 	inputCh  chan string
 	histPath string
-
-	// Shared state with display worker (protected by mu)
-	mu     sync.Mutex
-	ls     *linenoise.LinenoiseState // current linenoiseState (nil when not editing)
-	active bool                      // true when in an editing session
 }
 
 // NewReadline creates a Readline with history stored at ~/.bash-agent/history.
@@ -78,11 +65,9 @@ func (r *Readline) loop() {
 			return
 		}
 
-		// Register the linenoiseState for display worker to use
-		r.mu.Lock()
-		r.ls = ls
-		r.active = true
-		r.mu.Unlock()
+		// Register state for LinenoiseWrite to use Hide/Show
+		linenoise.RegisterState(ls)
+		linenoise.SetActive(true)
 
 		// Non-blocking poll + feed loop
 		var line string
@@ -104,11 +89,9 @@ func (r *Readline) loop() {
 			break
 		}
 
-		// Unregister the linenoiseState
-		r.mu.Lock()
-		r.ls = nil
-		r.active = false
-		r.mu.Unlock()
+		// Unregister state
+		linenoise.SetActive(false)
+		linenoise.RegisterState(nil)
 
 		linenoise.EditStop(ls)
 
@@ -138,21 +121,6 @@ func (r *Readline) loop() {
 
 		// Send to agent — no done wait
 		r.inputCh <- line
-	}
-}
-
-// AcquireOutputLock hides the linenoise prompt and returns an unlock function.
-// The display worker should call this before writing to stdout.
-func (r *Readline) AcquireOutputLock() func() {
-	r.mu.Lock()
-	if r.active && r.ls != nil {
-		linenoise.Hide(r.ls)
-	}
-	return func() {
-		if r.active && r.ls != nil {
-			linenoise.Show(r.ls)
-		}
-		r.mu.Unlock()
 	}
 }
 

--- a/go/cmd/goagent/readline.go
+++ b/go/cmd/goagent/readline.go
@@ -15,8 +15,9 @@ import (
 //
 // Display output uses linenoiseWrite which handles Hide/OPOST/Show internally.
 type Readline struct {
-	inputCh  chan string
-	histPath string
+	inputCh     chan string
+	histPath    string
+	interruptCb func() // called on Ctrl+C to interrupt running agent
 }
 
 // NewReadline creates a Readline with history stored at ~/.bash-agent/history.
@@ -47,6 +48,12 @@ func (r *Readline) SetImagePasteCallback(fn func() string) {
 // Input returns the channel on which user input lines are delivered.
 func (r *Readline) Input() <-chan string {
 	return r.inputCh
+}
+
+// SetInterruptCallback registers a function to be called when Ctrl+C is pressed
+// during agent execution. The callback should cancel the current agent turn.
+func (r *Readline) SetInterruptCallback(fn func()) {
+	r.interruptCb = fn
 }
 
 const promptStr = "\x1b[32m> \x1b[0m"
@@ -98,6 +105,10 @@ func (r *Readline) loop() {
 		if feedErr != nil {
 			if feedErr == linenoise.ErrInterrupted {
 				// Ctrl+C — linenoise already displayed ^C and newline
+				// Notify agent to interrupt if running
+				if r.interruptCb != nil {
+					r.interruptCb()
+				}
 				continue
 			}
 			// Ctrl+D or I/O error — exit

--- a/go/display.go
+++ b/go/display.go
@@ -131,15 +131,13 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 	case EventToolCall:
 		d.prevThinking = false
 		d.EnsureNewline()
-		name := ""
-		if len(ev.Fields) > 1 {
-			name = ev.Fields[1]
-		}
 		summary := ""
 		if len(ev.Fields) > 4 {
 			summary = ev.Fields[4]
+		} else if len(ev.Fields) > 1 {
+			summary = ev.Fields[1]
 		}
-		d.writef("\033[33m[tool] %s(%s)\033[0m\n", name, summary)
+		d.writef("\033[33m[tool] %s\033[0m\n", summary)
 
 	case EventToolResult:
 		d.prevThinking = false

--- a/go/display.go
+++ b/go/display.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/lloyd/claude-code/bash-agent/go2/linenoise"
 )
@@ -19,8 +18,6 @@ type TermDisplay struct {
 	prevThinking bool      // 上一个事件是否为 THINKING
 	silent       bool      // stream-json 模式下抑制人类可读输出
 	testWriter   io.Writer // 仅用于测试：非 nil 时走这里而非 linenoiseWrite
-	outputCol    int       // assistant 尾行显示列（ANSI=0，ASCII=1，非 ASCII=2）
-	batching     bool      // 是否处于一次事件批量输出中
 }
 
 func NewTermDisplay() *TermDisplay {
@@ -32,94 +29,35 @@ func (d *TermDisplay) SetWriter(w io.Writer) {
 	d.testWriter = w
 }
 
-// writeRaw 发送字符串，不更新显示状态。
+// writeRaw 发送字符串，不更新 lastChar（用于 ANSI 控制序列）。
 func (d *TermDisplay) writeRaw(s string) {
 	if s == "" {
 		return
 	}
 	if d.testWriter != nil {
 		fmt.Fprint(d.testWriter, s)
-	} else if d.batching {
-		fmt.Fprint(os.Stdout, s)
 	} else {
 		linenoise.LinenoiseWrite(s)
 	}
 }
 
-// write 发送字符串并更新显示状态。
+// write 发送字符串并更新 lastChar。
 func (d *TermDisplay) write(s string) {
-	d.writeRaw(s)
-	d.updateState(s)
+	if s == "" {
+		return
+	}
+	if d.testWriter != nil {
+		fmt.Fprint(d.testWriter, s)
+	} else {
+		linenoise.LinenoiseWrite(s)
+	}
+	d.lastChar = s[len(s)-1]
 }
 
 // writef 格式化并写入
 func (d *TermDisplay) writef(format string, args ...interface{}) {
 	s := fmt.Sprintf(format, args...)
 	d.write(s)
-}
-
-func (d *TermDisplay) beginEvent() {
-	if d.testWriter == nil {
-		linenoise.DisplayBegin()
-	}
-	d.batching = true
-}
-
-func (d *TermDisplay) endEvent() {
-	if !d.batching {
-		return
-	}
-	d.batching = false
-	if d.testWriter == nil {
-		linenoise.DisplayEnd(d.outputCol, d.lastChar == '\n')
-	}
-}
-
-func (d *TermDisplay) updateState(s string) {
-	if s == "" {
-		return
-	}
-	d.lastChar = s[len(s)-1]
-	d.updateOutputCol(s)
-}
-
-func (d *TermDisplay) updateOutputCol(s string) {
-	esc := false
-	for len(s) > 0 {
-		c := s[0]
-		if esc {
-			_, size := utf8.DecodeRuneInString(s)
-			if size <= 0 {
-				size = 1
-			}
-			if c >= 0x40 && c <= 0x7e {
-				esc = false
-			}
-			s = s[size:]
-			continue
-		}
-		if c == 0x1b && len(s) > 1 && s[1] == '[' {
-			esc = true
-			s = s[2:]
-			continue
-		}
-		if c == '\r' || c == '\n' {
-			d.outputCol = 0
-			s = s[1:]
-			continue
-		}
-		if c < 0x80 {
-			d.outputCol++
-			s = s[1:]
-			continue
-		}
-		_, size := utf8.DecodeRuneInString(s)
-		if size <= 0 {
-			size = 1
-		}
-		d.outputCol += 2
-		s = s[size:]
-	}
 }
 
 // EnsureNewline 确保光标在新行
@@ -132,9 +70,6 @@ func (d *TermDisplay) EnsureNewline() {
 // SetLastChar 直接设置上次输出的最后一个字符
 func (d *TermDisplay) SetLastChar(c byte) {
 	d.lastChar = c
-	if c == '\n' || c == '\r' || c == 0 {
-		d.outputCol = 0
-	}
 }
 
 // HumanText 输出人类可读文本
@@ -162,7 +97,6 @@ func (d *TermDisplay) clearLineIfAtNewline() {
 	if d.testWriter == nil && d.lastChar == '\n' {
 		d.write("\r\033[K")
 		d.lastChar = 0
-		d.outputCol = 0
 	}
 }
 
@@ -171,9 +105,6 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 	if d.silent {
 		return
 	}
-
-	d.beginEvent()
-	defer d.endEvent()
 
 	switch ev.Type {
 	case EventText:
@@ -189,23 +120,26 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 	case EventThinking:
 		d.clearLineIfAtNewline()
 		if len(ev.Fields) > 1 && ev.Fields[1] != "" {
-			// ANSI 颜色控制序列不能更新 lastChar，否则内容以 \n 结尾时会被误判为未换行，导致额外空行。
-			d.writeRaw("\033[90m")
-			d.write(ev.Fields[1])
-			d.writeRaw("\033[0m")
+			content := ev.Fields[1]
+			/* 颜色码 + 内容 + 重置必须在一个 linenoiseWrite 调用内，
+			 * 否则中间的 Show 重绘 prompt 时 \033[0m 会重置终端颜色 */
+			linenoise.LinenoiseWrite("\033[90m" + content + "\033[0m")
+			d.lastChar = content[len(content)-1]
 		}
 		d.prevThinking = true
 
 	case EventToolCall:
 		d.prevThinking = false
 		d.EnsureNewline()
+		name := ""
+		if len(ev.Fields) > 1 {
+			name = ev.Fields[1]
+		}
 		summary := ""
 		if len(ev.Fields) > 4 {
 			summary = ev.Fields[4]
-		} else if len(ev.Fields) > 1 {
-			summary = ev.Fields[1]
 		}
-		d.writef("\033[33m[tool] %s\033[0m\n", summary)
+		d.writef("\033[33m[tool] %s(%s)\033[0m\n", name, summary)
 
 	case EventToolResult:
 		d.prevThinking = false

--- a/go/display.go
+++ b/go/display.go
@@ -3,48 +3,54 @@ package agent
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
+
+	"github.com/lloyd/claude-code/bash-agent/go2/linenoise"
 )
 
 // ═══════════════════════════════════════════
 // TermDisplay — 终端输出显示
 // ═══════════════════════════════════════════
 
-// OutputLocker hides the prompt before output and restores it after.
-// Returns an unlock function that must be called when output is done.
-type OutputLocker func() func()
-
 type TermDisplay struct {
-	writer         io.Writer // 输出目标（默认 os.Stdout）
-	lastChar       byte      // 上次输出的最后一个字符
-	prevThinking   bool      // 上一个事件是否为 THINKING
-	silent         bool      // stream-json 模式下抑制人类可读输出
-	titleFormatter func(model string) string
-	outputLocker   OutputLocker // hide/show 保护（可能为 nil）
+	lastChar     byte      // 上次输出的最后一个字符
+	prevThinking bool      // 上一个事件是否为 THINKING
+	silent       bool      // stream-json 模式下抑制人类可读输出
+	testWriter   io.Writer // 仅用于测试：非 nil 时走这里而非 linenoiseWrite
 }
 
 func NewTermDisplay() *TermDisplay {
-	return &TermDisplay{
-		writer: os.Stdout,
+	return &TermDisplay{}
+}
+
+// SetWriter 设置输出目标（仅用于测试）
+func (d *TermDisplay) SetWriter(w io.Writer) {
+	d.testWriter = w
+}
+
+// write 发送字符串。生产环境走 linenoiseWrite（自动 Hide/OPOST/Show），
+// 测试环境走 testWriter。
+func (d *TermDisplay) write(s string) {
+	if d.testWriter != nil {
+		fmt.Fprint(d.testWriter, s)
+	} else {
+		linenoise.LinenoiseWrite(s)
+	}
+	if len(s) > 0 {
+		d.lastChar = s[len(s)-1]
 	}
 }
 
-// SetWriter 设置输出目标
-func (d *TermDisplay) SetWriter(w io.Writer) {
-	d.writer = w
-}
-
-// SetTitleFormatter 设置标题格式化函数
-func (d *TermDisplay) SetTitleFormatter(fn func(model string) string) {
-	d.titleFormatter = fn
+// writef 格式化并写入
+func (d *TermDisplay) writef(format string, args ...interface{}) {
+	s := fmt.Sprintf(format, args...)
+	d.write(s)
 }
 
 // EnsureNewline 确保光标在新行
 func (d *TermDisplay) EnsureNewline() {
 	if d.lastChar != '\n' && d.lastChar != 0 {
-		fmt.Fprintln(d.writer)
-		d.lastChar = '\n'
+		d.write("\n")
 	}
 }
 
@@ -58,12 +64,7 @@ func (d *TermDisplay) HumanText(s string) {
 	if s == "" {
 		return
 	}
-	fmt.Fprint(d.writer, s)
-	if strings.HasSuffix(s, "\n") {
-		d.lastChar = '\n'
-	} else {
-		d.lastChar = s[len(s)-1]
-	}
+	d.write(s)
 }
 
 // SetSilent 设置静默模式（stream-json 时抑制人类可读输出）
@@ -71,21 +72,12 @@ func (d *TermDisplay) SetSilent(s bool) {
 	d.silent = s
 }
 
-// SetOutputLocker sets a callback for hide/show protection during display output.
-func (d *TermDisplay) SetOutputLocker(locker OutputLocker) {
-	d.outputLocker = locker
-}
-
 // SetTitle 设置终端标题
 func (d *TermDisplay) SetTitle(title string) {
 	if d.silent {
 		return
 	}
-	if d.titleFormatter != nil {
-		title = d.titleFormatter(title)
-	}
-	// OSC 终端标题
-	fmt.Fprintf(d.writer, "\033]0;%s\007", title)
+	d.write(fmt.Sprintf("\033]0;%s\007", title))
 }
 
 // ShowEvent 显示一个 Event
@@ -94,37 +86,19 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 		return
 	}
 
-	// Hide linenoise prompt before writing output
-	var unlock func()
-	if d.outputLocker != nil {
-		unlock = d.outputLocker()
-	}
-	defer func() {
-		if unlock != nil {
-			unlock()
-		}
-	}()
-
 	switch ev.Type {
 	case EventText:
-		// thinking → text 转换时补换行
 		if d.prevThinking && d.lastChar != '\n' {
-			fmt.Fprintln(d.writer)
-			d.lastChar = '\n'
+			d.write("\n")
 		}
 		d.prevThinking = false
 		if len(ev.Fields) > 1 && ev.Fields[1] != "" {
-			d.HumanText(ev.Fields[1])
+			d.write(ev.Fields[1])
 		}
 
 	case EventThinking:
 		if len(ev.Fields) > 1 && ev.Fields[1] != "" {
-			fmt.Fprintf(d.writer, "\033[90m%s\033[0m", ev.Fields[1])
-			if strings.HasSuffix(ev.Fields[1], "\n") {
-				d.lastChar = '\n'
-			} else {
-				d.lastChar = ev.Fields[1][len(ev.Fields[1])-1]
-			}
+			d.writef("\033[90m%s\033[0m", ev.Fields[1])
 		}
 		d.prevThinking = true
 
@@ -133,19 +107,17 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 		d.EnsureNewline()
 		summary := ""
 		if len(ev.Fields) > 4 {
-			// Fields: ["TOOL_CALL", name, id, inputJSON, callSummary]
 			summary = ev.Fields[4]
 		} else if len(ev.Fields) > 1 {
 			summary = ev.Fields[1]
 		}
-		fmt.Fprintf(d.writer, "\033[33m[tool] %s\033[0m\n", summary)
-		d.lastChar = '\n'
+		d.writef("\033[33m[tool] %s\033[0m\n", summary)
 
 	case EventToolResult:
 		d.prevThinking = false
 		text := ""
 		if len(ev.Fields) > 3 {
-			text = ev.Fields[3] // result content
+			text = ev.Fields[3]
 		}
 		if text != "" {
 			name := ""
@@ -153,36 +125,28 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 				name = ev.Fields[2]
 			}
 			if name == "Edit" {
-				// Edit: 全文 + 换行
 				text = text + "\n"
 			} else if name == "Read" || name == "Write" {
-				// Read/Write: 只显示第一行摘要 + 换行
 				lines := strings.SplitN(text, "\n", 2)
 				text = lines[0] + "\n"
 			} else {
-				// 其他工具：全文 + 换行（与 bash 版一致）
 				text = text + "\n"
 			}
-			d.HumanText(text)
+			d.write(text)
 		}
 
 	case EventUsage:
-		// usage 不需要终端显示
 
 	case EventStop:
 		d.prevThinking = false
 		d.EnsureNewline()
-		// 与 bash 版 display_message STOP 分支对齐：interrupted 时打印提示
 		if len(ev.Fields) > 1 && ev.Fields[1] == "interrupted" {
-			fmt.Printf("\033[36mInterrupted.\033[0m\n")
-			d.lastChar = '\n'
+			d.writef("\033[36mInterrupted.\033[0m\n")
 		}
 
 	case EventSubAgentResult:
-		// Fields: ["SUB_AGENT_RESULT", sessionID, status, in, out, thinking, text]
 		d.EnsureNewline()
-		// 清空当前行，避免子 agent 残留内容导致排版混乱（与 bash/C 版对齐）
-		fmt.Fprintf(d.writer, "\r\033[K")
+		d.write("\r\033[K")
 		if len(ev.Fields) >= 4 {
 			sessionID := ev.Fields[1]
 			status := ev.Fields[2]
@@ -200,33 +164,31 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 				text = ev.Fields[6]
 			}
 			if status == "ok" {
-				fmt.Fprintf(d.writer, "\033[35m[sub-agent %s] completed (in=%s, out=%s)\033[0m\n", sessionID, in, out)
+				d.writef("\033[35m[sub-agent %s] completed (in=%s, out=%s)\033[0m\n", sessionID, in, out)
 			} else {
-				fmt.Fprintf(d.writer, "\033[31m[sub-agent %s] failed\033[0m\n", sessionID)
+				d.writef("\033[31m[sub-agent %s] failed\033[0m\n", sessionID)
 			}
 			if thinking != "" {
 				if len(thinking) > 120 {
-					fmt.Fprintf(d.writer, "\033[90m%s…\033[0m\n", thinking[:120])
+					d.writef("\033[90m%s…\033[0m\n", thinking[:120])
 				} else {
-					fmt.Fprintf(d.writer, "\033[90m%s\033[0m\n", thinking)
+					d.writef("\033[90m%s\033[0m\n", thinking)
 				}
 			}
 			if text != "" {
 				if len(text) > 120 {
-					fmt.Fprintf(d.writer, "%s…\n", text[:120])
+					d.writef("%s…\n", text[:120])
 				} else {
-					fmt.Fprintf(d.writer, "%s\n", text)
+					d.writef("%s\n", text)
 				}
 			}
 		}
-		d.lastChar = '\n'
 
 	case EventError:
 		d.EnsureNewline()
 		if len(ev.Fields) > 1 {
-			fmt.Fprintf(d.writer, "\033[31mError: %s\033[0m\n", ev.Fields[1])
+			d.writef("\033[31mError: %s\033[0m\n", ev.Fields[1])
 		}
-		d.lastChar = '\n'
 
 	case EventContextUpdate:
 		d.EnsureNewline()
@@ -234,8 +196,7 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 		if len(ev.Fields) > 2 {
 			info = ev.Fields[2]
 		}
-		fmt.Fprintf(d.writer, "\033[36mContext compacted (%s).\033[0m\n", info)
-		d.lastChar = '\n'
+		d.writef("\033[36mContext compacted (%s).\033[0m\n", info)
 
 	case EventImageDescribe:
 		d.EnsureNewline()
@@ -248,9 +209,8 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 			desc = ev.Fields[2]
 		}
 		if desc != "" {
-			fmt.Fprintf(d.writer, "\033[36m📸 %s: %s\033[0m\n", images, desc)
+			d.writef("\033[36m📸 %s: %s\033[0m\n", images, desc)
 		}
-		d.lastChar = '\n'
 
 	case EventUserMessage:
 		content := ""
@@ -259,8 +219,7 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 		}
 		if content != "" {
 			d.EnsureNewline()
-			fmt.Fprintf(d.writer, "\033[33m> %s\033[0m\n", content)
-			d.lastChar = '\n'
+			d.writef("\033[33m> %s\033[0m\n", content)
 		}
 	}
 }

--- a/go/display.go
+++ b/go/display.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/lloyd/claude-code/bash-agent/go2/linenoise"
 )
@@ -13,14 +15,16 @@ import (
 // ═══════════════════════════════════════════
 
 type TermDisplay struct {
-	lastChar     byte      // 上次输出的最后一个字符
+	lastChar     byte      // 上次输出的最后一个字节
 	prevThinking bool      // 上一个事件是否为 THINKING
 	silent       bool      // stream-json 模式下抑制人类可读输出
 	testWriter   io.Writer // 仅用于测试：非 nil 时走这里而非 linenoiseWrite
+	outputCol    int       // assistant 尾行显示列（ANSI=0，ASCII=1，非 ASCII=2）
+	batching     bool      // 是否处于一次事件批量输出中
 }
 
 func NewTermDisplay() *TermDisplay {
-	return &TermDisplay{}
+	return &TermDisplay{lastChar: '\n'}
 }
 
 // SetWriter 设置输出目标（仅用于测试）
@@ -28,23 +32,94 @@ func (d *TermDisplay) SetWriter(w io.Writer) {
 	d.testWriter = w
 }
 
-// write 发送字符串。生产环境走 linenoiseWrite（自动 Hide/OPOST/Show），
-// 测试环境走 testWriter。
-func (d *TermDisplay) write(s string) {
+// writeRaw 发送字符串，不更新显示状态。
+func (d *TermDisplay) writeRaw(s string) {
+	if s == "" {
+		return
+	}
 	if d.testWriter != nil {
 		fmt.Fprint(d.testWriter, s)
+	} else if d.batching {
+		fmt.Fprint(os.Stdout, s)
 	} else {
 		linenoise.LinenoiseWrite(s)
 	}
-	if len(s) > 0 {
-		d.lastChar = s[len(s)-1]
-	}
+}
+
+// write 发送字符串并更新显示状态。
+func (d *TermDisplay) write(s string) {
+	d.writeRaw(s)
+	d.updateState(s)
 }
 
 // writef 格式化并写入
 func (d *TermDisplay) writef(format string, args ...interface{}) {
 	s := fmt.Sprintf(format, args...)
 	d.write(s)
+}
+
+func (d *TermDisplay) beginEvent() {
+	if d.testWriter == nil {
+		linenoise.DisplayBegin()
+	}
+	d.batching = true
+}
+
+func (d *TermDisplay) endEvent() {
+	if !d.batching {
+		return
+	}
+	d.batching = false
+	if d.testWriter == nil {
+		linenoise.DisplayEnd(d.outputCol, d.lastChar == '\n')
+	}
+}
+
+func (d *TermDisplay) updateState(s string) {
+	if s == "" {
+		return
+	}
+	d.lastChar = s[len(s)-1]
+	d.updateOutputCol(s)
+}
+
+func (d *TermDisplay) updateOutputCol(s string) {
+	esc := false
+	for len(s) > 0 {
+		c := s[0]
+		if esc {
+			_, size := utf8.DecodeRuneInString(s)
+			if size <= 0 {
+				size = 1
+			}
+			if c >= 0x40 && c <= 0x7e {
+				esc = false
+			}
+			s = s[size:]
+			continue
+		}
+		if c == 0x1b && len(s) > 1 && s[1] == '[' {
+			esc = true
+			s = s[2:]
+			continue
+		}
+		if c == '\r' || c == '\n' {
+			d.outputCol = 0
+			s = s[1:]
+			continue
+		}
+		if c < 0x80 {
+			d.outputCol++
+			s = s[1:]
+			continue
+		}
+		_, size := utf8.DecodeRuneInString(s)
+		if size <= 0 {
+			size = 1
+		}
+		d.outputCol += 2
+		s = s[size:]
+	}
 }
 
 // EnsureNewline 确保光标在新行
@@ -57,6 +132,9 @@ func (d *TermDisplay) EnsureNewline() {
 // SetLastChar 直接设置上次输出的最后一个字符
 func (d *TermDisplay) SetLastChar(c byte) {
 	d.lastChar = c
+	if c == '\n' || c == '\r' || c == 0 {
+		d.outputCol = 0
+	}
 }
 
 // HumanText 输出人类可读文本
@@ -77,7 +155,15 @@ func (d *TermDisplay) SetTitle(title string) {
 	if d.silent {
 		return
 	}
-	d.write(fmt.Sprintf("\033]0;%s\007", title))
+	fmt.Fprintf(os.Stderr, "\033]0;%s\007", title)
+}
+
+func (d *TermDisplay) clearLineIfAtNewline() {
+	if d.testWriter == nil && d.lastChar == '\n' {
+		d.write("\r\033[K")
+		d.lastChar = 0
+		d.outputCol = 0
+	}
 }
 
 // ShowEvent 显示一个 Event
@@ -86,8 +172,12 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 		return
 	}
 
+	d.beginEvent()
+	defer d.endEvent()
+
 	switch ev.Type {
 	case EventText:
+		d.clearLineIfAtNewline()
 		if d.prevThinking && d.lastChar != '\n' {
 			d.write("\n")
 		}
@@ -97,8 +187,12 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 		}
 
 	case EventThinking:
+		d.clearLineIfAtNewline()
 		if len(ev.Fields) > 1 && ev.Fields[1] != "" {
-			d.writef("\033[90m%s\033[0m", ev.Fields[1])
+			// ANSI 颜色控制序列不能更新 lastChar，否则内容以 \n 结尾时会被误判为未换行，导致额外空行。
+			d.writeRaw("\033[90m")
+			d.write(ev.Fields[1])
+			d.writeRaw("\033[0m")
 		}
 		d.prevThinking = true
 
@@ -145,8 +239,10 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 		}
 
 	case EventSubAgentResult:
+		if d.testWriter == nil && d.lastChar == '\n' {
+			d.write("\r\033[K")
+		}
 		d.EnsureNewline()
-		d.write("\r\033[K")
 		if len(ev.Fields) >= 4 {
 			sessionID := ev.Fields[1]
 			status := ev.Fields[2]

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -92,8 +92,14 @@ var (
 	ErrMore        = errors.New("edit more") // sentinel: still editing
 )
 
-// LinenoiseState wraps the C struct linenoiseState for non-blocking editing.
-type LinenoiseState C.struct_linenoiseState
+// LinenoiseState owns C-allocated linenoise state, input buffer and prompt.
+// All three must stay alive until EditStop; linenoiseState stores pointers to
+// the buffer and prompt internally.
+type LinenoiseState struct {
+	ptr    *C.struct_linenoiseState
+	buf    unsafe.Pointer
+	prompt *C.char
+}
 
 // imagePasteFn is set by SetImagePasteCallback.
 var imagePasteFn func() string
@@ -169,18 +175,33 @@ func SetMultiLine(ml bool) {
 // EditStart initializes a non-blocking line editing session.
 // Returns a LinenoiseState pointer for subsequent EditFeed/EditStop/Hide/Show calls.
 func EditStart(stdinFd, stdoutFd int, buf []byte, prompt string) (*LinenoiseState, error) {
-	cprompt := C.CString(prompt)
-	defer C.free(unsafe.Pointer(cprompt))
-
-	ls := &LinenoiseState{}
-	rc := C.linenoise_edit_start((*C.struct_linenoiseState)(ls),
-		C.int(stdinFd), C.int(stdoutFd),
-		(*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)),
-		cprompt)
-	if rc == -1 {
+	bufLen := len(buf)
+	if bufLen == 0 {
+		bufLen = 65536
+	}
+	// Allocate buffer in C memory so linenoiseState never holds a Go pointer.
+	cbuf := C.malloc(C.size_t(bufLen))
+	if cbuf == nil {
 		return nil, ErrEOF
 	}
-	return ls, nil
+	cprompt := C.CString(prompt) // also C-allocated
+	cls := (*C.struct_linenoiseState)(C.malloc(C.size_t(unsafe.Sizeof(C.struct_linenoiseState{}))))
+	if cls == nil {
+		C.free(cbuf)
+		C.free(unsafe.Pointer(cprompt))
+		return nil, ErrEOF
+	}
+	rc := C.linenoise_edit_start(cls,
+		C.int(stdinFd), C.int(stdoutFd),
+		(*C.char)(cbuf), C.size_t(bufLen),
+		cprompt)
+	if rc == -1 {
+		C.free(unsafe.Pointer(cls))
+		C.free(cbuf)
+		C.free(unsafe.Pointer(cprompt))
+		return nil, ErrEOF
+	}
+	return &LinenoiseState{ptr: cls, buf: cbuf, prompt: cprompt}, nil
 }
 
 // EditFeed processes one character / event from stdin.
@@ -189,7 +210,10 @@ func EditStart(stdinFd, stdoutFd int, buf []byte, prompt string) (*LinenoiseStat
 // Returns ("", ErrInterrupted) on Ctrl+C.
 // Returns ("", ErrEOF) on Ctrl+D or error.
 func EditFeed(ls *LinenoiseState) (string, error) {
-	r := C.linenoise_edit_feed_safe((*C.struct_linenoiseState)(ls))
+	if ls == nil || ls.ptr == nil {
+		return "", ErrEOF
+	}
+	r := C.linenoise_edit_feed_safe(ls.ptr)
 	if r.line == C.linenoiseEditMore {
 		return "", ErrMore
 	}
@@ -208,17 +232,30 @@ func EditFeed(ls *LinenoiseState) (string, error) {
 
 // EditStop exits raw mode and cleans up the editing session.
 func EditStop(ls *LinenoiseState) {
-	C.linenoise_edit_stop((*C.struct_linenoiseState)(ls))
+	if ls == nil || ls.ptr == nil {
+		return
+	}
+	C.linenoise_edit_stop(ls.ptr)
+	C.free(unsafe.Pointer(ls.ptr))
+	C.free(ls.buf)
+	C.free(unsafe.Pointer(ls.prompt))
+	ls.ptr = nil
+	ls.buf = nil
+	ls.prompt = nil
 }
 
 // Hide clears the current prompt line from the terminal.
 func Hide(ls *LinenoiseState) {
-	C.linenoise_hide((*C.struct_linenoiseState)(ls))
+	if ls != nil && ls.ptr != nil {
+		C.linenoise_hide(ls.ptr)
+	}
 }
 
 // Show restores the prompt line to the terminal.
 func Show(ls *LinenoiseState) {
-	C.linenoise_show((*C.struct_linenoiseState)(ls))
+	if ls != nil && ls.ptr != nil {
+		C.linenoise_show(ls.ptr)
+	}
 }
 
 // PollStdin polls stdin for available data with a timeout in milliseconds.
@@ -241,8 +278,8 @@ func LinenoiseWrite(s string) {
 // Must be called when starting an editing session so that LinenoiseWrite
 // knows which state to Hide/Show.
 func RegisterState(ls *LinenoiseState) {
-	if ls != nil {
-		C.linenoise_register_state(unsafe.Pointer(ls))
+	if ls != nil && ls.ptr != nil {
+		C.linenoise_register_state(unsafe.Pointer(ls.ptr))
 	}
 }
 

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -72,14 +72,6 @@ static void linenoise_write(const char *s, size_t len) {
 	linenoiseWrite(s, len);
 }
 
-static void readline_display_begin_wrapper(void) {
-	readline_display_begin();
-}
-
-static void readline_display_end_wrapper(int output_col, int output_at_newline) {
-	readline_display_end(output_col, output_at_newline);
-}
-
 static void linenoise_register_state(void *state) {
 	linenoiseRegisterState(state);
 }
@@ -273,27 +265,12 @@ func PollStdin(fd int, timeoutMs int) int {
 }
 
 // LinenoiseWrite writes a string to stdout with automatic Hide/OPOST/Show management.
-// This is the only function callers need for display output — no separate
-// outputCol tracking, OPOST toggling, or Hide/Show calls required.
+// Each call is atomic — Lock → Hide → write → Show → Unlock.
 func LinenoiseWrite(s string) {
 	if len(s) == 0 {
 		return
 	}
 	C.linenoise_write((*C.char)(unsafe.Pointer(unsafe.StringData(s))), C.size_t(len(s)))
-}
-
-// DisplayBegin hides the active prompt and holds the linenoise display lock.
-func DisplayBegin() {
-	C.readline_display_begin_wrapper()
-}
-
-// DisplayEnd restores the active prompt and releases the linenoise display lock.
-func DisplayEnd(outputCol int, outputAtNewline bool) {
-	atNewline := 0
-	if outputAtNewline {
-		atNewline = 1
-	}
-	C.readline_display_end_wrapper(C.int(outputCol), C.int(atNewline))
 }
 
 // RegisterState registers the linenoise state with the display system.

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -72,6 +72,14 @@ static void linenoise_write(const char *s, size_t len) {
 	linenoiseWrite(s, len);
 }
 
+static void readline_display_begin_wrapper(void) {
+	readline_display_begin();
+}
+
+static void readline_display_end_wrapper(int output_col, int output_at_newline) {
+	readline_display_end(output_col, output_at_newline);
+}
+
 static void linenoise_register_state(void *state) {
 	linenoiseRegisterState(state);
 }
@@ -272,6 +280,20 @@ func LinenoiseWrite(s string) {
 		return
 	}
 	C.linenoise_write((*C.char)(unsafe.Pointer(unsafe.StringData(s))), C.size_t(len(s)))
+}
+
+// DisplayBegin hides the active prompt and holds the linenoise display lock.
+func DisplayBegin() {
+	C.readline_display_begin_wrapper()
+}
+
+// DisplayEnd restores the active prompt and releases the linenoise display lock.
+func DisplayEnd(outputCol int, outputAtNewline bool) {
+	atNewline := 0
+	if outputAtNewline {
+		atNewline = 1
+	}
+	C.readline_display_end_wrapper(C.int(outputCol), C.int(atNewline))
 }
 
 // RegisterState registers the linenoise state with the display system.

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -27,10 +27,6 @@ static int linenoise_edit_start(struct linenoiseState *l, int ifd, int ofd,
 	return linenoiseEditStart(l, ifd, ofd, buf, buflen, prompt);
 }
 
-static char *linenoise_edit_feed(struct linenoiseState *l) {
-	return linenoiseEditFeed(l);
-}
-
 static void linenoise_edit_stop(struct linenoiseState *l) {
 	linenoiseEditStop(l);
 }

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -67,6 +67,18 @@ static struct edit_feed_result linenoise_edit_feed_safe(struct linenoiseState *l
 
 // C wrapper that calls the Go export below.
 extern void goImagePasteCallback(char **out, size_t *outlen);
+
+static void linenoise_write(const char *s, size_t len) {
+	linenoiseWrite(s, len);
+}
+
+static void linenoise_register_state(void *state) {
+	linenoiseRegisterState(state);
+}
+
+static void linenoise_set_active(int active) {
+	linenoiseSetActive(active);
+}
 */
 import "C"
 import (
@@ -213,4 +225,34 @@ func Show(ls *LinenoiseState) {
 // Returns >0 if data available, 0 on timeout, -1 on error.
 func PollStdin(fd int, timeoutMs int) int {
 	return int(C.poll_stdin(C.int(fd), C.int(timeoutMs)))
+}
+
+// LinenoiseWrite writes a string to stdout with automatic Hide/OPOST/Show management.
+// This is the only function callers need for display output — no separate
+// outputCol tracking, OPOST toggling, or Hide/Show calls required.
+func LinenoiseWrite(s string) {
+	if len(s) == 0 {
+		return
+	}
+	C.linenoise_write((*C.char)(unsafe.Pointer(unsafe.StringData(s))), C.size_t(len(s)))
+}
+
+// RegisterState registers the linenoise state with the display system.
+// Must be called when starting an editing session so that LinenoiseWrite
+// knows which state to Hide/Show.
+func RegisterState(ls *LinenoiseState) {
+	if ls != nil {
+		C.linenoise_register_state(unsafe.Pointer(ls))
+	}
+}
+
+// SetActive sets whether the editor is active.
+// Must be called (true before EditFeed, false after) so that LinenoiseWrite
+// knows when to apply Hide/OPOST/Show.
+func SetActive(active bool) {
+	if active {
+		C.linenoise_set_active(1)
+	} else {
+		C.linenoise_set_active(0)
+	}
 }

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -2241,7 +2241,7 @@ fn image_describe(paths: &[std::path::PathBuf]) -> String {
 
     use base64::Engine as _;
     let mut content: Vec<serde_json::Value> = vec![
-        serde_json::json!({"type": "text", "text": "Output all visible text from each image. Transcribe every character including special symbols. Preserve exact spacing and line breaks. Do not summarize or describe - just output the raw text exactly as shown. If an image has no text, briefly describe what you see."})
+        serde_json::json!({"type": "text", "text": "Output all visible text from each image, separated by a blank line between images. Transcribe every character including special symbols (arrows, prompts, dots, slashes). Preserve exact spacing and line breaks. Pay attention to date formats (month names, numbers). Do not summarize or describe - just output the raw text exactly as shown. If an image has no text, briefly describe what you see."})
     ];
     for p in paths {
         if let Ok(data) = std::fs::read(p) {

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -12,7 +12,6 @@ use crate::util::{
     build_claude_request,
     chrono_like_now,
     chrono_now_rfc3339,
-    normalize_display_text,
     parse_input_fields,
     stats_get_f64,
     touch,
@@ -251,12 +250,6 @@ enum MainLoopMessage {
     },
 }
 
-/// Wrapper to allow sending raw linenoiseState pointers across threads.
-/// Safety: we only use the pointer for Hide/Show calls under mutex protection.
-pub(crate) struct LinenoiseStatePtr(*mut ffi::LinenoiseState);
-unsafe impl Send for LinenoiseStatePtr {}
-unsafe impl Sync for LinenoiseStatePtr {}
-
 struct Agent {
     cfg: Config,
     cwd: PathBuf,
@@ -268,6 +261,7 @@ struct Agent {
     http: StreamClient,
     transport: TransportRef,
     interrupted: Arc<AtomicBool>,
+    running: Arc<AtomicBool>,              // 1 = agent_loop 执行中，readline 据此判断 Ctrl+C 是否应中断
     last_context_tokens: usize,
     last_input_tokens: usize,
     last_output_tokens: usize,
@@ -282,7 +276,6 @@ struct Agent {
     display_tx: Option<mpsc::Sender<DisplayCommand>>,
     display_handle: Option<thread::JoinHandle<()>>,
     cancel_read_fd: i32,                      // cancel pipe 读端 FD，传给 Runner 做 kqueue wait
-    linenoise_state: Arc<Mutex<Option<LinenoiseStatePtr>>>, // 共享 linenoiseState，display worker 用于 hide/show
 }
 
 struct DisplayState {
@@ -364,99 +357,81 @@ enum DisplayCommand {
     Flush(mpsc::Sender<()>),
 }
 
-fn display_write_human(out: &mut dyn Write, interactive: bool, s: &str) -> Result<()> {
-    write!(out, "{}", normalize_display_text(s, interactive))?;
-    out.flush()?;
+#[allow(dead_code)]
+fn display_write_human(_out: &mut dyn Write, _interactive: bool, _s: &str) -> Result<()> {
+    ffi::linenoise_write(_s);
     Ok(())
 }
 
 fn render_display_event(
     ds: &mut DisplayState,
-    out: &mut dyn Write,
     interactive: bool,
     evt: DisplayEvent,
 ) -> Result<()> {
+    let lw = |s: &str| { ffi::linenoise_write(s); };
+
     match evt {
         DisplayEvent::Thinking(content) => {
-            // bash 版在每个消息显示前检查 last_char=='\n' 并执行 \r\x1b[K
             if interactive && ds.last_char == "\n" {
-                display_write_human(out, interactive, "\r\x1b[K")?;
+                lw("\r\x1b[K");
+                ds.last_char.clear();
             }
-            display_write_human(out, interactive, &format!("\x1b[90m{}\x1b[0m", content))?;
-            let display_content = normalize_display_text(&content, interactive);
-            if display_content.ends_with('\n') {
-                ds.last_char = "\n".to_string();
-            } else if let Some(c) = display_content.chars().last() {
-                ds.last_char = c.to_string();
+            if !content.is_empty() {
+                /* 颜色码 + 内容 + 重置必须在一个 linenoiseWrite 调用内，
+                 * 否则中间的 Show 重绘 prompt 时 \x1b[0m 会重置终端颜色 */
+                lw(&format!("\x1b[90m{}\x1b[0m", content));
+                update_last_char(ds, &content);
             }
             ds.prev_was_thinking = true;
         }
         DisplayEvent::Text(content) => {
-            // bash 版在每个消息显示前检查 last_char=='\n' 并执行 \r\x1b[K
             if interactive && ds.last_char == "\n" {
-                display_write_human(out, interactive, "\r\x1b[K")?;
+                lw("\r\x1b[K");
+                ds.last_char.clear();
             }
             if ds.prev_was_thinking && ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
+                lw("\n");
                 ds.last_char = "\n".to_string();
             }
-            display_write_human(out, interactive, &content)?;
-            let display_content = normalize_display_text(&content, interactive);
-            if display_content.ends_with('\n') {
-                ds.last_char = "\n".to_string();
-            } else if let Some(c) = display_content.chars().last() {
-                ds.last_char = c.to_string();
+            if !content.is_empty() {
+                lw(&content);
+                update_last_char(ds, &content);
             }
             ds.prev_was_thinking = false;
         }
         DisplayEvent::ToolCall(call) => {
-            if ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
-            }
+            ensure_newline(ds, &lw);
+            lw(&format!(
+                "\x1b[33m[tool] {}\x1b[0m\n",
+                build_tool_call_summary(&call.name, &call.fields)
+            ));
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
-            display_write_human(
-                out,
-                interactive,
-                &format!(
-                    "\x1b[33m[tool] {}\x1b[0m\n",
-                    build_tool_call_summary(&call.name, &call.fields)
-                ),
-            )?;
         }
         DisplayEvent::Usage(_) => {}
         DisplayEvent::Stop(reason) => {
-            if ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
-                ds.last_char = "\n".to_string();
-            }
+            ensure_newline(ds, &lw);
             if reason == "interrupted" {
-                display_write_human(out, interactive, "\x1b[36mInterrupted.\x1b[0m\n")?;
+                lw("\x1b[36mInterrupted.\x1b[0m\n");
                 ds.last_char = "\n".to_string();
             }
             ds.prev_was_thinking = false;
         }
         DisplayEvent::Error(message) => {
-            if ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
-            }
-            display_write_human(out, interactive, &format!("\x1b[31mError: {}\x1b[0m\n", message))?;
+            ensure_newline(ds, &lw);
+            lw(&format!("\x1b[31mError: {}\x1b[0m\n", message));
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
         }
         DisplayEvent::UserMessage(content) => {
-            if ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
-            }
-            display_write_human(out, interactive, &format!("\x1b[32m> {}\x1b[0m\n", truncate_for_replay(&content, 77)))?;
+            ensure_newline(ds, &lw);
+            lw(&format!("\x1b[32m> {}\x1b[0m\n", truncate_for_replay(&content, 77)));
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
         }
         DisplayEvent::ContextUpdate(trigger) => {
-            if ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
-            }
-            display_write_human(out, interactive, &format!("\x1b[36mContext compacted ({}).\x1b[0m\n", trigger))?;
+            ensure_newline(ds, &lw);
+            lw(&format!("\x1b[36mContext compacted ({}).\x1b[0m\n", trigger));
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
         }
@@ -465,30 +440,20 @@ fn render_display_event(
                 return Ok(());
             }
             let tr_text = if result.tool_name == "Edit" {
-                // Don't normalize_display_text here — display_write_human already does it.
-                // Double-normalizing would turn \n → \r\n → \r\r\n, causing garbled output.
                 let mut s = result.content.replace("\r\n", "\n").replace('\r', "\n");
-                if !s.ends_with('\n') {
-                    s.push('\n');
-                }
+                if !s.ends_with('\n') { s.push('\n'); }
                 s
             } else if result.tool_name == "Read" || result.tool_name == "Write" {
                 first_line(&result.content).to_string() + "\n"
             } else {
-                // Don't normalize_display_text here — display_write_human already does it.
                 result.content.clone() + "\n"
             };
             if ds.prev_was_thinking && ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
-                ds.last_char = "\n".to_string();
+                lw("\n");
             }
             ds.prev_was_thinking = false;
-            display_write_human(out, interactive, &tr_text)?;
-            if tr_text.ends_with('\n') {
-                ds.last_char = "\n".to_string();
-            } else if let Some(c) = tr_text.chars().last() {
-                ds.last_char = c.to_string();
-            }
+            lw(&tr_text);
+            update_last_char(ds, &tr_text);
         }
         DisplayEvent::SubAgentResult {
             session_id,
@@ -498,53 +463,31 @@ fn render_display_event(
             in_tokens,
             out_tokens,
         } => {
-            if ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
+            if interactive && ds.last_char == "\n" {
+                lw("\r\x1b[K");
             }
-            // 清空当前行，避免子 agent 残留内容导致排版混乱
-            // 只在 interactive 模式下执行，与 bash 版对齐
-            if interactive {
-                display_write_human(out, interactive, "\r\x1b[K")?;
-            }
+            ensure_newline(ds, &lw);
             if status == "ok" {
-                display_write_human(
-                    out,
-                    interactive,
-                    &format!(
-                        "\x1b[35m[sub-agent {}] completed (in={}, out={})\x1b[0m\n",
-                        session_id, in_tokens, out_tokens
-                    ),
-                )?;
+                lw(&format!(
+                    "\x1b[35m[sub-agent {}] completed (in={}, out={})\x1b[0m\n",
+                    session_id, in_tokens, out_tokens
+                ));
             } else {
-                display_write_human(
-                    out,
-                    interactive,
-                    &format!("\x1b[31m[sub-agent {}] failed\x1b[0m\n", session_id),
-                )?;
+                lw(&format!("\x1b[31m[sub-agent {}] failed\x1b[0m\n", session_id));
             }
             if !thinking.is_empty() {
-                display_write_human(
-                    out,
-                    interactive,
-                    &format!("\x1b[90m{}\x1b[0m\n", truncate_str(&thinking, 120)),
-                )?;
+                lw(&format!("\x1b[90m{}\x1b[0m\n", truncate_str(&thinking, 120)));
             }
             if !text.is_empty() {
-                display_write_human(out, interactive, &format!("{}\n", truncate_str(&text, 120)))?;
+                lw(&format!("{}\n", truncate_str(&text, 120)));
             }
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
         }
         DisplayEvent::ImageDescribe { images, description } => {
-            if ds.last_char != "\n" {
-                display_write_human(out, interactive, "\n")?;
-            }
+            ensure_newline(ds, &lw);
             if !description.is_empty() {
-                display_write_human(
-                    out,
-                    interactive,
-                    &format!("\x1b[36m📸 {}: {}\x1b[0m\n", images, description),
-                )?;
+                lw(&format!("\x1b[36m📸 {}: {}\x1b[0m\n", images, description));
             }
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
@@ -553,38 +496,44 @@ fn render_display_event(
     Ok(())
 }
 
+fn ensure_newline(ds: &mut DisplayState, lw: &dyn Fn(&str)) {
+    if ds.last_char != "\n" {
+        lw("\n");
+        ds.last_char = "\n".to_string();
+    }
+}
+
+fn update_last_char(ds: &mut DisplayState, s: &str) {
+    if s.is_empty() { return; }
+    let mut esc = false;
+    let mut last_visible: Option<char> = None;
+    for c in s.chars() {
+        if esc {
+            if ('\u{40}'..='\u{7e}').contains(&c) { esc = false; }
+            continue;
+        }
+        if c == '\u{1b}' { esc = true; continue; }
+        last_visible = Some(c);
+    }
+    if let Some(c) = last_visible {
+        ds.last_char = c.to_string();
+    }
+}
+
 impl Agent {
-    fn start_display_worker(interactive: bool, ls: Arc<Mutex<Option<LinenoiseStatePtr>>>) -> (mpsc::Sender<DisplayCommand>, thread::JoinHandle<()>) {
+    fn start_display_worker(interactive: bool) -> (mpsc::Sender<DisplayCommand>, thread::JoinHandle<()>) {
         let (tx, rx) = mpsc::channel::<DisplayCommand>();
         let handle = thread::spawn(move || {
             let mut ds = DisplayState {
                 last_char: String::from("\n"),
                 prev_was_thinking: false,
             };
-            let mut out: Box<dyn Write + Send> = Box::new(io::stdout());
             while let Ok(cmd) = rx.recv() {
                 match cmd {
                     DisplayCommand::Event(evt) => {
-                        // Hide linenoise prompt before output
-                        if interactive {
-                            let guard = ls.lock().unwrap();
-                            if let Some(LinenoiseStatePtr(ls_ptr)) = *guard {
-                                unsafe { ffi::hide(ls_ptr); }
-                            }
-                            drop(guard);
-                        }
-                        let _ = render_display_event(&mut ds, &mut out, interactive, evt);
-                        // Show linenoise prompt after output
-                        if interactive {
-                            let guard = ls.lock().unwrap();
-                            if let Some(LinenoiseStatePtr(ls_ptr)) = *guard {
-                                unsafe { ffi::show(ls_ptr); }
-                            }
-                            drop(guard);
-                        }
+                        let _ = render_display_event(&mut ds, interactive, evt);
                     }
                     DisplayCommand::Flush(done) => {
-                        let _ = out.flush();
                         let _ = done.send(());
                     }
                 }
@@ -663,15 +612,15 @@ impl Agent {
         let tools_json: Vec<Value> = serde_json::from_str(TOOLS_JSON)?;
         let api_url = api_url(&cfg);
         let interrupted = Arc::new(AtomicBool::new(false));
+        let running = Arc::new(AtomicBool::new(false));
         let transport = Arc::from(crate::transport::new_transport(&cfg));
         let (msg_tx, msg_rx) = mpsc::channel(); // 初始化消息队列
         let msg_tx = Arc::new(Mutex::new(Some(msg_tx))); // 包装在 Arc<Mutex<Option>> 中
-        let linenoise_state: Arc<Mutex<Option<LinenoiseStatePtr>>> = Arc::new(Mutex::new(None));
 
         let (display_tx, display_handle) = if cfg.output_format == OutputFormat::StreamJson {
             (None, None)
         } else {
-            let (tx, handle) = Self::start_display_worker(cfg.interactive, linenoise_state.clone());
+            let (tx, handle) = Self::start_display_worker(cfg.interactive);
             (Some(tx), Some(handle))
         };
 
@@ -686,6 +635,7 @@ impl Agent {
             http: StreamClient::new()?,
             transport,
             interrupted,
+            running,
             last_context_tokens: 0,
             last_input_tokens: 0,
             last_output_tokens: 0,
@@ -700,7 +650,6 @@ impl Agent {
             display_tx,
             display_handle,
             cancel_read_fd: 0, // 占位，稍后由 agent_run 设置
-            linenoise_state,
         };
 
         if new_session {
@@ -796,6 +745,7 @@ impl Agent {
                 http: StreamClient::new().expect("Failed to create HTTP client"),
                 transport: Arc::from(crate::transport::new_transport(&cfg)),
                 interrupted: Arc::new(AtomicBool::new(false)),
+                running: Arc::new(AtomicBool::new(false)),
                 last_context_tokens: 0,
                 last_input_tokens: 0,
                 last_output_tokens: 0,
@@ -810,7 +760,6 @@ impl Agent {
                 display_tx: None,
                 display_handle: None,
                 cancel_read_fd: -1,
-                linenoise_state: Arc::new(Mutex::new(None)),
             };
 
             // 4. 执行 agent_loop
@@ -922,8 +871,9 @@ impl Agent {
         ffi::set_image_dir(self.paths.session_dir.join("images"));
         ffi::register_paste_callback();
 
-        // 使用 Agent 结构体中的共享 linenoiseState（display worker 已经持有 clone）
-        let linenoise_state = self.linenoise_state.clone();
+        // 使用 Agent 结构体中的共享 interrupted / running，供 Ctrl+C 中断 agent
+        let interrupted_flag = self.interrupted.clone();
+        let running_flag = self.running.clone();
 
         // 启动 readline 线程，将用户输入发送到消息队列
         let msg_tx_arc = self.msg_tx.clone();
@@ -963,11 +913,9 @@ impl Agent {
                     }
                     let ls_ptr = ls.as_mut_ptr();
 
-                    // 注册到共享状态
-                    {
-                        let mut guard = linenoise_state.lock().unwrap();
-                        *guard = Some(LinenoiseStatePtr(ls_ptr));
-                    }
+                    // 注册到 linenoise 全局状态（linenoiseWrite 用它做 Hide/Show）
+                    unsafe { ffi::register_state(ls_ptr); }
+                    ffi::set_active(true);
 
                     // Feed 循环
                     let line = loop {
@@ -996,10 +944,8 @@ impl Agent {
                     };
 
                     // 清除共享状态
-                    {
-                        let mut guard = linenoise_state.lock().unwrap();
-                        *guard = None;
-                    }
+                    ffi::set_active(false);
+                    unsafe { ffi::register_state(std::ptr::null_mut()); }
 
                     // EditStop
                     unsafe { ffi::edit_stop_ptr(ls_ptr); }
@@ -1026,7 +972,11 @@ impl Agent {
                             }
                         }
                         Err(ffi::LineError::Interrupted) => {
-                            continue; // Ctrl+C → 重新输入
+                            // Ctrl+C — 如果 agent 正在运行，设置 interrupted 标志中断 HTTP 请求
+                            if running_flag.load(Ordering::SeqCst) {
+                                interrupted_flag.store(true, Ordering::SeqCst);
+                            }
+                            continue;
                         }
                         Err(_) => {
                             return; // Ctrl+D / EOF
@@ -1075,6 +1025,8 @@ impl Agent {
                         // 清除当前行（包括提示符）
                         let _ = write!(self.stderr.borrow_mut(), "\r\x1b[2K");
                     }
+                    self.running.store(true, Ordering::SeqCst);
+                    self.interrupted.store(false, Ordering::SeqCst);
                     if let Err(e) = self.agent_loop(input) {
                         let msg = e.to_string();
                         // 不打印中断相关的错误（包括 SSE 流被 Ctrl+C 断开的情况）
@@ -1085,6 +1037,7 @@ impl Agent {
                             self.error(&msg);
                         }
                     }
+                    self.running.store(false, Ordering::SeqCst);
                     self.flush_display();
 
                     // Go 版架构：agent_loop 结束后，如果有活跃子 agent，

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -68,10 +68,11 @@ unsafe extern "C" {
 }
 
 /// Opaque type matching C's struct linenoiseState.
-/// We only ever hold a pointer to it — the layout is managed by linenoise.c.
+/// Must be large enough for the actual C struct (~376 bytes on 64-bit).
+/// Uses u64 for correct 8-byte alignment matching size_t/pointer fields.
 #[repr(C)]
 pub struct LinenoiseState {
-    _opaque: [u8; 0],
+    _opaque: [u64; 64], // 512 bytes, generous for struct linenoiseState
 }
 
 /// Result of a non-blocking EditFeed call.
@@ -302,7 +303,7 @@ fn try_clipboard_image(next: usize, img_dir: &std::path::Path) -> Option<Vec<u8>
     let tmp_path = img_dir.join(format!("{next}.png.tmp"));
     let tmp_str = tmp_path.to_string_lossy().to_string();
     let osa_cmd = format!(
-        "set theImage to the clipboard as «class PNGf»\nset theFile to open for access POSIX file \"{tmp_str}\" with write permission\nwrite theImage to theFile\ncoaccess theFile"
+        "set theImage to the clipboard as «class PNGf»\nset theFile to open for access POSIX file \"{tmp_str}\" with write permission\nwrite theImage to theFile\nclose access theFile"
     );
     if std::process::Command::new("osascript")
         .arg("-e")

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -47,6 +47,9 @@ unsafe extern "C" {
     fn linenoiseHistoryLoad(filename: *const c_char) -> libc::c_int;
     fn linenoiseSetMultiLine(ml: libc::c_int);
     fn linenoiseSetImagePasteCallback(cb: Option<unsafe extern "C" fn(*mut *mut libc::c_char, *mut libc::size_t)>);
+    fn linenoiseWrite(s: *const c_char, len: libc::size_t);
+    fn linenoiseRegisterState(ls: *mut LinenoiseState);
+    fn linenoiseSetActive(active: libc::c_int);
 
     // Non-blocking API
     fn linenoiseEditStart(
@@ -129,6 +132,30 @@ pub unsafe fn hide(ls: *mut LinenoiseState) {
 /// ls must be a valid, active linenoiseState pointer.
 pub unsafe fn show(ls: *mut LinenoiseState) {
     unsafe { linenoiseShow(ls); }
+}
+
+/// Atomic display write: Lock → Hide → restore cursor → OPOST on → write →
+/// OPOST off → update cursor → handle detach → Show → Unlock.
+/// Each call is fully self-contained; callers don't track columns or call begin/end.
+pub fn linenoise_write(s: &str) {
+    if s.is_empty() {
+        return;
+    }
+    unsafe {
+        linenoiseWrite(s.as_ptr() as *const c_char, s.len() as libc::size_t);
+    }
+}
+
+/// Register/unregister the active linenoise state for synchronized display output.
+/// # Safety
+/// ls must be a valid pointer or null.
+pub unsafe fn register_state(ls: *mut LinenoiseState) {
+    unsafe { linenoiseRegisterState(ls); }
+}
+
+/// Set whether a linenoise edit session is currently active.
+pub fn set_active(active: bool) {
+    unsafe { linenoiseSetActive(if active { 1 } else { 0 }); }
 }
 
 /// Free a line returned by linenoise or edit_feed_raw.
@@ -275,10 +302,7 @@ fn try_clipboard_image(next: usize, img_dir: &std::path::Path) -> Option<Vec<u8>
     let tmp_path = img_dir.join(format!("{next}.png.tmp"));
     let tmp_str = tmp_path.to_string_lossy().to_string();
     let osa_cmd = format!(
-        "set theImage to the clipboard as «class PNGf»
-set theFile to open for access POSIX file \"{tmp_str}\" with write permission
-write theImage to theFile
-close access theFile"
+        "set theImage to the clipboard as «class PNGf»\nset theFile to open for access POSIX file \"{tmp_str}\" with write permission\nwrite theImage to theFile\ncoaccess theFile"
     );
     if std::process::Command::new("osascript")
         .arg("-e")

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2423,7 +2423,13 @@ static pthread_mutex_t g_display_mutex = PTHREAD_MUTEX_INITIALIZER;
 static struct linenoiseState *g_current_ls = NULL;
 static int g_ls_active = 0;
 static int g_prompt_detached = 0;  /* last output didn't end with \n */
-static int g_output_col = 0;       /* cursor column at end of last output (last line) */
+static int g_output_col = 0;       /* physical cursor column at end of last output */
+
+static int linenoiseNormalizeOutputCol(int col) {
+    int cols = (g_current_ls && g_current_ls->cols > 0) ? (int)g_current_ls->cols : 0;
+    if (cols <= 0 || col <= 0) return col;
+    return ((col - 1) % cols) + 1;
+}
 
 /* Calculate display width of a UTF-8 string (public, used by readline layers) */
 size_t linenoiseUtf8StrWidth(const char *s, size_t len) {
@@ -2491,6 +2497,7 @@ static void linenoiseWriteInternal(const char *s, size_t len) {
             } else {
                 g_output_col += (int)utf8StrWidth(s, len);
             }
+            g_output_col = linenoiseNormalizeOutputCol(g_output_col);
         }
 
         /* If output didn't end with \n, push prompt to next line
@@ -2556,7 +2563,7 @@ void readline_display_end(int output_col, int output_at_newline) {
             tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
         }
 
-        g_output_col = output_col;
+        g_output_col = linenoiseNormalizeOutputCol(output_col);
 
         if (!output_at_newline) {
             write(STDOUT_FILENO, "\r\n", 2);

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2399,6 +2399,8 @@ int linenoiseHistoryLoad(const char *filename) {
  * Readline state management & mutex for EditFeed synchronization
  * ============================================================ */
 
+#include <stdarg.h>
+
 #ifdef _WIN32
 /* Windows: use critical section for mutex-like behavior */
 static CRITICAL_SECTION g_display_mutex;
@@ -2431,6 +2433,44 @@ static int linenoiseNormalizeOutputCol(int col) {
     return ((col - 1) % cols) + 1;
 }
 
+/* Simulate terminal cursor position after writing a string.
+ * Start from 'start_col' on a terminal of 'cols' columns.
+ * Returns the final column (0 = cursor wrapped to start of next line).
+ *
+ * Correctly handles:
+ *  - ANSI CSI sequences (zero-width, skipped)
+ *  - \\n / \\r (column resets to 0)
+ *  - Wide chars that trigger wrap-before-write when they don't fit */
+static int simulateCursorCol(const char *s, size_t len, int start_col, int cols) {
+    int col = start_col;
+    size_t i = 0;
+    while (i < len) {
+        unsigned char c = (unsigned char)s[i];
+        /* Skip ANSI CSI sequences */
+        if (c == 0x1b && i + 1 < len) {
+            size_t skip = ansiEscapeLen(s + i, len - i);
+            if (skip > 0) { i += skip; continue; }
+        }
+        /* Newline / carriage return */
+        if (c == '\n' || c == '\r') { col = 0; i++; continue; }
+        /* Get UTF-8 character display width */
+        size_t clen;
+        uint32_t cp = utf8DecodeChar(s + i, &clen);
+        int cw = utf8CharWidth(cp);
+        if (cw < 0) cw = 0;
+        /* Simulate terminal wrapping */
+        if (cols > 0 && cw > 0) {
+            if (col + cw > cols) col = 0;   /* wide char doesn't fit → wrap */
+            col += cw;
+            if (col >= cols) col = 0;        /* at exact edge → delayed wrap */
+        } else {
+            col += cw;
+        }
+        i += clen;
+    }
+    return col;
+}
+
 /* Calculate display width of a UTF-8 string (public, used by readline layers) */
 size_t linenoiseUtf8StrWidth(const char *s, size_t len) {
     return utf8StrWidth(s, len);
@@ -2454,7 +2494,7 @@ static void linenoiseWriteInternal(const char *s, size_t len) {
          * a separate line below the output. After Hide clears that line,
          * cursor is on a blank line. Move back up to where output ended. */
         if (g_prompt_detached) {
-            write(STDOUT_FILENO, "\x1b[1A\r", 4);
+            write(STDOUT_FILENO, "\x1b[1A\r", 5);
             if (g_output_col > 0) {
                 char seq[16];
                 int n = snprintf(seq, sizeof(seq), "\x1b[%dC", g_output_col);
@@ -2483,8 +2523,9 @@ static void linenoiseWriteInternal(const char *s, size_t len) {
             tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
         }
 
-        /* Update output_col: reset on \n/\r, compute width of last line segment */
+        /* Update output_col: simulate terminal wrapping for accurate cursor tracking */
         {
+            int cols = (g_current_ls && g_current_ls->cols > 0) ? (int)g_current_ls->cols : 0;
             size_t lastNL = (size_t)-1;
             for (size_t i = len; i > 0; i--) {
                 if (s[i-1] == '\n' || s[i-1] == '\r') {
@@ -2493,11 +2534,12 @@ static void linenoiseWriteInternal(const char *s, size_t len) {
                 }
             }
             if (lastNL < len) {
-                g_output_col = (int)utf8StrWidth(s + lastNL + 1, len - lastNL - 1);
+                /* Text after last newline: start from column 0 */
+                g_output_col = simulateCursorCol(s + lastNL + 1, len - lastNL - 1, 0, cols);
             } else {
-                g_output_col += (int)utf8StrWidth(s, len);
+                /* No newline: continue from current column */
+                g_output_col = simulateCursorCol(s, len, g_output_col, cols);
             }
-            g_output_col = linenoiseNormalizeOutputCol(g_output_col);
         }
 
         /* If output didn't end with \n, push prompt to next line
@@ -2536,7 +2578,7 @@ void readline_display_begin(void) {
         linenoiseHide(g_current_ls);
 
         if (g_prompt_detached) {
-            write(STDOUT_FILENO, "\x1b[1A\r", 4);
+            write(STDOUT_FILENO, "\x1b[1A\r", 5);
             if (g_output_col > 0) {
                 char seq[16];
                 int n = snprintf(seq, sizeof(seq), "\x1b[%dC", g_output_col);
@@ -2578,6 +2620,21 @@ void readline_display_end(int output_col, int output_at_newline) {
     UNLOCK_MUTEX();
 }
 
+
+/* linenoisePrintf - printf-style convenience wrapper for linenoiseWrite.
+ * Formats into a stack buffer and calls linenoiseWrite atomically. */
+void linenoisePrintf(const char *fmt, ...) {
+    char buf[256 * 1024];  /* 256KB — tool_result 等内容可能超过 100K */
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    if (n > 0) {
+        size_t len = (size_t)n;
+        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+        linenoiseWrite(buf, len);
+    }
+}
 
 /* Register current linenoise state (called by readline thread) */
 void linenoiseRegisterState(struct linenoiseState *ls) {

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2394,3 +2394,223 @@ int linenoiseHistoryLoad(const char *filename) {
     fclose(fp);
     return 0;
 }
+
+/* ============================================================
+ * Unified Display API
+ *
+ * These functions provide a unified way for display workers to output
+ * content while managing linenoise prompt state internally.
+ *
+ * The state includes:
+ * - g_display_mutex: protects all display operations
+ * - g_current_ls: pointer to current linenoise state (set by readline thread)
+ * - g_ls_active: whether linenoise is in editing mode
+ * - g_prompt_detached: whether prompt was pushed to next line
+ * - g_output_col: last display output column (for cursor restore)
+ * - g_last_char: last character written (for newline detection)
+ * ============================================================ */
+
+#ifdef _WIN32
+/* Windows: use critical section for mutex-like behavior */
+static CRITICAL_SECTION g_display_mutex;
+static int g_display_mutex_init = 0;
+#define INIT_MUTEX() do { \
+    if (!g_display_mutex_init) { \
+        InitializeCriticalSection(&g_display_mutex); \
+        g_display_mutex_init = 1; \
+    } \
+} while(0)
+#define LOCK_MUTEX() EnterCriticalSection(&g_display_mutex)
+#define UNLOCK_MUTEX() LeaveCriticalSection(&g_display_mutex)
+#else
+/* POSIX: use pthread mutex */
+#include <pthread.h>
+static pthread_mutex_t g_display_mutex = PTHREAD_MUTEX_INITIALIZER;
+#define INIT_MUTEX() (void)0
+#define LOCK_MUTEX() pthread_mutex_lock(&g_display_mutex)
+#define UNLOCK_MUTEX() pthread_mutex_unlock(&g_display_mutex)
+#endif
+
+static struct linenoiseState *g_current_ls = NULL;
+static int g_ls_active = 0;
+static int g_prompt_detached = 0;
+static int g_output_col = 0;
+static char g_last_char = '\n';
+
+/* Update output column based on text content (UTF-8 aware) */
+static void update_output_col(const char *text, size_t len) {
+    if (!text || len == 0) return;
+
+    int esc = 0;
+    for (size_t i = 0; i < len; ) {
+        unsigned char c = (unsigned char)text[i];
+
+        /* Handle ANSI escape sequences */
+        if (esc) {
+            if (c >= 0x40 && c <= 0x7e) esc = 0;
+            i++;
+            continue;
+        }
+        if (c == 0x1b && i + 1 < len && text[i + 1] == '[') {
+            esc = 1;
+            i += 2;
+            continue;
+        }
+
+        /* Handle control characters */
+        if (c == '\r') {
+            g_output_col = 0;
+            i++;
+            continue;
+        }
+        if (c == '\n') {
+            g_output_col = 0;
+            i++;
+            continue;
+        }
+
+        /* UTF-8 character: count display width */
+        if (c < 0x80) {
+            g_output_col++;
+            i++;
+        } else if (c < 0xE0 && i + 1 < len) {
+            g_output_col += 2;  /* 2-byte UTF-8 */
+            i += 2;
+        } else if (c < 0xF0 && i + 2 < len) {
+            g_output_col += 2;  /* 3-byte UTF-8 */
+            i += 3;
+        } else if (c < 0xF8 && i + 3 < len) {
+            g_output_col += 2;  /* 4-byte UTF-8 */
+            i += 4;
+        } else {
+            i++;  /* Invalid UTF-8, skip */
+        }
+    }
+}
+
+/* Update last character (UTF-8 safe) */
+static void update_last_char(const char *text, size_t len) {
+    if (len > 0) {
+        /* Find the last UTF-8 character */
+        size_t i = len - 1;
+        while (i > 0 && ((unsigned char)text[i] & 0xC0) == 0x80) {
+            i--;
+        }
+        if (i < len) {
+            g_last_char = text[i];
+        }
+    }
+}
+
+/* Lock display, hide prompt, enable OPOST.
+ * Must be followed by DisplayWrite() calls and DisplayFlush().
+ */
+void linenoiseDisplayLock(void) {
+    INIT_MUTEX();
+    LOCK_MUTEX();
+
+    if (g_ls_active && g_current_ls) {
+        /* Hide prompt */
+        linenoiseHide(g_current_ls);
+
+        /* Restore cursor if prompt was detached */
+        if (g_prompt_detached) {
+            fputs("\x1b[1A\r", stdout);
+            if (g_output_col > 0) {
+                fprintf(stdout, "\x1b[%dC", g_output_col);
+            }
+            fflush(stdout);
+            g_prompt_detached = 0;
+        }
+
+        /* Enable OPOST so \n becomes \r\n automatically */
+        struct termios tios;
+        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
+            tios.c_oflag |= OPOST;
+            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
+        }
+    }
+}
+
+/* Write content to stdout.
+ * Should be called between DisplayLock() and DisplayFlush().
+ * Multiple calls are supported.
+ */
+void linenoiseDisplayWrite(const char *text, size_t len) {
+    if (text && len > 0) {
+        fwrite(text, 1, len, stdout);
+        update_output_col(text, len);
+        update_last_char(text, len);
+    }
+}
+
+/* Flush output, restore OPOST, optionally add newline, show prompt, unlock.
+ * endedAtNewline: whether the last output ended with '\n'
+ */
+void linenoiseDisplayFlush(int endedAtNewline) {
+    if (g_ls_active && g_current_ls) {
+        /* Flush all output */
+        fflush(stdout);
+
+        /* Disable OPOST to restore linenoise raw mode */
+        struct termios tios;
+        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
+            tios.c_oflag &= ~OPOST;
+            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
+        }
+
+        /* If output didn't end at newline, push prompt to next line */
+        if (!endedAtNewline) {
+            fputs("\r\n", stdout);
+            fflush(stdout);
+            g_prompt_detached = 1;
+        } else {
+            g_prompt_detached = 0;
+        }
+
+        /* Show prompt */
+        linenoiseShow(g_current_ls);
+    }
+
+    UNLOCK_MUTEX();
+}
+
+/* Convenience function: lock, write string, flush in one call.
+ * For simple one-line outputs.
+ */
+void linenoiseDisplayWriteStr(const char *text) {
+    if (!text) return;
+
+    linenoiseDisplayLock();
+    size_t len = strlen(text);
+    linenoiseDisplayWrite(text, len);
+    int endedAtNewline = (len > 0 && text[len - 1] == '\n');
+    linenoiseDisplayFlush(endedAtNewline);
+}
+
+/* Register current linenoise state (called by readline thread) */
+void linenoiseRegisterState(struct linenoiseState *ls) {
+    INIT_MUTEX();
+    LOCK_MUTEX();
+    g_current_ls = ls;
+    UNLOCK_MUTEX();
+}
+
+/* Set linenoise active flag (called by readline thread) */
+void linenoiseSetActive(int active) {
+    INIT_MUTEX();
+    LOCK_MUTEX();
+    g_ls_active = active;
+    UNLOCK_MUTEX();
+}
+
+/* Lock for EditFeed - prevents concurrent display operations */
+void linenoiseEditLock(void) {
+    INIT_MUTEX();
+    LOCK_MUTEX();
+}
+
+/* Unlock for EditFeed */
+void linenoiseEditUnlock(void) {
+    UNLOCK_MUTEX();
+}

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2396,18 +2396,7 @@ int linenoiseHistoryLoad(const char *filename) {
 }
 
 /* ============================================================
- * Unified Display API
- *
- * These functions provide a unified way for display workers to output
- * content while managing linenoise prompt state internally.
- *
- * The state includes:
- * - g_display_mutex: protects all display operations
- * - g_current_ls: pointer to current linenoise state (set by readline thread)
- * - g_ls_active: whether linenoise is in editing mode
- * - g_prompt_detached: whether prompt was pushed to next line
- * - g_output_col: last display output column (for cursor restore)
- * - g_last_char: last character written (for newline detection)
+ * Readline state management & mutex for EditFeed synchronization
  * ============================================================ */
 
 #ifdef _WIN32
@@ -2433,97 +2422,122 @@ static pthread_mutex_t g_display_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static struct linenoiseState *g_current_ls = NULL;
 static int g_ls_active = 0;
-static int g_prompt_detached = 0;
-static int g_output_col = 0;
-static char g_last_char = '\n';
+static int g_prompt_detached = 0;  /* last output didn't end with \n */
+static int g_output_col = 0;       /* cursor column at end of last output (last line) */
 
-/* Update output column based on text content (UTF-8 aware) */
-static void update_output_col(const char *text, size_t len) {
-    if (!text || len == 0) return;
-
-    int esc = 0;
-    for (size_t i = 0; i < len; ) {
-        unsigned char c = (unsigned char)text[i];
-
-        /* Handle ANSI escape sequences */
-        if (esc) {
-            if (c >= 0x40 && c <= 0x7e) esc = 0;
-            i++;
-            continue;
-        }
-        if (c == 0x1b && i + 1 < len && text[i + 1] == '[') {
-            esc = 1;
-            i += 2;
-            continue;
-        }
-
-        /* Handle control characters */
-        if (c == '\r') {
-            g_output_col = 0;
-            i++;
-            continue;
-        }
-        if (c == '\n') {
-            g_output_col = 0;
-            i++;
-            continue;
-        }
-
-        /* UTF-8 character: count display width */
-        if (c < 0x80) {
-            g_output_col++;
-            i++;
-        } else if (c < 0xE0 && i + 1 < len) {
-            g_output_col += 2;  /* 2-byte UTF-8 */
-            i += 2;
-        } else if (c < 0xF0 && i + 2 < len) {
-            g_output_col += 2;  /* 3-byte UTF-8 */
-            i += 3;
-        } else if (c < 0xF8 && i + 3 < len) {
-            g_output_col += 2;  /* 4-byte UTF-8 */
-            i += 4;
-        } else {
-            i++;  /* Invalid UTF-8, skip */
-        }
-    }
+/* Calculate display width of a UTF-8 string (public, used by readline layers) */
+size_t linenoiseUtf8StrWidth(const char *s, size_t len) {
+    return utf8StrWidth(s, len);
 }
 
-/* Update last character (UTF-8 safe) */
-static void update_last_char(const char *text, size_t len) {
-    if (len > 0) {
-        /* Find the last UTF-8 character */
-        size_t i = len - 1;
-        while (i > 0 && ((unsigned char)text[i] & 0xC0) == 0x80) {
-            i--;
-        }
-        if (i < len) {
-            g_last_char = text[i];
-        }
-    }
-}
-
-/* Lock display, hide prompt, enable OPOST.
- * Must be followed by DisplayWrite() calls and DisplayFlush().
- */
-void linenoiseDisplayLock(void) {
-    INIT_MUTEX();
-    LOCK_MUTEX();
+/* Internal: the core write logic. Caller must hold g_display_mutex.
+ *
+ * Hide prompt -> restore cursor if detached -> OPOST on -> write ->
+ * flush -> OPOST off -> update state -> Show prompt
+ *
+ * linenoiseHide() restores the cursor to the end of previous output.
+ * If previous output was detached (didn't end with \n), we also need
+ * to move the cursor back up to the correct row. */
+static void linenoiseWriteInternal(const char *s, size_t len) {
+    if (!s || len == 0) return;
 
     if (g_ls_active && g_current_ls) {
-        /* Hide prompt */
         linenoiseHide(g_current_ls);
 
-        /* Restore cursor if prompt was detached */
+        /* If previous output didn't end with \n, the prompt was pushed to
+         * a separate line below the output. After Hide clears that line,
+         * cursor is on a blank line. Move back up to where output ended. */
         if (g_prompt_detached) {
-            fputs("\x1b[1A\r", stdout);
+            write(STDOUT_FILENO, "\x1b[1A\r", 4);
             if (g_output_col > 0) {
-                fprintf(stdout, "\x1b[%dC", g_output_col);
+                char seq[16];
+                int n = snprintf(seq, sizeof(seq), "\x1b[%dC", g_output_col);
+                write(STDOUT_FILENO, seq, n);
             }
-            fflush(stdout);
             g_prompt_detached = 0;
         }
 
-        /* Enable OPOST so \n becomes \r\n automatically */
+        struct termios tios;
+        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
+            tios.c_oflag |= OPOST;
+            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
+        }
+    }
+
+    /* Write the string */
+    write(STDOUT_FILENO, s, len);
+
+    if (g_ls_active && g_current_ls) {
+        fflush(stdout);
+
+        /* Restore raw mode (OPOST off) for linenoise */
+        struct termios tios;
+        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
+            tios.c_oflag &= ~OPOST;
+            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
+        }
+
+        /* Update output_col: reset on \n/\r, compute width of last line segment */
+        {
+            size_t lastNL = (size_t)-1;
+            for (size_t i = len; i > 0; i--) {
+                if (s[i-1] == '\n' || s[i-1] == '\r') {
+                    lastNL = i - 1;
+                    break;
+                }
+            }
+            if (lastNL < len) {
+                g_output_col = (int)utf8StrWidth(s + lastNL + 1, len - lastNL - 1);
+            } else {
+                g_output_col += (int)utf8StrWidth(s, len);
+            }
+        }
+
+        /* If output didn't end with \n, push prompt to next line
+         * so it doesn't collide with the output. */
+        if (s[len-1] != '\n') {
+            write(STDOUT_FILENO, "\r\n", 2);
+            fflush(stdout);
+            g_prompt_detached = 1;
+        } else {
+            g_prompt_detached = 0;
+        }
+
+        linenoiseShow(g_current_ls);
+    }
+}
+
+/* linenoiseWrite - safe printf for linenoise raw mode.
+ * Prints a string to stdout. When linenoise is active, it handles
+ * Hide/OPOST/Show and cursor position tracking internally.
+ * Each call is atomic (holds the display mutex). */
+void linenoiseWrite(const char *s, size_t len) {
+    if (!s || len == 0) return;
+    INIT_MUTEX();
+    LOCK_MUTEX();
+    linenoiseWriteInternal(s, len);
+    UNLOCK_MUTEX();
+}
+
+/* readline_display_begin/end - compatibility wrappers.
+ * The C display layer can use these for batch display:
+ *   display_begin() -> multiple linenoiseWrite() -> display_end()
+ * The display_end must be called to release the mutex. */
+void readline_display_begin(void) {
+    LOCK_MUTEX();
+    if (g_ls_active && g_current_ls) {
+        linenoiseHide(g_current_ls);
+
+        if (g_prompt_detached) {
+            write(STDOUT_FILENO, "\x1b[1A\r", 4);
+            if (g_output_col > 0) {
+                char seq[16];
+                int n = snprintf(seq, sizeof(seq), "\x1b[%dC", g_output_col);
+                write(STDOUT_FILENO, seq, n);
+            }
+            g_prompt_detached = 0;
+        }
+
         struct termios tios;
         if (tcgetattr(STDIN_FILENO, &tios) == 0) {
             tios.c_oflag |= OPOST;
@@ -2532,61 +2546,31 @@ void linenoiseDisplayLock(void) {
     }
 }
 
-/* Write content to stdout.
- * Should be called between DisplayLock() and DisplayFlush().
- * Multiple calls are supported.
- */
-void linenoiseDisplayWrite(const char *text, size_t len) {
-    if (text && len > 0) {
-        fwrite(text, 1, len, stdout);
-        update_output_col(text, len);
-        update_last_char(text, len);
-    }
-}
-
-/* Flush output, restore OPOST, optionally add newline, show prompt, unlock.
- * endedAtNewline: whether the last output ended with '\n'
- */
-void linenoiseDisplayFlush(int endedAtNewline) {
+void readline_display_end(int output_col, int output_at_newline) {
     if (g_ls_active && g_current_ls) {
-        /* Flush all output */
         fflush(stdout);
 
-        /* Disable OPOST to restore linenoise raw mode */
         struct termios tios;
         if (tcgetattr(STDIN_FILENO, &tios) == 0) {
             tios.c_oflag &= ~OPOST;
             tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
         }
 
-        /* If output didn't end at newline, push prompt to next line */
-        if (!endedAtNewline) {
-            fputs("\r\n", stdout);
+        g_output_col = output_col;
+
+        if (!output_at_newline) {
+            write(STDOUT_FILENO, "\r\n", 2);
             fflush(stdout);
             g_prompt_detached = 1;
         } else {
             g_prompt_detached = 0;
         }
 
-        /* Show prompt */
         linenoiseShow(g_current_ls);
     }
-
     UNLOCK_MUTEX();
 }
 
-/* Convenience function: lock, write string, flush in one call.
- * For simple one-line outputs.
- */
-void linenoiseDisplayWriteStr(const char *text) {
-    if (!text) return;
-
-    linenoiseDisplayLock();
-    size_t len = strlen(text);
-    linenoiseDisplayWrite(text, len);
-    int endedAtNewline = (len > 0 && text[len - 1] == '\n');
-    linenoiseDisplayFlush(endedAtNewline);
-}
 
 /* Register current linenoise state (called by readline thread) */
 void linenoiseRegisterState(struct linenoiseState *ls) {

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2427,12 +2427,6 @@ static int g_ls_active = 0;
 static int g_prompt_detached = 0;  /* last output didn't end with \n */
 static int g_output_col = 0;       /* physical cursor column at end of last output */
 
-static int linenoiseNormalizeOutputCol(int col) {
-    int cols = (g_current_ls && g_current_ls->cols > 0) ? (int)g_current_ls->cols : 0;
-    if (cols <= 0 || col <= 0) return col;
-    return ((col - 1) % cols) + 1;
-}
-
 /* Simulate terminal cursor position after writing a string.
  * Start from 'start_col' on a terminal of 'cols' columns.
  * Returns the final column (0 = cursor wrapped to start of next line).
@@ -2469,11 +2463,6 @@ static int simulateCursorCol(const char *s, size_t len, int start_col, int cols)
         i += clen;
     }
     return col;
-}
-
-/* Calculate display width of a UTF-8 string (public, used by readline layers) */
-size_t linenoiseUtf8StrWidth(const char *s, size_t len) {
-    return utf8StrWidth(s, len);
 }
 
 /* Internal: the core write logic. Caller must hold g_display_mutex.
@@ -2568,58 +2557,6 @@ void linenoiseWrite(const char *s, size_t len) {
     UNLOCK_MUTEX();
 }
 
-/* readline_display_begin/end - compatibility wrappers.
- * The C display layer can use these for batch display:
- *   display_begin() -> multiple linenoiseWrite() -> display_end()
- * The display_end must be called to release the mutex. */
-void readline_display_begin(void) {
-    LOCK_MUTEX();
-    if (g_ls_active && g_current_ls) {
-        linenoiseHide(g_current_ls);
-
-        if (g_prompt_detached) {
-            write(STDOUT_FILENO, "\x1b[1A\r", 5);
-            if (g_output_col > 0) {
-                char seq[16];
-                int n = snprintf(seq, sizeof(seq), "\x1b[%dC", g_output_col);
-                write(STDOUT_FILENO, seq, n);
-            }
-            g_prompt_detached = 0;
-        }
-
-        struct termios tios;
-        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
-            tios.c_oflag |= OPOST;
-            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
-        }
-    }
-}
-
-void readline_display_end(int output_col, int output_at_newline) {
-    if (g_ls_active && g_current_ls) {
-        fflush(stdout);
-
-        struct termios tios;
-        if (tcgetattr(STDIN_FILENO, &tios) == 0) {
-            tios.c_oflag &= ~OPOST;
-            tcsetattr(STDIN_FILENO, TCSADRAIN, &tios);
-        }
-
-        g_output_col = linenoiseNormalizeOutputCol(output_col);
-
-        if (!output_at_newline) {
-            write(STDOUT_FILENO, "\r\n", 2);
-            fflush(stdout);
-            g_prompt_detached = 1;
-        } else {
-            g_prompt_detached = 0;
-        }
-
-        linenoiseShow(g_current_ls);
-    }
-    UNLOCK_MUTEX();
-}
-
 
 /* linenoisePrintf - printf-style convenience wrapper for linenoiseWrite.
  * Formats into a stack buffer and calls linenoiseWrite atomically. */
@@ -2652,13 +2589,3 @@ void linenoiseSetActive(int active) {
     UNLOCK_MUTEX();
 }
 
-/* Lock for EditFeed - prevents concurrent display operations */
-void linenoiseEditLock(void) {
-    INIT_MUTEX();
-    LOCK_MUTEX();
-}
-
-/* Unlock for EditFeed */
-void linenoiseEditUnlock(void) {
-    UNLOCK_MUTEX();
-}

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -127,6 +127,8 @@ size_t linenoiseUtf8StrWidth(const char *s, size_t len);
  * Hide/OPOST-enable/write/flush/OPOST-disable/Show management.
  * Callers only need this one function — no separate outputCol tracking needed. */
 void linenoiseWrite(const char *s, size_t len);
+void readline_display_begin(void);
+void readline_display_end(int output_col, int output_at_newline);
 
 #ifdef __cplusplus
 }

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -126,17 +126,9 @@ void linenoiseMaskModeDisable(void);
 void linenoiseWrite(const char *s, size_t len);
 void linenoisePrintf(const char *fmt, ...);
 
-/* Batch display API (for Rust compatibility). */
-void readline_display_begin(void);
-void readline_display_end(int output_col, int output_at_newline);
-
 /* State management for readline thread. */
 void linenoiseRegisterState(struct linenoiseState *ls);
 void linenoiseSetActive(int active);
-
-/* Lock/Unlock for EditFeed synchronization. */
-void linenoiseEditLock(void);
-void linenoiseEditUnlock(void);
 
 #ifdef __cplusplus
 }

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -120,29 +120,26 @@ void linenoisePrintKeyCodes(void);
 void linenoiseMaskModeEnable(void);
 void linenoiseMaskModeDisable(void);
 
-/* UTF-8 display width calculation (used by readline layers for output column tracking). */
-size_t linenoiseUtf8StrWidth(const char *s, size_t len);
-
-/* Unified display output: writes a string to stdout with automatic
- * Hide/OPOST-enable/write/flush/OPOST-disable/Show management.
- * Callers only need this one function — no separate outputCol tracking needed. */
+/* Display output: atomic write that coordinates with linenoise prompt.
+ * Handles Hide → restore cursor → OPOST on → write → OPOST off → Show.
+ * Cursor position is tracked internally; callers don't need to manage it. */
 void linenoiseWrite(const char *s, size_t len);
+void linenoisePrintf(const char *fmt, ...);
+
+/* Batch display API (for Rust compatibility). */
 void readline_display_begin(void);
 void readline_display_end(int output_col, int output_at_newline);
+
+/* State management for readline thread. */
+void linenoiseRegisterState(struct linenoiseState *ls);
+void linenoiseSetActive(int active);
+
+/* Lock/Unlock for EditFeed synchronization. */
+void linenoiseEditLock(void);
+void linenoiseEditUnlock(void);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __LINENOISE_H */
-
-/* State management for readline thread.
- * The readline thread calls these to register/unregister its linenoiseState.
- */
-void linenoiseRegisterState(struct linenoiseState *ls);
-void linenoiseSetActive(int active);
-
-/* Lock/Unlock for EditFeed synchronization with display operations.
- * These should be called around linenoiseEditFeed to prevent concurrent display. */
-void linenoiseEditLock(void);
-void linenoiseEditUnlock(void);

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -120,8 +120,35 @@ void linenoisePrintKeyCodes(void);
 void linenoiseMaskModeEnable(void);
 void linenoiseMaskModeDisable(void);
 
+/* Unified display API for interop with output workers.
+ * These functions handle Hide/Show/OPOST/promptDetached internally.
+ *
+ * Usage pattern:
+ *   linenoiseDisplayLock();        // Acquire lock, hide prompt, enable OPOST
+ *   linenoiseDisplayWrite(...);   // Multiple calls to write content
+ *   linenoiseDisplayFlush(ended);  // Disable OPOST, optional \r\n, show prompt, release lock
+ *
+ * Or use the combined API:
+ *   linenoiseDisplayWriteStr(text); // Lock, write, unlock in one call
+ */
+void linenoiseDisplayLock(void);
+void linenoiseDisplayWrite(const char *text, size_t len);
+void linenoiseDisplayFlush(int endedAtNewline);
+void linenoiseDisplayWriteStr(const char *text);  /* Convenience: lock+write+flush */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __LINENOISE_H */
+
+/* State management for readline thread.
+ * The readline thread calls these to register/unregister its linenoiseState.
+ */
+void linenoiseRegisterState(struct linenoiseState *ls);
+void linenoiseSetActive(int active);
+
+/* Lock/Unlock for EditFeed synchronization with display operations.
+ * These should be called around linenoiseEditFeed to prevent concurrent display. */
+void linenoiseEditLock(void);
+void linenoiseEditUnlock(void);

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -120,21 +120,13 @@ void linenoisePrintKeyCodes(void);
 void linenoiseMaskModeEnable(void);
 void linenoiseMaskModeDisable(void);
 
-/* Unified display API for interop with output workers.
- * These functions handle Hide/Show/OPOST/promptDetached internally.
- *
- * Usage pattern:
- *   linenoiseDisplayLock();        // Acquire lock, hide prompt, enable OPOST
- *   linenoiseDisplayWrite(...);   // Multiple calls to write content
- *   linenoiseDisplayFlush(ended);  // Disable OPOST, optional \r\n, show prompt, release lock
- *
- * Or use the combined API:
- *   linenoiseDisplayWriteStr(text); // Lock, write, unlock in one call
- */
-void linenoiseDisplayLock(void);
-void linenoiseDisplayWrite(const char *text, size_t len);
-void linenoiseDisplayFlush(int endedAtNewline);
-void linenoiseDisplayWriteStr(const char *text);  /* Convenience: lock+write+flush */
+/* UTF-8 display width calculation (used by readline layers for output column tracking). */
+size_t linenoiseUtf8StrWidth(const char *s, size_t len);
+
+/* Unified display output: writes a string to stdout with automatic
+ * Hide/OPOST-enable/write/flush/OPOST-disable/Show management.
+ * Callers only need this one function — no separate outputCol tracking needed. */
+void linenoiseWrite(const char *s, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
  概要

  - 统一显示架构：C/Go/Rust 三个版本共用 vendor/linenoise/linenoise.c 中的
  linenoiseWrite/linenoisePrintf，单次调用原子完成 Hide→恢复光标→OPOST 开→写入→OPOST
  关→光标跟踪→Show，上层无需跟踪光标位置或调用 begin/end 配对。
  - Ctrl+C 中断：readline 线程检测到 Ctrl+C（linenoise 返回 EAGAIN），通过 running 标志判断是否正在执行
  agent，若是则设置 interrupted 中断正在进行的 SSE/HTTP 请求；空闲状态仅重新显示提示符。
  - CJK 光标跟踪：simulateCursorCol
  逐字符模拟终端折行，正确处理宽字符放不下时的换行和恰好填满行的延迟折行，替代原来有 bug 的
  linenoiseNormalizeOutputCol。

  主要变更

  vendor/linenoise/ — 核心同步层
  - 新增 linenoiseWrite、linenoisePrintf、linenoiseRegisterState、linenoiseSetActive
  - 新增 simulateCursorCol 精确跟踪光标列位置
  - 移除未使用的函数：readline_display_begin/end、linenoiseEditLock/Unlock、linenoiseNormalizeOutputCol、linenoi
  seUtf8StrWidth

  C — 简化显示 + Ctrl+C
  - display.c：所有输出通过 linenoisePrintf/linenoiseWrite，移除 begin/end 和列跟踪
  - readline.c：Ctrl+C 在 agent 运行时设置 interrupted 标志

  Go — 简化显示 + Ctrl+C
  - display.go：所有输出通过 linenoise.LinenoiseWrite，移除批量模式和列跟踪
  - linenoise.go：C 分配状态（避免 cgo 指针 panic），Interrupt() 方法
  - agent.go：running 标志协调 Ctrl+C

  Rust — 统一显示 + Ctrl+C + bug 修复
  - agent.rs：显示通过 ffi::linenoise_write，readline 线程 Ctrl+C 时设置 interrupted
  - ffi/mod.rs：修复 LinenoiseState 零大小类型（[u8; 0] → [u64; 64]）导致段错误；修复 AppleScript
  拼写错误（coaccess → close access）导致 Ctrl+V 粘贴失效
  - 同步图片描述提示词与 bash/go 版本一致

  测试计划

  - 交互模式：输入消息，验证流式输出显示正常
  - agent 响应中按 Ctrl+C：中断并返回提示符
  - 空闲提示符按 Ctrl+C：仅重新显示提示符，无报错
  - CJK 文本折行：行尾无丢字
  - Thinking 颜色：流式 thinking 文本显示灰色，后续正常文本颜色正确
  - Ctrl+V 图片粘贴：剪贴板图片保存，插入 [Image #N]
  - 输入 exit / Ctrl+D：正常退出，无段错误
  - stream-json 模式（--output stream-json）：事件输出正确