### PR TITLE
fix: Edit 工具彩色 diff 输出及行数统计修复

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -1010,7 +1010,14 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                             while ((ch = fgetc(fp)) != EOF) {
                                 if (ch == '\n') nl++;
                             }
-                            flines = nl;
+                            /* nl = 换行符个数；最后一行无换行符结尾则补1 */
+                            if (fbytes > 0) {
+                                fseek(fp, -1, SEEK_END);
+                                int last = fgetc(fp);
+                                flines = nl + (last != '\n' ? 1 : 0);
+                            } else {
+                                flines = 0;
+                            }
                             fclose(fp);
                         }
                         sb_appendf(&summary, "%s(%s) [%ld lines, %ld bytes",

--- a/c/tools.c
+++ b/c/tools.c
@@ -221,7 +221,7 @@ static ToolResult tool_edit(const char *input_json) {
             sb_init(&diffcmd);
             const char *label = path;
             if (label[0] == '/') label++;
-            sb_appendf(&diffcmd, "diff -u --label 'a/%s' --label 'b/%s' -- '%s' '%s' 2>/dev/null || true",
+            sb_appendf(&diffcmd, "diff -u --color=always --label 'a/%s' --label 'b/%s' -- '%s' '%s' 2>/dev/null || true",
                        label, label, tmppath_old, tmppath_new);
             FILE *dp = popen(diffcmd.data, "r");
             if (dp) {
@@ -229,9 +229,11 @@ static ToolResult tool_edit(const char *input_json) {
                 sb_init(&diffout);
                 char lbuf[65536];
                 while (fgets(lbuf, sizeof(lbuf), dp)) {
-                    /* 计数 added/removed 行 */
-                    if (lbuf[0] == '+' && lbuf[1] != '+') added++;
-                    else if (lbuf[0] == '-' && lbuf[1] != '-') removed++;
+                    /* 计数 added/removed 行 — 跳过 ANSI escape (\x1b[...m) */
+                    const char *p = lbuf;
+                    if (*p == '\x1b') { p++; if (*p == '[') { while (*p && !((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z'))) p++; if (*p) p++; } }
+                    if (*p == '+' && *(p+1) != '+') added++;
+                    else if (*p == '-' && *(p+1) != '-') removed++;
                     sb_append(&diffout, lbuf);
                 }
                 pclose(dp);

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -1,7 +1,7 @@
 package linenoise
 
 /*
-#cgo CFLAGS: -Wall -O2
+#cgo CFLAGS: -Wall -O2 -Wno-unused-function
 #include "linenoise.h"
 #include <errno.h>
 #include <stdlib.h>

--- a/go/tools.go
+++ b/go/tools.go
@@ -265,21 +265,69 @@ func (td *ToolDispatcher) toolEdit(p, oldStr, newStr string) (string, error) {
 	}
 
 	newContent := strings.Replace(content, oldStr, newStr, 1)
+
+	// 生成 diff — 对齐 bash 版: diff -u --color=always
+	label := p
+	if strings.HasPrefix(label, "/") {
+		label = label[1:]
+	}
+	oldFile, _ := os.CreateTemp("", "edit_diff_old_*.tmp")
+	newFile, _ := os.CreateTemp("", "edit_diff_new_*.tmp")
+	var diffOutput string
+	if oldFile != nil && newFile != nil {
+		os.WriteFile(oldFile.Name(), []byte(content), 0644)
+		os.WriteFile(newFile.Name(), []byte(newContent), 0644)
+		cmd := exec.Command("diff", "-u", "--color=always",
+			"--label", "a/"+label, "--label", "b/"+label,
+			oldFile.Name(), newFile.Name())
+		out, _ := cmd.Output()
+		diffOutput = string(out)
+		if strings.Contains(diffOutput, "unsupported --color") || strings.Contains(diffOutput, "unrecognized option '--color'") {
+			cmd = exec.Command("diff", "-u",
+				"--label", "a/"+label, "--label", "b/"+label,
+				oldFile.Name(), newFile.Name())
+			out, _ = cmd.Output()
+			diffOutput = string(out)
+		}
+		os.Remove(oldFile.Name())
+		os.Remove(newFile.Name())
+		oldFile.Close()
+		newFile.Close()
+	}
+
 	if err := os.WriteFile(p, []byte(newContent), 0644); err != nil {
 		return "", err
 	}
 
-	// 统计添加/删除行数
-	added := strings.Count(newStr, "\n")
-	removed := strings.Count(oldStr, "\n")
-	if !strings.HasSuffix(oldStr, "\n") {
-		removed++
-	}
-	if !strings.HasSuffix(newStr, "\n") {
-		added++
+	// 统计 added/removed 行数 — 跳过 ANSI escape (\x1b[...m)
+	added := 0
+	removed := 0
+	for _, line := range strings.Split(diffOutput, "\n") {
+		p := line
+		for len(p) > 0 && p[0] == '\x1b' {
+			if len(p) > 1 && p[1] == '[' {
+				idx := strings.IndexAny(p[2:], "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+				if idx >= 0 {
+					p = p[idx+3:]
+				} else {
+					break
+				}
+			} else {
+				break
+			}
+		}
+		if strings.HasPrefix(p, "+") && !strings.HasPrefix(p, "++") {
+			added++
+		} else if strings.HasPrefix(p, "-") && !strings.HasPrefix(p, "--") {
+			removed++
+		}
 	}
 
-	return fmt.Sprintf("Edit(%s) [+%d -%d lines]", p, added, removed), nil
+	result := fmt.Sprintf("Edit(%s) [+%d -%d lines]", p, added, removed)
+	if diffOutput != "" {
+		result += "\n" + diffOutput
+	}
+	return result, nil
 }
 
 var (
@@ -719,11 +767,16 @@ func FileSummary(kind, path, offset, limit string) string {
 	if err != nil {
 		return fmt.Sprintf("%s(%s)", kind, path)
 	}
-	// 统计行数
+	// 统计行数 — 换行符个数，最后一行无换行补1
 	data, err := os.ReadFile(path)
 	lines := 0
 	if err == nil {
-		lines = strings.Count(string(data), "\n")
+		nl := strings.Count(string(data), "\n")
+		if len(data) > 0 && data[len(data)-1] != '\n' {
+			lines = nl + 1
+		} else {
+			lines = nl
+		}
 	}
 	rng := ""
 	if offset != "" || limit != "" {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1086,7 +1086,9 @@ pub mod conversation {
         if s.is_empty() {
             0
         } else {
-            s.iter().filter(|&&c| c == b'\n').count() + 1
+            let nl = s.iter().filter(|&&c| c == b'\n').count();
+            // 对齐 awk NR: 换行符个数，最后不以 \n 结尾则补1
+            if s.last() == Some(&b'\n') { nl } else { nl + 1 }
         }
     }
 

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2437,6 +2437,7 @@ static int g_output_col = 0;       /* physical cursor column at end of last outp
  *  - Wide chars that trigger wrap-before-write when they don't fit */
 static int simulateCursorCol(const char *s, size_t len, int start_col, int cols) {
     int col = start_col;
+    int at_margin = 0;  /* delayed wrap: cursor at right margin, not yet on next line */
     size_t i = 0;
     while (i < len) {
         unsigned char c = (unsigned char)s[i];
@@ -2445,8 +2446,10 @@ static int simulateCursorCol(const char *s, size_t len, int start_col, int cols)
             size_t skip = ansiEscapeLen(s + i, len - i);
             if (skip > 0) { i += skip; continue; }
         }
-        /* Newline / carriage return */
-        if (c == '\n' || c == '\r') { col = 0; i++; continue; }
+        /* Newline / carriage return: clears delayed wrap */
+        if (c == '\n' || c == '\r') { col = 0; at_margin = 0; i++; continue; }
+        /* Resolve pending delayed wrap */
+        if (at_margin) { col = 0; at_margin = 0; }
         /* Get UTF-8 character display width */
         size_t clen;
         uint32_t cp = utf8DecodeChar(s + i, &clen);
@@ -2456,13 +2459,14 @@ static int simulateCursorCol(const char *s, size_t len, int start_col, int cols)
         if (cols > 0 && cw > 0) {
             if (col + cw > cols) col = 0;   /* wide char doesn't fit → wrap */
             col += cw;
-            if (col >= cols) col = 0;        /* at exact edge → delayed wrap */
+            if (col == cols) at_margin = 1;  /* at exact edge → delayed wrap pending */
         } else {
             col += cw;
         }
         i += clen;
     }
-    return col;
+    /* If delayed wrap is pending, report col as 0 (cursor will wrap on next output) */
+    return at_margin ? 0 : col;
 }
 
 /* Internal: the core write logic. Caller must hold g_display_mutex.

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2563,17 +2563,26 @@ void linenoiseWrite(const char *s, size_t len) {
 
 
 /* linenoisePrintf - printf-style convenience wrapper for linenoiseWrite.
- * Formats into a stack buffer and calls linenoiseWrite atomically. */
+ * Formats into a stack buffer (small) or heap (large) and calls linenoiseWrite. */
 void linenoisePrintf(const char *fmt, ...) {
-    char buf[256 * 1024];  /* 256KB — tool_result 等内容可能超过 100K */
+    char sbuf[4096];  /* small stack buffer for most output */
     va_list ap;
     va_start(ap, fmt);
-    int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    int n = vsnprintf(sbuf, sizeof(sbuf), fmt, ap);
     va_end(ap);
-    if (n > 0) {
-        size_t len = (size_t)n;
-        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
-        linenoiseWrite(buf, len);
+    if (n <= 0) return;
+    size_t len = (size_t)n;
+    if (len < sizeof(sbuf)) {
+        linenoiseWrite(sbuf, len);
+    } else {
+        /* Large output: format to heap */
+        char *hbuf = malloc(len + 1);
+        if (!hbuf) { linenoiseWrite(sbuf, sizeof(sbuf) - 1); return; }
+        va_start(ap, fmt);
+        vsnprintf(hbuf, len + 1, fmt, ap);
+        va_end(ap);
+        linenoiseWrite(hbuf, len);
+        free(hbuf);
     }
 }
 


### PR DESCRIPTION
  ## 概述

  修复 Edit 工具的 diff 输出缺少颜色、行数统计错误，以及 linenoise 光标跟踪和内存问题。

  ## 变更

  - **Edit diff 彩色输出**: C 版添加 `--color=always`，Go 版新增 diff 输出（之前只有摘要），与 Bash/Rust 对齐
  - **diff 行数统计修复**: `--color=always` 导致 `+`/`-` 行前面有 ANSI escape，C/Go 版计数全部为 0。修复为跳过 ANSI escape 后再判断
  - **Read 工具行数统计**: C/Go 版对无换行结尾的文件（如 `"AlbC"`）显示 0 行。修复为对齐 awk NR 语义（`\n` 个数，最后不以 `\n` 结尾补 1）
  - **simulateCursorCol delayed wrap**: 字符刚好填满行末时直接 `col=0` 导致 Hide/Show 光标位置算错，输出覆盖前一行。引入 `at_margin` 标志正确跟踪终端 delayed wrap 状态
  - **linenoisePrintf 内存优化**: 固定 256KB 栈分配改为 4KB 栈 + 按需堆分配，避免每次 display 调用浪费栈空间

  ## 涉及文件

  | 文件 | 变更 |
  |------|------|
  | `c/tools.c` | diff 添加 `--color=always`，ANSI escape 跳过计数 |
  | `c/agent.c` | FileSummary 行数统计修复 |
  | `go/tools.go` | 新增 diff 输出，行数/计数修复 |
  | `rust/src/lib.rs` | `line_count` 修复为 awk NR 语义 |
  | `vendor/linenoise/linenoise.c` | simulateCursorCol delayed wrap，linenoisePrintf 内存优化 |