### PR TITLE
OSC 终端标题增加 ⏳ 沙漏前缀，直观显示 agent 处理状态

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -75,3 +75,12 @@ Bash / Go / Rust / C 四个版本的 **system prompt** 和 **tools.json** 必须
 - [ ] `go/`、`rust/src/`、`c/`、`src/` 四处的 `tools.json` SHA256 是否一致？(`sha256sum src/tools.json rust/src/tools.json go/tools.json c/tools.json`)
 
 > **经验**: 同一 session 在三个版本间切换是正常的开发/调试流程。system prompt 不同直接导致缓存失效，每次切换都相当于冷启动。保持一致性就是省钱。
+
+### 架构逻辑一致性
+
+C / Go / Rust 是 Bash 版的 **Port 版本**，整体架构必须完全复刻 Bash 版。Bash 版是主线，所有架构决策以 Bash 版为准。三个 Port 版本在 Bash 版因语言限制做不到的地方可以超越（如多线程、原子操作等），但 **Port 版本之间的差异也必须保持一致**——不允许某个 Port 版本有独有行为而其他版本没有。
+
+**规则**:
+1. 以 Bash 版为主线，任何运行时行为改动先改 Bash 版，再同步到 C / Go / Rust
+2. C / Go / Rust 三个版本之间必须完全一致，不得出现某个版本独有的行为或缺失
+3. 如果 Bash 版因语言限制无法实现某个功能，三个 Port 版本仍须保持一致

--- a/c/agent.c
+++ b/c/agent.c
@@ -744,6 +744,8 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
     /* 递增 turn 计数 — 对齐 bash 版 store_stats_update current_turn_count=+1 */
     store_stats_set_int_file(agent->paths.stats, "current_turn_count",
         store_stats_get_file_int(agent->paths.stats, "current_turn_count") + 1);
+    /* 对齐 bash 版: store_stats_update 末尾调 display_term_title */
+    agent_update_title(agent);
 
     /* 记录事件：新 session 时记录 session_start */
     {
@@ -1518,7 +1520,7 @@ int agent_main_loop(Agent *agent) {
                   agent->running = 0;
 
                 /* 对齐 bash 版: 每轮 agent_loop 完成后刷新终端标题 */
-                agent_update_title(agent);
+                agent_update_title_status(agent, "idle");
 
                 /* 如果有活跃的 sub-agent，继续处理它们的结果，
                  * 直到所有 sub-agent 完成才 signal done。
@@ -2836,6 +2838,10 @@ static void format_ll_commas(long long n, char *out, size_t out_size) {
 }
 
 void agent_update_title(Agent *agent) {
+    agent_update_title_status(agent, NULL);
+}
+
+void agent_update_title_status(Agent *agent, const char *status) {
     if (!agent->interactive) return;
     char *stats_content = store_stats_read(agent->paths.stats);
     if (!stats_content) return;
@@ -2860,8 +2866,9 @@ void agent_update_title(Agent *agent) {
     format_int_commas(ao, ao_s, sizeof(ao_s));
     format_int_commas(ct, ct_s, sizeof(ct_s));
 
-    fprintf(stderr, "\x1b]0;%s T:%s R:%s I:%s(%d%%) O:%s C:%s\x07",
-            agent->model, tc_s, ar_s, total_i_s, pct, ao_s, ct_s);
+    const char *prefix = (status && strcmp(status, "idle") == 0) ? "" : "\xe2\x8f\xb3 ";
+    fprintf(stderr, "\x1b]0;%s%s T:%s R:%s I:%s(%d%%) O:%s C:%s\x07",
+            prefix, agent->model, tc_s, ar_s, total_i_s, pct, ao_s, ct_s);
     fflush(stderr);
 
     free(stats_content);

--- a/c/agent.h
+++ b/c/agent.h
@@ -109,6 +109,7 @@ int agent_replay_events(Agent *agent, int max_turns);
 
 /* 更新终端标题 */
 void agent_update_title(Agent *agent);
+void agent_update_title_status(Agent *agent, const char *status);
 
 /* ============================================================
  * 图片占位符支持

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -298,8 +298,9 @@ int main(int argc, char *argv[]) {
           /* 等待 display 线程消费完所有 replay 消息，
            * 防止 readline 线程启动后进入 raw mode 与 display 线程争抢终端 */
           if (!agent->output_format) display_flush(&display_queue);
-        /* 对齐 bash/Rust 版: replay 后更新终端标题 */
-        agent_update_title(agent);
+        /* 对齐 bash/Rust 版: replay 后更新终端标题 (idle) */
+        agent_update_title_status(agent, "idle");
+
 
         /* readline 线程 */
         pthread_t readline_thread;

--- a/go/agent.go
+++ b/go/agent.go
@@ -757,6 +757,8 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 
 	// 用户输入时递增 turn（与 bash 版一致：store_stats_update current_turn_count=+1）
 	_ = a.store.IncrementTurn()
+	// 对齐 bash版: store_stats_update 末尾调 display_term_title
+	a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, ""))
 
 	// 中断处理：用 context.WithCancel 包装，Ctrl+C 同时取消 context（取消 HTTP 请求）
 	var interrupted atomic.Bool
@@ -922,7 +924,7 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		_ = ctxTokens
 
 		// 更新终端标题（与 bash 版 store_stats_update 后调 display_term_title 一致）
-		a.display.SetTitle(a.store.FormatTitle(a.cfg.Model))
+		a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, ""))
 
 		if interrupted.Load() {
 			a.EmitDisplay(Event{Type: EventStop, Fields: []string{"STOP", "interrupted"}})

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -215,7 +215,7 @@ Examples:
 	}
 
 	// 设置标题
-	display.SetTitle(store.FormatTitle(cfg.Model))
+	display.SetTitle(store.FormatTitle(cfg.Model, "idle"))
 
 	// 运行
 	ctx := context.Background()
@@ -255,7 +255,7 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 	replayEvents(a, store, display, 10)
 
 	// 更新终端标题
-	display.SetTitle(store.FormatTitle(model))
+	display.SetTitle(store.FormatTitle(model, "idle"))
 
 	// 如果有初始输入，先执行
 	if initialInput != "" {
@@ -263,6 +263,7 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 		a.FlushDisplay()
+		display.SetTitle(store.FormatTitle(model, "idle"))
 	}
 
 	// 启动 readline goroutine
@@ -277,6 +278,7 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 		a.FlushDisplay()
+		display.SetTitle(store.FormatTitle(model, "idle"))
 		// 不再调用 rl.Done() — readline goroutine 立即开始下一轮 EditStart
 	}
 

--- a/go/store.go
+++ b/go/store.go
@@ -731,14 +731,19 @@ func (s *FileStore) ConvTurnKeep(ratio float64) (int, error) {
 
 // ─── FormatTitle: 终端标题 ───
 
-func (s *FileStore) FormatTitle(model string) string {
+func (s *FileStore) FormatTitle(model, status string) string {
 	st := s.stats
 	cacheTotal := st.InputTokens + st.CacheRead
 	cachePct := "—"
 	if cacheTotal > 0 && st.CacheRead > 0 {
 		cachePct = fmt.Sprintf("%.0f%%", float64(st.CacheRead)/float64(cacheTotal)*100)
 	}
-	return fmt.Sprintf("%s T:%s R:%d I:%s(%s) O:%s C:%s",
+	prefix := "⏳ "
+	if status == "idle" {
+		prefix = ""
+	}
+	return fmt.Sprintf("%s%s T:%s R:%d I:%s(%s) O:%s C:%s",
+		prefix,
 		model,
 		fmtInt(st.TurnCount),
 		st.TotalRequests,

--- a/go/types.go
+++ b/go/types.go
@@ -190,7 +190,7 @@ type SessionStore interface {
 	// Stats
 	UpdateStats(usage Usage, model string) error
 	GetStats() Stats
-	FormatTitle(model string) string
+	FormatTitle(model, status string) string
 	SetContextTokens(n int)
 	IncrementTurn() error
 	SetTurnCount(n int) error

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -859,7 +859,7 @@ impl Agent {
         self.info("bash-agent interactive mode (type 'exit' or Ctrl+D to quit)");
         self.replay_last_turns();
         // Show terminal title AFTER replay so it isn't overwritten by replayed output
-        self.update_term_title();
+        self.update_term_title_with_status("idle");
         let history_path = self.home.join(".bash-agent/history");
         if let Some(parent) = history_path.parent() {
             fs::create_dir_all(parent)?;
@@ -1039,6 +1039,7 @@ impl Agent {
                     }
                     self.running.store(false, Ordering::SeqCst);
                     self.flush_display();
+                    self.update_term_title_with_status("idle");
 
                     // Go 版架构：agent_loop 结束后，如果有活跃子 agent，
                     // main_loop 在内部循环等待所有 AgentResult 并处理，
@@ -1911,6 +1912,10 @@ impl Agent {
 
     /// update_term_title updates the terminal title with current stats (matches bash stats_show_osc).
     fn update_term_title(&self) {
+        self.update_term_title_with_status("");
+    }
+
+    fn update_term_title_with_status(&self, status: &str) {
         let stats = store::store_stats_read(&self.paths.stats).unwrap_or_default();
         let tc = stats_get_f64(&stats, "current_turn_count") as usize;
         let ar = stats_get_f64(&stats, "agent_request_count") as usize;
@@ -1926,9 +1931,11 @@ impl Agent {
                 "—".to_string()
             }
         };
+        let prefix = if status == "idle" { "" } else { "⏳ " };
         let _ = write!(
             self.stderr.borrow_mut(),
-            "\x1b]0;{} T:{} R:{} I:{}({}) O:{} C:{}\x07",
+            "\x1b]0;{}{} T:{} R:{} I:{}({}) O:{} C:{}\x07",
+            prefix,
             self.cfg.model,
             Self::fmt_num(tc),
             Self::fmt_num(ar),

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -557,7 +557,7 @@ store_conv_turn_keep() {
 }
 
 # — store_stats: stats 格式化 API —
-store_stats_format_title() { util_awk_run -v model="$1" -f "$AWK_DIR/term_title.awk" "$STATS_FILE"; }
+store_stats_format_title() { util_awk_run -v model="$1" ${2:+-v status="$2"} -f "$AWK_DIR/term_title.awk" "$STATS_FILE"; }
 
 # — store_conv: sub-agent 结果发送 —
 store_sub_send_result() {
@@ -1168,7 +1168,7 @@ display_message() {
     esac
 }
 
-display_term_title() { store_stats_format_title "$MODEL"; }
+display_term_title() { store_stats_format_title "$MODEL" "${1:-}"; }
 
 # 子进程渲染：从管道读取 RESP 消息，渲染到 stdout（终端）
 display_stream() { while util_read_msg; do display_message; done; }
@@ -1317,6 +1317,7 @@ agent_main_loop() {
                 ;;
             USER_INPUT)
                 agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
+                display_term_title "idle"
                 ;;
             AGENT_RESULT)
                 if [[ "$INTERRUPT_REQUESTED" == true ]]; then
@@ -1634,7 +1635,7 @@ interactive_mode() {
         printf '\n'
         DISPLAY_LAST_CHAR=$'\n'
     fi
-    display_term_title
+    display_term_title "idle"
     {
         exec 5> "$INPUT_FIFO"
         set -o emacs 2>/dev/null || true

--- a/src/awk/term_title.awk
+++ b/src/awk/term_title.awk
@@ -28,6 +28,7 @@ NR == 1 {
     cr = jnum($0, "total_cache_read_tokens")
 }
 END {
-    printf "\033]0;%s T:%s R:%s I:%s(%s) O:%s C:%s\007", \
-        model, fmt(t), fmt(r), fmt(i+cr), pct(cr, cr+i), fmt(o), fmt(c) > "/dev/stderr"
+    prefix = (status == "idle") ? "" : "⏳ "
+    printf "\033]0;%s%s T:%s R:%s I:%s(%s) O:%s C:%s\007", \
+        prefix, model, fmt(t), fmt(r), fmt(i+cr), pct(cr, cr+i), fmt(o), fmt(c) > "/dev/stderr"
 }


### PR DESCRIPTION
  ## 变更

  - **标题格式**: 处理中显示 `⏳ model T:... R:...`，空闲显示 `model T:... R:...`
  - **刷新逻辑**: title 刷新由 stats update 驱动（默认 busy），agent_loop 结束后显式设为 idle
  - **四个版本同步**: Bash/Go/Rust/C 统一实现
    - Bash: `term_title.awk` 增加 status 变量，非 idle 时显示 ⏳
    - Go: `FormatTitle(model, status)` 增加 status 参数
    - Rust: `update_term_title_with_status(status)` 新增带状态方法
    - C: `agent_update_title_status(agent, status)` 新增带状态函数
  - **AGENT.md**: 新增架构逻辑一致性规则，要求 C/Go/Rust 三个 Port 版本保持一致

  ## 涉及文件

  | 文件 | 变更 |
  |------|------|
  | `src/awk/term_title.awk` | 增加 status 变量，默认显示 ⏳ |
  | `src/agent.sh` | agent_run_loop 后设 idle，replay 后设 idle |
  | `go/store.go` | `FormatTitle` 增加 status 参数 |
  | `go/types.go` | `SessionStore` 接口同步更新 |
  | `go/agent.go` | `IncrementTurn` 后刷新 busy title |
  | `go/cmd/goagent/main.go` | RunLoop 结束后设 idle，replay 后设 idle |
  | `rust/src/agent.rs` | 新增 `update_term_title_with_status`，loop 后设 idle，replay 后设 idle |
  | `c/agent.c` | 新增 `agent_update_title_status`，turn_count 递增后刷新 busy title |
  | `c/agent.h` | 声明 `agent_update_title_status` |
  | `c/cagent.c` | replay 后设 idle |
  | `AGENT.md` | 新增架构一致性规则 |