### PR TITLE
feat: 实现 --fork 命令行参数 + 修复 C 版 Read offset/limit 显示

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -1012,8 +1012,8 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                     JsonParse jp2 = json_parse_root(tc->input_json.data);
                     if (!jp2.error) {
                         fpath = json_get_string(jp2.val, "path");
-                        foffset = json_get_string(jp2.val, "offset");
-                        flimit = json_get_string(jp2.val, "limit");
+                        foffset = json_as_string(json_get(jp2.val, "offset"));
+                        flimit = json_as_string(json_get(jp2.val, "limit"));
                     }
 
                     StrBuf summary;

--- a/c/agent.c
+++ b/c/agent.c
@@ -292,8 +292,6 @@ Agent *agent_create(const char *provider, const char *model,
     a->paths = store_session_paths_for(home, cwd, sid);
     free(sid);
 
-    /* 判断是否新会话：与 bash 版一致，以 events.jsonl 是否为空为准。
-     * 只看 conversation.jsonl 是否存在会把已有空会话当作旧会话，也可能在跨版本切换时误判。 */
     int is_new = 1;
     struct stat st;
     if (stat(a->paths.events, &st) == 0 && st.st_size > 0) is_new = 0;

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -44,14 +44,10 @@ static void usage(const char *prog) {
     fprintf(stderr, "  --output human|stream-json Output format\n");
     fprintf(stderr, "  -h, --help                 Show this help\n");
     fprintf(stderr, "Environment:\n");
-    fprintf(stderr, "  ANTHROPIC_API_KEY       API key for Claude\n");
-    fprintf(stderr, "  OPENAI_API_KEY          API key for OpenAI\n");
-    fprintf(stderr, "  DEEPSEEK_API_KEY        API key for DeepSeek (auto-configures provider)\n");
-    fprintf(stderr, "  ANTHROPIC_BASE_URL      Claude API base URL\n");
-    fprintf(stderr, "  OPENAI_BASE_URL         OpenAI API base URL\n");
-    fprintf(stderr, "  BASH_AGENT_HOME         Override base directory for session storage\n");
-    fprintf(stderr, "  BASH_AGENT_BASH_MODE    Bash tool permissions as 4 octal rwx digits: system/external/network/workspace (default: 0467)\n");
-    fprintf(stderr, "  MODEL                   Default model name\n");
+    fprintf(stderr, "  *_API_KEY               API key (ANTHROPIC / OPENAI / DEEPSEEK auto-detected)\n");
+    fprintf(stderr, "  *_BASE_URL              Override API base URL (ANTHROPIC / OPENAI)\n");
+    fprintf(stderr, "  BASH_AGENT_HOME         Override session storage (default: $HOME)\n");
+    fprintf(stderr, "  BASH_AGENT_BASH_MODE    Bash tool permissions (default: 0467)\n");
 }
 
 static char *g_paste_session_dir = NULL;

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -38,6 +38,7 @@ static void usage(const char *prog) {
     fprintf(stderr, "  --base-url URL             API base URL\n");
     fprintf(stderr, "  --session ID               Session ID\n");
     fprintf(stderr, "  --continue                 Continue last session\n");
+    fprintf(stderr, "  --fork-session             When resuming, create a new forked session (use with --session or --continue)\n");
     fprintf(stderr, "  --interactive              Force interactive mode\n");
     fprintf(stderr, "  --verbose                  Verbose logging\n");
     fprintf(stderr, "  --output human|stream-json Output format\n");
@@ -74,6 +75,7 @@ int main(int argc, char *argv[]) {
     const char *thinking_str = NULL;
     const char *tool_timeout_str = NULL;
     int do_continue = 0;
+    int do_fork = 0;
     int force_interactive = 0;
     int verbose = 0;
     int do_print = 0;
@@ -102,6 +104,8 @@ int main(int argc, char *argv[]) {
             }
         } else if (strcmp(argv[i], "--continue") == 0) {
             do_continue = 1;
+        } else if (strcmp(argv[i], "--fork-session") == 0) {
+            do_fork = 1;
         } else if (strcmp(argv[i], "--interactive") == 0 || strcmp(argv[i], "-i") == 0) {
             force_interactive = 1;
         } else if (strcmp(argv[i], "--verbose") == 0 || strcmp(argv[i], "-v") == 0) {
@@ -234,8 +238,37 @@ int main(int argc, char *argv[]) {
     /* 初始化 curl */
     curl_global_init(CURL_GLOBAL_DEFAULT);
 
-    /* 自动生成 session_id（如果未指定或为空） */
-    if (!effective_session || !effective_session[0]) {
+    /* --fork-session: 从源 session 派生新 session（对齐 bash 版 store_session_fork_resolve）
+     * 必须在 auto-generate session_id 之前：此时 effective_session 指向源 session */
+    char *fork_source_id = NULL;
+    if (do_fork) {
+        fork_source_id = util_strdup(effective_session);
+        /* 如果没指定源 session，回退到最新（等价 --continue） */
+        if (!fork_source_id || !fork_source_id[0]) {
+            free(fork_source_id);
+            fork_source_id = store_session_resolve_continue(home, cwd);
+        }
+        if (!fork_source_id || !fork_source_id[0]) {
+            fprintf(stderr, "Error: --fork-session requires an existing session (use with --session <id> or --continue)\n");
+            return 1;
+        }
+        /* 验证 source conversation 存在且非空 */
+        SessionPaths src_paths = store_session_paths_for(home, cwd, fork_source_id);
+        char *src_conv = util_read_file(src_paths.conversation);
+        int has_conv = (src_conv && strlen(src_conv) > 0);
+        free(src_conv);
+        store_session_paths_free(&src_paths);
+        if (!has_conv) {
+            fprintf(stderr, "Error: --fork-session: source session '%s' has no conversation to fork\n", fork_source_id);
+            return 1;
+        }
+    }
+
+    /* 自动生成 session_id（如果未指定或为空；fork 模式生成全新 ID） */
+    if (do_fork) {
+        free(effective_session);
+        effective_session = session_new_id();
+    } else if (!effective_session || !effective_session[0]) {
         free(effective_session);
         effective_session = session_new_id();
     }
@@ -261,6 +294,24 @@ int main(int argc, char *argv[]) {
     }
     agent->verbose = verbose;
     agent->output_format = (strcmp(output_fmt, "stream-json") == 0) ? 1 : 0;
+
+    /* --fork-session: fork 复制 conversation/summary/plan + 写 session_fork 事件
+     * agent_create 内部的 store_session_init 已创建新 session（含 session_start 事件） */
+    if (do_fork && fork_source_id) {
+        SessionPaths src_paths = store_session_paths_for(home, cwd, fork_source_id);
+        store_session_fork(&src_paths, &agent->paths);
+        store_session_paths_free(&src_paths);
+        /* session_fork 事件溯源（与 bash 版一致：events.jsonl 保持全新） */
+        StrBuf evt;
+        sb_init(&evt);
+        sb_append(&evt, "{\"type\":\"session_fork\",\"session_id\":");
+        sb_append_json_string(&evt, effective_session);
+        sb_append(&evt, ",\"source_session_id\":");
+        sb_append_json_string(&evt, fork_source_id);
+        sb_append_char(&evt, '}');
+        store_event_append(&agent->paths, evt.data);
+        sb_free(&evt);
+    }
 
     /* 设置 CLI 参数到 agent — 支持 k/m/g 后缀 */
     {
@@ -431,6 +482,7 @@ int main(int argc, char *argv[]) {
     free(effective_model);
     free(effective_base_url);
     free(effective_session);
+    free(fork_source_id);
     curl_global_cleanup();
 
     return 0;

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -213,7 +213,7 @@ int main(int argc, char *argv[]) {
 
     /* 继续 session */
     char *effective_session = util_strdup(session_id);
-    if (do_continue && (!effective_session || !effective_session[0])) {
+    if ((do_continue || do_fork) && (!effective_session || !effective_session[0])) {
         char cwd_buf[4096];
         getcwd(cwd_buf, sizeof(cwd_buf));
         const char *env_h = util_env("BASH_AGENT_HOME", NULL);
@@ -238,15 +238,10 @@ int main(int argc, char *argv[]) {
     /* 初始化 curl */
     curl_global_init(CURL_GLOBAL_DEFAULT);
 
-    /* --fork：从源 session 派生新 session。记录源 ID（--session 或回退到最新），然后生成新 ID。
-     * 必须在 auto-generate session_id 之前：此时 effective_session 指向源 session */
+    /* --fork：effective_session 此时已是源 session（上方 session 解析已统一处理 resolve） */
     char *fork_source_id = NULL;
     if (do_fork) {
         fork_source_id = util_strdup(effective_session);
-        if (!fork_source_id || !fork_source_id[0]) {
-            free(fork_source_id);
-            fork_source_id = store_session_resolve_continue(home, cwd);
-        }
     }
 
     /* 自动生成 session_id（如果未指定或为空；fork 模式生成全新 ID） */

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -38,7 +38,7 @@ static void usage(const char *prog) {
     fprintf(stderr, "  --base-url URL             API base URL\n");
     fprintf(stderr, "  --session ID               Session ID\n");
     fprintf(stderr, "  --continue                 Continue last session\n");
-    fprintf(stderr, "  --fork-session             When resuming, create a new forked session (use with --session or --continue)\n");
+    fprintf(stderr, "  --fork                     When resuming, create a new forked session (use with --session or --continue)\n");
     fprintf(stderr, "  --interactive              Force interactive mode\n");
     fprintf(stderr, "  --verbose                  Verbose logging\n");
     fprintf(stderr, "  --output human|stream-json Output format\n");
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
             }
         } else if (strcmp(argv[i], "--continue") == 0) {
             do_continue = 1;
-        } else if (strcmp(argv[i], "--fork-session") == 0) {
+        } else if (strcmp(argv[i], "--fork") == 0) {
             do_fork = 1;
         } else if (strcmp(argv[i], "--interactive") == 0 || strcmp(argv[i], "-i") == 0) {
             force_interactive = 1;
@@ -238,29 +238,14 @@ int main(int argc, char *argv[]) {
     /* 初始化 curl */
     curl_global_init(CURL_GLOBAL_DEFAULT);
 
-    /* --fork-session: 从源 session 派生新 session（对齐 bash 版 store_session_fork_resolve）
+    /* --fork：从源 session 派生新 session。记录源 ID（--session 或回退到最新），然后生成新 ID。
      * 必须在 auto-generate session_id 之前：此时 effective_session 指向源 session */
     char *fork_source_id = NULL;
     if (do_fork) {
         fork_source_id = util_strdup(effective_session);
-        /* 如果没指定源 session，回退到最新（等价 --continue） */
         if (!fork_source_id || !fork_source_id[0]) {
             free(fork_source_id);
             fork_source_id = store_session_resolve_continue(home, cwd);
-        }
-        if (!fork_source_id || !fork_source_id[0]) {
-            fprintf(stderr, "Error: --fork-session requires an existing session (use with --session <id> or --continue)\n");
-            return 1;
-        }
-        /* 验证 source conversation 存在且非空 */
-        SessionPaths src_paths = store_session_paths_for(home, cwd, fork_source_id);
-        char *src_conv = util_read_file(src_paths.conversation);
-        int has_conv = (src_conv && strlen(src_conv) > 0);
-        free(src_conv);
-        store_session_paths_free(&src_paths);
-        if (!has_conv) {
-            fprintf(stderr, "Error: --fork-session: source session '%s' has no conversation to fork\n", fork_source_id);
-            return 1;
         }
     }
 
@@ -295,7 +280,7 @@ int main(int argc, char *argv[]) {
     agent->verbose = verbose;
     agent->output_format = (strcmp(output_fmt, "stream-json") == 0) ? 1 : 0;
 
-    /* --fork-session: fork 复制 conversation/summary/plan + 写 session_fork 事件
+    /* --fork：fork 复制 conversation/summary/plan + 写 session_fork 事件
      * agent_create 内部的 store_session_init 已创建新 session（含 session_start 事件） */
     if (do_fork && fork_source_id) {
         SessionPaths src_paths = store_session_paths_for(home, cwd, fork_source_id);

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -284,19 +284,6 @@ int main(int argc, char *argv[]) {
     agent->verbose = verbose;
     agent->output_format = (strcmp(output_fmt, "stream-json") == 0) ? 1 : 0;
 
-    /* --fork：session_fork 事件溯源（session_start 已由 agent_create 内部写入） */
-    if (do_fork && fork_source_id) {
-        StrBuf evt;
-        sb_init(&evt);
-        sb_append(&evt, "{\"type\":\"session_fork\",\"session_id\":");
-        sb_append_json_string(&evt, effective_session);
-        sb_append(&evt, ",\"source_session_id\":");
-        sb_append_json_string(&evt, fork_source_id);
-        sb_append_char(&evt, '}');
-        store_event_append(&agent->paths, evt.data);
-        sb_free(&evt);
-    }
-
     /* 设置 CLI 参数到 agent — 支持 k/m/g 后缀 */
     {
         long v;

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -261,6 +261,15 @@ int main(int argc, char *argv[]) {
 
     store_event_set_stream_json(strcmp(output_fmt, "stream-json") == 0);
 
+    /* --fork：先复制源 session 数据，agent_create 内部的 store_session_init 再补全 events/stats */
+    if (do_fork && fork_source_id) {
+        SessionPaths new_paths = store_session_paths_for(home, cwd, effective_session);
+        SessionPaths src_paths = store_session_paths_for(home, cwd, fork_source_id);
+        store_session_fork(&src_paths, &new_paths);
+        store_session_paths_free(&new_paths);
+        store_session_paths_free(&src_paths);
+    }
+
     /* 创建 Agent */
     Agent *agent = agent_create(provider, effective_model,
                                 effective_api_key, effective_base_url,
@@ -275,13 +284,8 @@ int main(int argc, char *argv[]) {
     agent->verbose = verbose;
     agent->output_format = (strcmp(output_fmt, "stream-json") == 0) ? 1 : 0;
 
-    /* --fork：fork 复制 conversation/summary/plan + 写 session_fork 事件
-     * agent_create 内部的 store_session_init 已创建新 session（含 session_start 事件） */
+    /* --fork：session_fork 事件溯源（session_start 已由 agent_create 内部写入） */
     if (do_fork && fork_source_id) {
-        SessionPaths src_paths = store_session_paths_for(home, cwd, fork_source_id);
-        store_session_fork(&src_paths, &agent->paths);
-        store_session_paths_free(&src_paths);
-        /* session_fork 事件溯源（与 bash 版一致：events.jsonl 保持全新） */
         StrBuf evt;
         sb_init(&evt);
         sb_append(&evt, "{\"type\":\"session_fork\",\"session_id\":");

--- a/c/store.c
+++ b/c/store.c
@@ -196,10 +196,10 @@ int store_session_fork(const SessionPaths *parent, const SessionPaths *child) {
 }
 
 int store_session_init_sub(const SessionPaths *parent_paths, const SessionPaths *sub_paths, int fork) {
-    if (store_session_init(sub_paths, 1) != 0) return -1;
     if (fork) {
         store_session_fork(parent_paths, sub_paths);
     }
+    if (store_session_init(sub_paths, 1) != 0) return -1;
     return 0;
 }
 

--- a/c/store.c
+++ b/c/store.c
@@ -181,26 +181,30 @@ int store_session_init(const SessionPaths *p, int is_new) {
     return 0;
 }
 
+int store_session_fork(const SessionPaths *parent, const SessionPaths *child) {
+    /* 复制 conversation/summary/plan（对齐 bash/go/rust 版 store_session_fork） */
+    char *parent_conv = util_read_file(parent->conversation);
+    if (parent_conv && strlen(parent_conv) > 0) {
+        util_write_file(child->conversation, parent_conv);
+    }
+    free(parent_conv);
+    char *parent_summary = util_read_file(parent->summary);
+    if (parent_summary && strlen(parent_summary) > 0) {
+        util_write_file(child->summary, parent_summary);
+    }
+    free(parent_summary);
+    char *parent_plan = util_read_file(parent->plan);
+    if (parent_plan && strlen(parent_plan) > 0) {
+        util_write_file(child->plan, parent_plan);
+    }
+    free(parent_plan);
+    return 0;
+}
+
 int store_session_init_sub(const SessionPaths *parent_paths, const SessionPaths *sub_paths, int fork) {
     if (store_session_init(sub_paths, 1) != 0) return -1;
     if (fork) {
-        /* 复制父会话文件到子会话 — 对齐 bash 版 store_session_fork:
-         * cp conversation.jsonl, summary.txt, plan.md */
-        char *parent_conv = util_read_file(parent_paths->conversation);
-        if (parent_conv && strlen(parent_conv) > 0) {
-            util_write_file(sub_paths->conversation, parent_conv);
-        }
-        free(parent_conv);
-        char *parent_summary = util_read_file(parent_paths->summary);
-        if (parent_summary && strlen(parent_summary) > 0) {
-            util_write_file(sub_paths->summary, parent_summary);
-        }
-        free(parent_summary);
-        char *parent_plan = util_read_file(parent_paths->plan);
-        if (parent_plan && strlen(parent_plan) > 0) {
-            util_write_file(sub_paths->plan, parent_plan);
-        }
-        free(parent_plan);
+        store_session_fork(parent_paths, sub_paths);
     }
     return 0;
 }

--- a/c/store.c
+++ b/c/store.c
@@ -182,23 +182,15 @@ int store_session_init(const SessionPaths *p, int is_new) {
 }
 
 int store_session_fork(const SessionPaths *parent, const SessionPaths *child) {
-    /* 确保目标目录存在（对齐 bash/go 版的 mkdir -p / MkdirAll） */
     util_mkdirs(child->session_dir, 0755);
-    /* 复制 conversation/summary/plan */
     char *parent_conv = util_read_file(parent->conversation);
-    if (parent_conv && strlen(parent_conv) > 0) {
-        util_write_file(child->conversation, parent_conv);
-    }
+    if (parent_conv && strlen(parent_conv) > 0) util_write_file(child->conversation, parent_conv);
     free(parent_conv);
     char *parent_summary = util_read_file(parent->summary);
-    if (parent_summary && strlen(parent_summary) > 0) {
-        util_write_file(child->summary, parent_summary);
-    }
+    if (parent_summary && strlen(parent_summary) > 0) util_write_file(child->summary, parent_summary);
     free(parent_summary);
     char *parent_plan = util_read_file(parent->plan);
-    if (parent_plan && strlen(parent_plan) > 0) {
-        util_write_file(child->plan, parent_plan);
-    }
+    if (parent_plan && strlen(parent_plan) > 0) util_write_file(child->plan, parent_plan);
     free(parent_plan);
     return 0;
 }

--- a/c/store.c
+++ b/c/store.c
@@ -182,7 +182,9 @@ int store_session_init(const SessionPaths *p, int is_new) {
 }
 
 int store_session_fork(const SessionPaths *parent, const SessionPaths *child) {
-    /* 复制 conversation/summary/plan（对齐 bash/go/rust 版 store_session_fork） */
+    /* 确保目标目录存在（对齐 bash/go 版的 mkdir -p / MkdirAll） */
+    util_mkdirs(child->session_dir, 0755);
+    /* 复制 conversation/summary/plan */
     char *parent_conv = util_read_file(parent->conversation);
     if (parent_conv && strlen(parent_conv) > 0) {
         util_write_file(child->conversation, parent_conv);

--- a/c/store.h
+++ b/c/store.h
@@ -40,6 +40,9 @@ int store_session_init(const SessionPaths *p, int is_new);
 /* 为子 agent 创建新会话（初始化目录） */
 int store_session_init_sub(const SessionPaths *parent_paths, const SessionPaths *sub_paths, int fork);
 
+/* 复制 conversation/summary/plan 到新 session（不 init child，对齐 bash/go/rust 版 store_session_fork） */
+int store_session_fork(const SessionPaths *parent, const SessionPaths *child);
+
 const char *store_session_image_dir(const SessionPaths *paths);
 
 /* 从 cwd 生成 project key（简化为路径替换 / 为 -） */

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -220,8 +220,6 @@ Examples:
 		sessionID = agent.UtilNewSessionID()
 		store.Fork(sourceDir, filepath.Join(store.GetDir(), sessionID))
 		store.Init(sessionID)
-		store.AppendEvent(fmt.Sprintf(`{"type":"session_fork","session_id":"%s","source_session_id":"%s"}`,
-			agent.UtilJSONEscape(sessionID), agent.UtilJSONEscape(filepath.Base(sourceDir))))
 	} else if err := store.Init(sessionID); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: init session: %v\n", err)
 		os.Exit(1)

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -68,24 +68,15 @@ Options:
 		flag.PrintDefaults()
 		fmt.Fprint(os.Stderr, `
 Environment:
-  ANTHROPIC_API_KEY       API key for Claude
-  OPENAI_API_KEY          API key for OpenAI
-  DEEPSEEK_API_KEY        API key for DeepSeek (auto-configures provider)
-  ANTHROPIC_BASE_URL      Claude API base URL
-  OPENAI_BASE_URL         OpenAI API base URL
-  BASH_AGENT_HOME         Override base directory for session storage
-  BASH_AGENT_BASH_MODE    Bash tool permissions as 4 octal rwx digits: system/external/network/workspace (default: 0467)
-  MODEL                   Default model name
-  EFFORT                  Default thinking effort (default: high)
-  THINKING                Default thinking mode (default: adaptive)
+  *_API_KEY               API key (ANTHROPIC / OPENAI / DEEPSEEK auto-detected)
+  *_BASE_URL              Override API base URL (ANTHROPIC / OPENAI)
+  BASH_AGENT_HOME         Override session storage (default: $HOME)
+  BASH_AGENT_BASH_MODE    Bash tool permissions (default: 0467)
 
 Examples:
   goagent "Read /etc/hostname and tell me what it says"
-  goagent -m claude-sonnet-4-20250514 "List files in /tmp"
-  goagent --session code-review "Analyze this code"
   goagent --continue "What did we discuss?"
-  goagent --fork --continue "Branch off the last session and try a different approach"
-  goagent --fork --session code-review "Fork the code-review session"
+  goagent --fork --continue "Branch off the last session"
   goagent -i
 `)
 	}

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -196,15 +196,15 @@ Examples:
 	// 加载工具定义（编译时嵌入的 tools.json）
 	a.SetToolDefs(agent.UtilLoadToolDefs())
 
-	// Session 管理
+	// Session 管理：--fork 和 --continue 无 --session 时统一回退到最新 session
 	sessionID := session
-	if sessionID == "" {
-		sessionID = agent.UtilNewSessionID()
-	}
-	if cont {
+	if sessionID == "" && (fork || cont) {
 		if id, err := store.ResolveContinue(); err == nil && id != "" {
 			sessionID = id
 		}
+	}
+	if sessionID == "" {
+		sessionID = agent.UtilNewSessionID()
 	}
 
 	// --list-sessions
@@ -214,18 +214,14 @@ Examples:
 	}
 
 	// 初始化 session
-	// --fork：从源 session 派生新 session。直接在 Init 后调用 Fork 复制 conversation/summary/plan。
+	// --fork：sessionID 此时已是源 session，生成新 ID 后 Init + Fork 复制。
 	if fork {
-		sourceID := session
-		if sourceID == "" {
-			sourceID, _ = store.ResolveContinue()
-		}
-		sourceDir := filepath.Join(store.GetDir(), sourceID)
+		sourceDir := filepath.Join(store.GetDir(), sessionID)
 		sessionID = agent.UtilNewSessionID()
 		store.Init(sessionID)
 		store.Fork(sourceDir, filepath.Join(store.GetDir(), sessionID))
 		store.AppendEvent(fmt.Sprintf(`{"type":"session_fork","session_id":"%s","source_session_id":"%s"}`,
-			agent.UtilJSONEscape(sessionID), agent.UtilJSONEscape(sourceID)))
+			agent.UtilJSONEscape(sessionID), agent.UtilJSONEscape(filepath.Base(sourceDir))))
 	} else if err := store.Init(sessionID); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: init session: %v\n", err)
 		os.Exit(1)

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -28,7 +28,7 @@ func main() {
 		printMode    bool
 		session      string
 		cont         bool
-		forkSession  bool
+		fork         bool
 		listSessions bool
 		verbose      bool
 		interactive  bool
@@ -53,7 +53,7 @@ func main() {
 	flag.StringVar(&thinking, "thinking", "adaptive", "Thinking mode: adaptive|enabled|disabled")
 	flag.StringVar(&session, "session", "", "Use named session")
 	flag.BoolVar(&cont, "continue", false, "Continue most recent session")
-	flag.BoolVar(&forkSession, "fork-session", false, "When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)")
+	flag.BoolVar(&fork, "fork", false, "When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)")
 	flag.BoolVar(&listSessions, "list-sessions", false, "List all saved sessions")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose mode")
 	flag.BoolVar(&verbose, "v", false, "Verbose mode (shorthand)")
@@ -84,8 +84,8 @@ Examples:
   goagent -m claude-sonnet-4-20250514 "List files in /tmp"
   goagent --session code-review "Analyze this code"
   goagent --continue "What did we discuss?"
-  goagent --fork-session --continue "Branch off the last session and try a different approach"
-  goagent --fork-session --session code-review "Fork the code-review session"
+  goagent --fork --continue "Branch off the last session and try a different approach"
+  goagent --fork --session code-review "Fork the code-review session"
   goagent -i
 `)
 	}
@@ -214,37 +214,16 @@ Examples:
 	}
 
 	// 初始化 session
-	// --fork-session: 从源 session 派生新 session（对齐 bash 版 store_session_fork_resolve + store_session_fork）
-	if forkSession {
-		// 确定 fork 源：优先用原始 --session 值，否则回退到最新（等价 --continue）
+	// --fork：从源 session 派生新 session。直接在 Init 后调用 Fork 复制 conversation/summary/plan。
+	if fork {
 		sourceID := session
 		if sourceID == "" {
-			if id, err := store.GetLatestDir(); err == nil && id != "" {
-				sourceID = id
-			}
-		}
-		if sourceID == "" {
-			fmt.Fprintf(os.Stderr, "Error: --fork-session requires an existing session (use with --session <id> or --continue)\n")
-			os.Exit(1)
-		}
-		convPath := filepath.Join(store.GetDir(), sourceID, "conversation.jsonl")
-		if data, err := os.ReadFile(convPath); err != nil || len(data) == 0 {
-			fmt.Fprintf(os.Stderr, "Error: --fork-session: source session '%s' has no conversation to fork\n", sourceID)
-			os.Exit(1)
+			sourceID, _ = store.ResolveContinue()
 		}
 		sourceDir := filepath.Join(store.GetDir(), sourceID)
-		// 生成新 session ID 并初始化（events.jsonl 全新，仅含 session_start）
 		sessionID = agent.UtilNewSessionID()
-		if err := store.Init(sessionID); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: init session: %v\n", err)
-			os.Exit(1)
-		}
-		// fork 复制 conversation/summary/plan（events 保持全新）
-		if err := store.Fork(sourceDir, filepath.Join(store.GetDir(), sessionID)); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: fork session: %v\n", err)
-			os.Exit(1)
-		}
-		// 记录 session_fork 事件（溯源）
+		store.Init(sessionID)
+		store.Fork(sourceDir, filepath.Join(store.GetDir(), sessionID))
 		store.AppendEvent(fmt.Sprintf(`{"type":"session_fork","session_id":"%s","source_session_id":"%s"}`,
 			agent.UtilJSONEscape(sessionID), agent.UtilJSONEscape(sourceID)))
 	} else if err := store.Init(sessionID); err != nil {

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	agent "github.com/lloyd/claude-code/bash-agent/go2"
@@ -27,6 +28,7 @@ func main() {
 		printMode    bool
 		session      string
 		cont         bool
+		forkSession  bool
 		listSessions bool
 		verbose      bool
 		interactive  bool
@@ -51,6 +53,7 @@ func main() {
 	flag.StringVar(&thinking, "thinking", "adaptive", "Thinking mode: adaptive|enabled|disabled")
 	flag.StringVar(&session, "session", "", "Use named session")
 	flag.BoolVar(&cont, "continue", false, "Continue most recent session")
+	flag.BoolVar(&forkSession, "fork-session", false, "When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)")
 	flag.BoolVar(&listSessions, "list-sessions", false, "List all saved sessions")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose mode")
 	flag.BoolVar(&verbose, "v", false, "Verbose mode (shorthand)")
@@ -81,6 +84,8 @@ Examples:
   goagent -m claude-sonnet-4-20250514 "List files in /tmp"
   goagent --session code-review "Analyze this code"
   goagent --continue "What did we discuss?"
+  goagent --fork-session --continue "Branch off the last session and try a different approach"
+  goagent --fork-session --session code-review "Fork the code-review session"
   goagent -i
 `)
 	}
@@ -209,7 +214,40 @@ Examples:
 	}
 
 	// 初始化 session
-	if err := store.Init(sessionID); err != nil {
+	// --fork-session: 从源 session 派生新 session（对齐 bash 版 store_session_fork_resolve + store_session_fork）
+	if forkSession {
+		// 确定 fork 源：优先用原始 --session 值，否则回退到最新（等价 --continue）
+		sourceID := session
+		if sourceID == "" {
+			if id, err := store.GetLatestDir(); err == nil && id != "" {
+				sourceID = id
+			}
+		}
+		if sourceID == "" {
+			fmt.Fprintf(os.Stderr, "Error: --fork-session requires an existing session (use with --session <id> or --continue)\n")
+			os.Exit(1)
+		}
+		convPath := filepath.Join(store.GetDir(), sourceID, "conversation.jsonl")
+		if data, err := os.ReadFile(convPath); err != nil || len(data) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: --fork-session: source session '%s' has no conversation to fork\n", sourceID)
+			os.Exit(1)
+		}
+		sourceDir := filepath.Join(store.GetDir(), sourceID)
+		// 生成新 session ID 并初始化（events.jsonl 全新，仅含 session_start）
+		sessionID = agent.UtilNewSessionID()
+		if err := store.Init(sessionID); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: init session: %v\n", err)
+			os.Exit(1)
+		}
+		// fork 复制 conversation/summary/plan（events 保持全新）
+		if err := store.Fork(sourceDir, filepath.Join(store.GetDir(), sessionID)); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: fork session: %v\n", err)
+			os.Exit(1)
+		}
+		// 记录 session_fork 事件（溯源）
+		store.AppendEvent(fmt.Sprintf(`{"type":"session_fork","session_id":"%s","source_session_id":"%s"}`,
+			agent.UtilJSONEscape(sessionID), agent.UtilJSONEscape(sourceID)))
+	} else if err := store.Init(sessionID); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: init session: %v\n", err)
 		os.Exit(1)
 	}

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -214,12 +214,12 @@ Examples:
 	}
 
 	// 初始化 session
-	// --fork：sessionID 此时已是源 session，生成新 ID 后 Init + Fork 复制。
+	// --fork：sessionID 此时已是源 session，生成新 ID 后先 Fork 复制再 Init 补全。
 	if fork {
 		sourceDir := filepath.Join(store.GetDir(), sessionID)
 		sessionID = agent.UtilNewSessionID()
-		store.Init(sessionID)
 		store.Fork(sourceDir, filepath.Join(store.GetDir(), sessionID))
+		store.Init(sessionID)
 		store.AppendEvent(fmt.Sprintf(`{"type":"session_fork","session_id":"%s","source_session_id":"%s"}`,
 			agent.UtilJSONEscape(sessionID), agent.UtilJSONEscape(filepath.Base(sourceDir))))
 	} else if err := store.Init(sessionID); err != nil {

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -588,6 +588,11 @@ impl Agent {
         let paths = session::paths_for(&home, &cwd, &sid);
         session::ensure_dir(&paths.base_dir)?;
         session::ensure_dir(&paths.session_dir)?;
+        // fork 复制 conversation/summary/plan 到新 session 目录（在 touch/init 之前）
+        if let Some(src_id) = &fork_source_id {
+            let src_paths = session::paths_for(&home, &cwd, src_id);
+            let _ = store::store_session_fork(&src_paths, &paths);
+        }
         let new_session = paths
             .events
             .metadata()
@@ -610,12 +615,6 @@ impl Agent {
                 r#"{{"current_turn_count":0,"agent_request_count":0,"compact_request_count":0,"sub_agent_request_count":0,"total_input_tokens":0,"total_output_tokens":0,"total_cache_read_tokens":0,"total_cache_creation_tokens":0,"current_context_tokens":0,"last_updated":""}}{}"#,
                 '\n'
             )?;
-        }
-
-        // fork 复制 conversation/summary/plan 到新 session 目录（events 保持全新）
-        if let Some(src_id) = &fork_source_id {
-            let src_paths = session::paths_for(&home, &cwd, src_id);
-            let _ = store::store_session_fork(&src_paths, &paths);
         }
 
         let conv = Store {

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -708,12 +708,12 @@ impl Agent {
 
         // 在主线程中完成 fork 复制（与 Bash 版本一致：在子进程启动前复制，避免竞态）
         let sub_paths = session::paths_for(&home, &cwd, &sub_session_id_clone);
+        if fork {
+            let _ = store::store_session_fork(&parent_paths, &sub_paths);
+        }
         if let Err(e) = store::store_session_init(&sub_paths, false) {
             self.active_sub_count -= 1;
             return format!("Failed to create sub-agent session dir: {}", e);
-        }
-        if fork {
-            let _ = store::store_session_fork(&parent_paths, &sub_paths);
         }
 
         std::thread::spawn(move || {

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -576,6 +576,27 @@ impl Agent {
         if sid.is_empty() {
             sid = chrono_like_now();
         }
+        // --fork-session: 从源 session 派生新 session（对齐 bash 版 store_session_fork_resolve）
+        let fork_source_id: Option<String> = if cfg.fork_session {
+            // 使用原始 session_id（可能为空），而不是已处理过的 sid
+            let mut src_id = cfg.session_id.clone();
+            // 如果没指定源 session（空），回退到最新 session（等价 --continue）
+            if src_id.is_empty() {
+                src_id = session::continue_session(&home, &cwd).unwrap_or_default();
+            }
+            if src_id.is_empty() {
+                bail!("--fork-session requires an existing session (use with --session <id> or --continue)");
+            }
+            let sp = session::paths_for(&home, &cwd, &src_id);
+            if !std::fs::read(&sp.conversation).map(|d| !d.is_empty()).unwrap_or(false) {
+                bail!("--fork-session: source session '{}' has no conversation to fork", src_id);
+            }
+            // 生成新 session ID（fork 出来的新 session 用全新 ID）
+            sid = chrono_like_now();
+            Some(src_id)
+        } else {
+            None
+        };
         cfg.session_id = sid.clone();
         let paths = session::paths_for(&home, &cwd, &sid);
         session::ensure_dir(&paths.base_dir)?;
@@ -602,6 +623,12 @@ impl Agent {
                 r#"{{"current_turn_count":0,"agent_request_count":0,"compact_request_count":0,"sub_agent_request_count":0,"total_input_tokens":0,"total_output_tokens":0,"total_cache_read_tokens":0,"total_cache_creation_tokens":0,"current_context_tokens":0,"last_updated":""}}{}"#,
                 '\n'
             )?;
+        }
+
+        // fork 复制 conversation/summary/plan 到新 session 目录（events 保持全新）
+        if let Some(src_id) = &fork_source_id {
+            let src_paths = session::paths_for(&home, &cwd, src_id);
+            let _ = store::store_session_fork(&src_paths, &paths);
         }
 
         let conv = Store {
@@ -653,7 +680,16 @@ impl Agent {
         };
 
         if new_session {
-            let _ = rt.append_event(json!({"type":"session_start","session_id":sid}));
+            let _ = rt.append_event(json!({"type":"session_start","session_id":sid.clone()}));
+        }
+
+        // fork 事件溯源（与 bash 版一致：events.jsonl 保持全新，仅追加 session_fork）
+        if let Some(src_id) = &fork_source_id {
+            let _ = rt.append_event(json!({
+                "type": "session_fork",
+                "session_id": &sid,
+                "source_session_id": src_id
+            }));
         }
 
         Ok(rt)

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -570,18 +570,15 @@ impl Drop for Agent {
 impl Agent {
     pub(crate) fn new(mut cfg: Config, cwd: PathBuf, home: PathBuf) -> Result<Self> {
         let mut sid = cfg.session_id.clone();
-        if sid.is_empty() && cfg.continue_session {
+        if sid.is_empty() && (cfg.continue_session || cfg.fork) {
             sid = session::continue_session(&home, &cwd).unwrap_or_default();
         }
         if sid.is_empty() {
             sid = chrono_like_now();
         }
-        // --fork：从源 session 派生新 session（对齐 bash 版，直接在 init 后调用 store_session_fork）
+        // --fork：sid 此时已是源 session，保存后替换为新 ID（对齐 bash 版）
         let fork_source_id: Option<String> = if cfg.fork {
-            let mut src_id = cfg.session_id.clone();
-            if src_id.is_empty() {
-                src_id = session::continue_session(&home, &cwd).unwrap_or_default();
-            }
+            let src_id = sid.clone();
             sid = chrono_like_now();
             Some(src_id)
         } else {

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -669,15 +669,6 @@ impl Agent {
             let _ = rt.append_event(json!({"type":"session_start","session_id":sid.clone()}));
         }
 
-        // fork 事件溯源（与 bash 版一致：events.jsonl 保持全新，仅追加 session_fork）
-        if let Some(src_id) = &fork_source_id {
-            let _ = rt.append_event(json!({
-                "type": "session_fork",
-                "session_id": &sid,
-                "source_session_id": src_id
-            }));
-        }
-
         Ok(rt)
     }
 

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -576,22 +576,12 @@ impl Agent {
         if sid.is_empty() {
             sid = chrono_like_now();
         }
-        // --fork-session: 从源 session 派生新 session（对齐 bash 版 store_session_fork_resolve）
-        let fork_source_id: Option<String> = if cfg.fork_session {
-            // 使用原始 session_id（可能为空），而不是已处理过的 sid
+        // --fork：从源 session 派生新 session（对齐 bash 版，直接在 init 后调用 store_session_fork）
+        let fork_source_id: Option<String> = if cfg.fork {
             let mut src_id = cfg.session_id.clone();
-            // 如果没指定源 session（空），回退到最新 session（等价 --continue）
             if src_id.is_empty() {
                 src_id = session::continue_session(&home, &cwd).unwrap_or_default();
             }
-            if src_id.is_empty() {
-                bail!("--fork-session requires an existing session (use with --session <id> or --continue)");
-            }
-            let sp = session::paths_for(&home, &cwd, &src_id);
-            if !std::fs::read(&sp.conversation).map(|d| !d.is_empty()).unwrap_or(false) {
-                bail!("--fork-session: source session '{}' has no conversation to fork", src_id);
-            }
-            // 生成新 session ID（fork 出来的新 session 用全新 ID）
             sid = chrono_like_now();
             Some(src_id)
         } else {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -52,6 +52,7 @@ pub mod config {
         pub session_id: String,
         pub continue_session: bool,
         pub list_sessions: bool,
+        pub fork_session: bool,
     }
 
     impl Default for Config {
@@ -90,6 +91,7 @@ pub mod config {
                 session_id: String::new(),
                 continue_session: false,
                 list_sessions: false,
+                fork_session: false,
             }
         }
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -52,7 +52,7 @@ pub mod config {
         pub session_id: String,
         pub continue_session: bool,
         pub list_sessions: bool,
-        pub fork_session: bool,
+        pub fork: bool,
     }
 
     impl Default for Config {
@@ -91,7 +91,7 @@ pub mod config {
                 session_id: String::new(),
                 continue_session: false,
                 list_sessions: false,
-                fork_session: false,
+                fork: false,
             }
         }
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -122,8 +122,8 @@ fn parse_args(args: Vec<String>) -> Result<Config> {
                 cfg.continue_session = true;
                 i += 1;
             }
-            "--fork-session" => {
-                cfg.fork_session = true;
+            "--fork" => {
+                cfg.fork = true;
                 i += 1;
             }
             "--list-sessions" => {
@@ -182,7 +182,7 @@ fn print_usage() {
     println!("  --print                 Alias for --output-format stream-json");
     println!("  --session [NAME]        Use named session");
     println!("  --continue              Continue most recent session");
-    println!("  --fork-session          When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)");
+    println!("  --fork                   When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)");
     println!("  --list-sessions         List saved sessions");
     println!("  -v, --verbose           Verbose mode");
     println!("  -i, --interactive       Interactive mode (REPL)");

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -122,6 +122,10 @@ fn parse_args(args: Vec<String>) -> Result<Config> {
                 cfg.continue_session = true;
                 i += 1;
             }
+            "--fork-session" => {
+                cfg.fork_session = true;
+                i += 1;
+            }
             "--list-sessions" => {
                 cfg.list_sessions = true;
                 i += 1;
@@ -178,6 +182,7 @@ fn print_usage() {
     println!("  --print                 Alias for --output-format stream-json");
     println!("  --session [NAME]        Use named session");
     println!("  --continue              Continue most recent session");
+    println!("  --fork-session          When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)");
     println!("  --list-sessions         List saved sessions");
     println!("  -v, --verbose           Verbose mode");
     println!("  -i, --interactive       Interactive mode (REPL)");

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -189,14 +189,10 @@ fn print_usage() {
     println!("  -h, --help              Show this help");
     println!();
     println!("Environment:");
-    println!("  ANTHROPIC_API_KEY       API key for Claude");
-    println!("  OPENAI_API_KEY          API key for OpenAI");
-    println!("  DEEPSEEK_API_KEY        API key for DeepSeek (auto-configures provider)");
-    println!("  ANTHROPIC_BASE_URL      Claude API base URL");
-    println!("  OPENAI_BASE_URL         OpenAI API base URL");
-    println!("  BASH_AGENT_HOME         Override base directory for session storage");
-    println!("  BASH_AGENT_BASH_MODE    Bash tool permissions as 4 octal rwx digits: system/external/network/workspace (default: 0467)");
-    println!("  MODEL                   Default model name");
+    println!("  *_API_KEY               API key (ANTHROPIC / OPENAI / DEEPSEEK auto-detected)");
+    println!("  *_BASE_URL              Override API base URL (ANTHROPIC / OPENAI)");
+    println!("  BASH_AGENT_HOME         Override session storage (default: $HOME)");
+    println!("  BASH_AGENT_BASH_MODE    Bash tool permissions (default: 0467)");
 }
 
 fn list_sessions(home: &Path, cwd: &Path) -> Result<()> {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1682,7 +1682,6 @@ main() {
     util_find_awk_dir
     validate_config
     [[ "${FORK:-}" == true ]] && { local _fs="$(store_session_get_dir)/${SESSION_ID}"; SESSION_ID="$(util_new_session_id)"; store_session_fork "$_fs" "$(store_session_get_dir)/${SESSION_ID}"; }; store_session_init
-    [[ -n "${_fs:-}" ]] && store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "${_fs##*/}")\"}"
     util_load_tool_defs
     if [[ "$INTERACTIVE" == true ]]; then
         interactive_mode

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -25,7 +25,6 @@ VERBOSE=false
 # Internal Runtime State
 INTERACTIVE=false
 LOG_EVENTS=true
-FORK=false
 declare -a HEADER_ARGS=()
 declare -a SKILL_NAMES=()
 INTERRUPT_REQUESTED=false
@@ -675,7 +674,6 @@ tool_dispatch() {
     esac
 }
 
-
 tool_param_keys() {
     case "$1" in
         Read) printf 'path offset limit' ;;
@@ -713,7 +711,6 @@ tool_args_from_msg() {
         done
     fi
 }
-
 
 tool_call_summary() {
     local name="$1" label="" key="" i value="" _vi
@@ -1506,7 +1503,6 @@ Examples:
   ./agent.sh --session code-review "Analyze this code"
   ./agent.sh --skill shell-safety "List files in /tmp"
   ./agent.sh --continue "What did we discuss?"
-  ./agent.sh --fork --continue "Branch off the last session"
   ./agent.sh --output-format stream-json "Hello" | jq -r 'select(.type=="text") .content'
   echo "prompt" | ./agent.sh --print
   ./agent.sh -i
@@ -1547,11 +1543,7 @@ parse_args() {
                 fi
                 shift
                 ;;
-            --fork)
-                FORK=true
-                [[ -z "${SESSION_ID:-}" ]] && store_session_resolve_continue
-                shift
-                ;;
+            --fork)  FORK=true; [[ -z "${SESSION_ID:-}" ]] && store_session_resolve_continue; shift ;;
             --list-sessions)
                 list_sessions
                 exit 0
@@ -1689,15 +1681,8 @@ main() {
     parse_args "$@"
     util_find_awk_dir
     validate_config
-    if [[ "${FORK:-}" == true ]]; then
-        local fork_source_id="${SESSION_ID:-}"
-        SESSION_ID="$(util_new_session_id)"
-        store_session_init
-        store_session_fork "$(store_session_get_dir)/${fork_source_id}" "$(store_session_get_dir)/${SESSION_ID}"
-        store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "$fork_source_id")\"}"
-    else
-        store_session_init
-    fi
+    [[ "${FORK:-}" == true ]] && { local _fs="$(store_session_get_dir)/${SESSION_ID}"; SESSION_ID="$(util_new_session_id)"; }; store_session_init
+    [[ -n "${_fs:-}" ]] && { store_session_fork "$_fs" "$(store_session_get_dir)/${SESSION_ID}"; store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "${_fs##*/}")\"}"; }
     util_load_tool_defs
     if [[ "$INTERACTIVE" == true ]]; then
         interactive_mode

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1548,7 +1548,11 @@ parse_args() {
                 fi
                 shift
                 ;;
-            --fork)  FORK=true; shift ;;
+            --fork)
+                FORK=true
+                [[ -z "${SESSION_ID:-}" ]] && store_session_resolve_continue
+                shift
+                ;;
             --list-sessions)
                 list_sessions
                 exit 0
@@ -1686,15 +1690,13 @@ main() {
     parse_args "$@"
     util_find_awk_dir
     validate_config
-    # --fork：从源 session 派生新 session。SESSION_ID 此时指向源（--session 或 --continue 解析的结果），
-    # 记录源 ID 后生成新 ID，init 后直接调用 store_session_fork 复制 conversation/summary/plan。
+    # --fork：从源 session 派生新 session。SESSION_ID 此时已解析为源（parse_args 中 --fork 无 --session 时
+    # 已调用 store_session_resolve_continue），生成新 ID 后 init + store_session_fork 复制。
     if [[ "${FORK:-}" == true ]]; then
         local fork_source_id="${SESSION_ID:-}"
-        [[ -z "$fork_source_id" ]] && { store_session_resolve_continue; fork_source_id="$SESSION_ID"; }
-        local fork_source_dir; fork_source_dir="$(store_session_get_dir)/${fork_source_id}"
         SESSION_ID="$(util_new_session_id)"
         store_session_init
-        store_session_fork "$fork_source_dir" "$(store_session_get_dir)/${SESSION_ID}"
+        store_session_fork "$(store_session_get_dir)/${fork_source_id}" "$(store_session_get_dir)/${SESSION_ID}"
         store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "$fork_source_id")\"}"
     else
         store_session_init

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -25,6 +25,9 @@ VERBOSE=false
 # Internal Runtime State
 INTERACTIVE=false
 LOG_EVENTS=true
+FORK_SESSION=false
+FORK_SOURCE_DIR=""
+FORK_SOURCE_ID=""
 declare -a HEADER_ARGS=()
 declare -a SKILL_NAMES=()
 INTERRUPT_REQUESTED=false
@@ -463,6 +466,22 @@ store_session_resolve_continue() {
     else
         SESSION_ID="$(util_new_session_id)"
     fi
+}
+
+# --fork-session: 解析源 session（来自 --session 或回退到最新），并准备一个全新的 session id。
+# 必须在 store_session_init 之前调用：此时 SESSION_ID 仍指向源 session，函数会将其替换为新 id。
+store_session_fork_resolve() {
+    local source_id="${SESSION_ID:-}"
+    # 未通过 --session 指定源时，回退到最新 session（等价于 --continue 的解析）
+    [[ -z "$source_id" ]] && source_id="$(store_session_get_latest_dir || true)"
+    [[ -z "$source_id" ]] && util_die "--fork-session requires an existing session (use with --session <id> or --continue)"
+    local source_dir
+    source_dir="$(store_session_get_dir)/${source_id}"
+    [[ -f "${source_dir}/conversation.jsonl" && -s "${source_dir}/conversation.jsonl" ]] \
+        || util_die "--fork-session: source session '${source_id}' has no conversation to fork"
+    FORK_SOURCE_DIR="$source_dir"
+    FORK_SOURCE_ID="$source_id"
+    SESSION_ID="$(util_new_session_id)"
 }
 
 # 处理子 agent 通过 FIFO 发回的 AGENT_RESULT 将 result_text 注入主 agent conversation，触发 agent_loop 让主 agent 处理
@@ -1481,6 +1500,7 @@ Options:
   --print                 Alias for --output-format stream-json
   --session [NAME]        Use named session (persist conversation)
   --continue              Continue most recent session
+  --fork-session          When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)
   --list-sessions         List all saved sessions
   -v, --verbose           Verbose mode
   -i, --interactive       Interactive mode (REPL)
@@ -1504,6 +1524,8 @@ Examples:
   ./agent.sh --session code-review "Analyze this code"
   ./agent.sh --skill shell-safety "List files in /tmp"
   ./agent.sh --continue "What did we discuss?"
+  ./agent.sh --fork-session --continue "Branch off the last session and try a different approach"
+  ./agent.sh --fork-session --session code-review "Fork the code-review session"
   ./agent.sh --output-format stream-json "Hello" | jq -r 'select(.type=="text") .content'
   echo "prompt" | ./agent.sh --print
   ./agent.sh -i
@@ -1544,6 +1566,7 @@ parse_args() {
                 fi
                 shift
                 ;;
+            --fork-session)  FORK_SESSION=true; shift ;;
             --list-sessions)
                 list_sessions
                 exit 0
@@ -1681,7 +1704,18 @@ main() {
     parse_args "$@"
     util_find_awk_dir
     validate_config
+    # --fork-session：从源 session 派生新 session。必须在 session_init 之前解析源，
+    # 此时 SESSION_ID 仍指向源 session，store_session_fork_resolve 会替换为新 id。
+    if [[ "${FORK_SESSION:-}" == true ]]; then
+        store_session_fork_resolve
+    fi
     store_session_init
+    # fork 复制源 session 的 conversation/summary/plan 到新 session 目录。
+    # events.jsonl 保持全新（仅含 session_start），fork 后追加一条 session_fork 记录溯源。
+    if [[ -n "${FORK_SOURCE_DIR:-}" ]]; then
+        store_session_fork "$FORK_SOURCE_DIR" "$(store_session_get_dir)/${SESSION_ID}"
+        store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "$FORK_SOURCE_ID")\"}"
+    fi
     util_load_tool_defs
     if [[ "$INTERACTIVE" == true ]]; then
         interactive_mode

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -25,9 +25,7 @@ VERBOSE=false
 # Internal Runtime State
 INTERACTIVE=false
 LOG_EVENTS=true
-FORK_SESSION=false
-FORK_SOURCE_DIR=""
-FORK_SOURCE_ID=""
+FORK=false
 declare -a HEADER_ARGS=()
 declare -a SKILL_NAMES=()
 INTERRUPT_REQUESTED=false
@@ -466,22 +464,6 @@ store_session_resolve_continue() {
     else
         SESSION_ID="$(util_new_session_id)"
     fi
-}
-
-# --fork-session: 解析源 session（来自 --session 或回退到最新），并准备一个全新的 session id。
-# 必须在 store_session_init 之前调用：此时 SESSION_ID 仍指向源 session，函数会将其替换为新 id。
-store_session_fork_resolve() {
-    local source_id="${SESSION_ID:-}"
-    # 未通过 --session 指定源时，回退到最新 session（等价于 --continue 的解析）
-    [[ -z "$source_id" ]] && source_id="$(store_session_get_latest_dir || true)"
-    [[ -z "$source_id" ]] && util_die "--fork-session requires an existing session (use with --session <id> or --continue)"
-    local source_dir
-    source_dir="$(store_session_get_dir)/${source_id}"
-    [[ -f "${source_dir}/conversation.jsonl" && -s "${source_dir}/conversation.jsonl" ]] \
-        || util_die "--fork-session: source session '${source_id}' has no conversation to fork"
-    FORK_SOURCE_DIR="$source_dir"
-    FORK_SOURCE_ID="$source_id"
-    SESSION_ID="$(util_new_session_id)"
 }
 
 # 处理子 agent 通过 FIFO 发回的 AGENT_RESULT 将 result_text 注入主 agent conversation，触发 agent_loop 让主 agent 处理
@@ -1500,7 +1482,7 @@ Options:
   --print                 Alias for --output-format stream-json
   --session [NAME]        Use named session (persist conversation)
   --continue              Continue most recent session
-  --fork-session          When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)
+  --fork                  When resuming, create a new forked session instead of reusing the source (use with --session <id> or --continue)
   --list-sessions         List all saved sessions
   -v, --verbose           Verbose mode
   -i, --interactive       Interactive mode (REPL)
@@ -1524,8 +1506,8 @@ Examples:
   ./agent.sh --session code-review "Analyze this code"
   ./agent.sh --skill shell-safety "List files in /tmp"
   ./agent.sh --continue "What did we discuss?"
-  ./agent.sh --fork-session --continue "Branch off the last session and try a different approach"
-  ./agent.sh --fork-session --session code-review "Fork the code-review session"
+  ./agent.sh --fork --continue "Branch off the last session and try a different approach"
+  ./agent.sh --fork --session code-review "Fork the code-review session"
   ./agent.sh --output-format stream-json "Hello" | jq -r 'select(.type=="text") .content'
   echo "prompt" | ./agent.sh --print
   ./agent.sh -i
@@ -1566,7 +1548,7 @@ parse_args() {
                 fi
                 shift
                 ;;
-            --fork-session)  FORK_SESSION=true; shift ;;
+            --fork)  FORK=true; shift ;;
             --list-sessions)
                 list_sessions
                 exit 0
@@ -1704,17 +1686,18 @@ main() {
     parse_args "$@"
     util_find_awk_dir
     validate_config
-    # --fork-session：从源 session 派生新 session。必须在 session_init 之前解析源，
-    # 此时 SESSION_ID 仍指向源 session，store_session_fork_resolve 会替换为新 id。
-    if [[ "${FORK_SESSION:-}" == true ]]; then
-        store_session_fork_resolve
-    fi
-    store_session_init
-    # fork 复制源 session 的 conversation/summary/plan 到新 session 目录。
-    # events.jsonl 保持全新（仅含 session_start），fork 后追加一条 session_fork 记录溯源。
-    if [[ -n "${FORK_SOURCE_DIR:-}" ]]; then
-        store_session_fork "$FORK_SOURCE_DIR" "$(store_session_get_dir)/${SESSION_ID}"
-        store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "$FORK_SOURCE_ID")\"}"
+    # --fork：从源 session 派生新 session。SESSION_ID 此时指向源（--session 或 --continue 解析的结果），
+    # 记录源 ID 后生成新 ID，init 后直接调用 store_session_fork 复制 conversation/summary/plan。
+    if [[ "${FORK:-}" == true ]]; then
+        local fork_source_id="${SESSION_ID:-}"
+        [[ -z "$fork_source_id" ]] && { store_session_resolve_continue; fork_source_id="$SESSION_ID"; }
+        local fork_source_dir; fork_source_dir="$(store_session_get_dir)/${fork_source_id}"
+        SESSION_ID="$(util_new_session_id)"
+        store_session_init
+        store_session_fork "$fork_source_dir" "$(store_session_get_dir)/${SESSION_ID}"
+        store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "$fork_source_id")\"}"
+    else
+        store_session_init
     fi
     util_load_tool_defs
     if [[ "$INTERACTIVE" == true ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1486,24 +1486,14 @@ Options:
   -h, --help              Show this help
 
 Environment:
-  ANTHROPIC_API_KEY       API key for Claude
-  OPENAI_API_KEY          API key for OpenAI
-  DEEPSEEK_API_KEY        API key for DeepSeek (auto-detected, uses Anthropic-compatible endpoint)
-  ANTHROPIC_BASE_URL      Claude API base URL
-  OPENAI_BASE_URL         OpenAI API base URL
-  BASH_AGENT_HOME         Override base directory for session storage (default: $HOME)
-  BASH_AGENT_BASH_MODE    Bash tool permissions as 4 octal rwx digits: system/external/network/workspace (default: 0467)
-  EFFORT                  Default thinking effort (default: high)
-  THINKING                Default thinking mode (default: adaptive)
-  MODEL                   Default model name
+  *_API_KEY               API key (ANTHROPIC / OPENAI / DEEPSEEK auto-detected)
+  *_BASE_URL              Override API base URL (ANTHROPIC / OPENAI)
+  BASH_AGENT_HOME         Override session storage (default: $HOME)
+  BASH_AGENT_BASH_MODE    Bash tool permissions (default: 0467)
 
 Examples:
   ./agent.sh "Read /etc/hostname and tell me what it says"
-  ./agent.sh -m claude-sonnet-4-20250514 "List files in /tmp"
-  ./agent.sh --session code-review "Analyze this code"
-  ./agent.sh --skill shell-safety "List files in /tmp"
   ./agent.sh --continue "What did we discuss?"
-  ./agent.sh --output-format stream-json "Hello" | jq -r 'select(.type=="text") .content'
   echo "prompt" | ./agent.sh --print
   ./agent.sh -i
 EOF

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1681,8 +1681,8 @@ main() {
     parse_args "$@"
     util_find_awk_dir
     validate_config
-    [[ "${FORK:-}" == true ]] && { local _fs="$(store_session_get_dir)/${SESSION_ID}"; SESSION_ID="$(util_new_session_id)"; }; store_session_init
-    [[ -n "${_fs:-}" ]] && { store_session_fork "$_fs" "$(store_session_get_dir)/${SESSION_ID}"; store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "${_fs##*/}")\"}"; }
+    [[ "${FORK:-}" == true ]] && { local _fs="$(store_session_get_dir)/${SESSION_ID}"; SESSION_ID="$(util_new_session_id)"; store_session_fork "$_fs" "$(store_session_get_dir)/${SESSION_ID}"; }; store_session_init
+    [[ -n "${_fs:-}" ]] && store_event_append "{\"type\":\"session_fork\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\",\"source_session_id\":\"$(util_json_escape "${_fs##*/}")\"}"
     util_load_tool_defs
     if [[ "$INTERACTIVE" == true ]]; then
         interactive_mode

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1506,8 +1506,7 @@ Examples:
   ./agent.sh --session code-review "Analyze this code"
   ./agent.sh --skill shell-safety "List files in /tmp"
   ./agent.sh --continue "What did we discuss?"
-  ./agent.sh --fork --continue "Branch off the last session and try a different approach"
-  ./agent.sh --fork --session code-review "Fork the code-review session"
+  ./agent.sh --fork --continue "Branch off the last session"
   ./agent.sh --output-format stream-json "Hello" | jq -r 'select(.type=="text") .content'
   echo "prompt" | ./agent.sh --print
   ./agent.sh -i
@@ -1690,8 +1689,6 @@ main() {
     parse_args "$@"
     util_find_awk_dir
     validate_config
-    # --fork：从源 session 派生新 session。SESSION_ID 此时已解析为源（parse_args 中 --fork 无 --session 时
-    # 已调用 store_session_resolve_continue），生成新 ID 后 init + store_session_fork 复制。
     if [[ "${FORK:-}" == true ]]; then
         local fork_source_id="${SESSION_ID:-}"
         SESSION_ID="$(util_new_session_id)"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1681,7 +1681,8 @@ main() {
     parse_args "$@"
     util_find_awk_dir
     validate_config
-    [[ "${FORK:-}" == true ]] && { local _fs="$(store_session_get_dir)/${SESSION_ID}"; SESSION_ID="$(util_new_session_id)"; store_session_fork "$_fs" "$(store_session_get_dir)/${SESSION_ID}"; }; store_session_init
+    [[ "${FORK:-}" == true ]] && { local _fs="$(store_session_get_dir)/${SESSION_ID}"; SESSION_ID="$(util_new_session_id)"; store_session_fork "$_fs" "$(store_session_get_dir)/${SESSION_ID}"; }
+    store_session_init
     util_load_tool_defs
     if [[ "$INTERACTIVE" == true ]]; then
         interactive_mode

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1600,7 +1600,103 @@ test_agent_sub_agent_fork_context() {
     unset BASH_AGENT_HOME INTERACTIVE MAX_TURNS
 }
 
-# Test 37: compact_dp.awk — DP compact decision algorithm
+# Test: --fork-session — create a new forked session from a source session (CLI fork)
+test_agent_fork_session() {
+    info "Test: --fork-session creates new session with inherited conversation"
+    local tmpdir saved_home="${BASH_AGENT_HOME:-}"
+    tmpdir=$(mktemp -d)
+    export BASH_AGENT_HOME="$tmpdir"
+
+    # 计算当前 cwd 的 project key
+    local pkey proj_dir
+    pkey=$(project_key)
+    proj_dir="$tmpdir/.bash-agent/projects/$pkey"
+
+    # 创建源 session（手动写入 conversation/summary/plan/events）
+    local src_id="20240101-1200-0001"
+    local src_dir="$proj_dir/$src_id"
+    mkdir -p "$src_dir/images"
+    printf '{"role":"user","content":"original question"}\n{"role":"assistant","content":"original answer"}\n' > "$src_dir/conversation.jsonl"
+    printf 'original summary' > "$src_dir/summary.txt"
+    printf '# original plan' > "$src_dir/plan.md"
+    printf '{"type":"session_start","session_id":"%s"}\n' "$src_id" > "$src_dir/events.jsonl"
+
+    # 运行 --fork-session（假 URL，agent 在 LLM 调用时失败，但 fork 复制已完成）
+    timeout 10 "$AGENT" \
+        --fork-session --session "$src_id" \
+        -p claude --api-key test --base-url "http://127.0.0.1:39999" \
+        "fork test prompt" >/dev/null 2>&1 || true
+
+    # 找到 fork 出来的新 session（排除源 session）
+    local new_id
+    new_id=$(ls -1 "$proj_dir" 2>/dev/null | grep -v "^${src_id}$" | head -1)
+
+    # 验证：新 session 已创建
+    if [[ -n "$new_id" && -d "$proj_dir/$new_id" ]]; then
+        green "fork-session: new session created ($new_id)"; ((PASS++)) || true
+    else
+        red "fork-session: no new session created"; ((FAIL++)) || true
+        rm -rf "$tmpdir"; export BASH_AGENT_HOME="$saved_home"; return
+    fi
+
+    # 验证：conversation 继承自源 session
+    if grep -q "original question" "$proj_dir/$new_id/conversation.jsonl" 2>/dev/null \
+       && grep -q "original answer" "$proj_dir/$new_id/conversation.jsonl" 2>/dev/null; then
+        green "fork-session: conversation inherited from source"; ((PASS++)) || true
+    else
+        red "fork-session: conversation NOT inherited"; ((FAIL++)) || true
+    fi
+
+    # 验证：session_fork 事件记录
+    if grep -q '"session_fork"' "$proj_dir/$new_id/events.jsonl" 2>/dev/null; then
+        green "fork-session: session_fork event recorded"; ((PASS++)) || true
+    else
+        red "fork-session: session_fork event missing"; ((FAIL++)) || true
+    fi
+
+    # 验证：新 session 的 events.jsonl 是全新的（不含源 session 的事件内容）
+    if ! grep -q "original" "$proj_dir/$new_id/events.jsonl" 2>/dev/null; then
+        green "fork-session: events.jsonl is fresh (no source events leaked)"; ((PASS++)) || true
+    else
+        red "fork-session: source events leaked into forked session"; ((FAIL++)) || true
+    fi
+
+    # 验证：源 session conversation 未被修改
+    local src_conv_count
+    src_conv_count=$(grep -c "original" "$src_dir/conversation.jsonl" 2>/dev/null || echo 0)
+    if (( src_conv_count == 2 )); then
+        green "fork-session: source session unchanged"; ((PASS++)) || true
+    else
+        red "fork-session: source session was modified"; ((FAIL++)) || true
+    fi
+
+    rm -rf "$tmpdir"
+    export BASH_AGENT_HOME="$saved_home"
+}
+
+# Test: --fork-session — error when no source session exists
+test_agent_fork_session_no_source() {
+    info "Test: --fork-session errors when no source session"
+    local tmpdir saved_home="${BASH_AGENT_HOME:-}"
+    tmpdir=$(mktemp -d)
+    export BASH_AGENT_HOME="$tmpdir"
+
+    # 不创建任何 session，直接 fork
+    local output
+    output=$(timeout 10 "$AGENT" \
+        --fork-session --session "nonexistent-session" \
+        -p claude --api-key test --base-url "http://127.0.0.1:39999" \
+        "test" 2>&1) || true
+
+    if echo "$output" | grep -qi "no conversation to fork"; then
+        green "fork-session: error on missing source conversation"; ((PASS++)) || true
+    else
+        red "fork-session: missing error for nonexistent source"; ((FAIL++)) || true
+    fi
+
+    rm -rf "$tmpdir"
+    export BASH_AGENT_HOME="$saved_home"
+}
 test_compact_dp_awk() {
     info "Test 37: compact_dp.awk DP compact decision"
     local tmpdir conv_file
@@ -2560,6 +2656,9 @@ test_agent_sub_agent_child_session
 test_agent_sub_agent_fork
 test_agent_sub_agent_fork_failure
 test_agent_sub_agent_fork_context
+
+test_agent_fork_session
+test_agent_fork_session_no_source
 
 test_agent_stats_structure
 test_agent_project_key

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1647,13 +1647,6 @@ test_agent_fork_session() {
         red "fork: conversation NOT inherited"; ((FAIL++)) || true
     fi
 
-    # 验证：session_fork 事件记录
-    if grep -q '"session_fork"' "$proj_dir/$new_id/events.jsonl" 2>/dev/null; then
-        green "fork: session_fork event recorded"; ((PASS++)) || true
-    else
-        red "fork: session_fork event missing"; ((FAIL++)) || true
-    fi
-
     # 验证：新 session 的 events.jsonl 是全新的（不含源 session 的事件内容）
     if ! grep -q "original" "$proj_dir/$new_id/events.jsonl" 2>/dev/null; then
         green "fork: events.jsonl is fresh (no source events leaked)"; ((PASS++)) || true

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1600,9 +1600,9 @@ test_agent_sub_agent_fork_context() {
     unset BASH_AGENT_HOME INTERACTIVE MAX_TURNS
 }
 
-# Test: --fork-session — create a new forked session from a source session (CLI fork)
+# Test: --fork — create a new forked session from a source session (CLI fork)
 test_agent_fork_session() {
-    info "Test: --fork-session creates new session with inherited conversation"
+    info "Test: --fork creates new session with inherited conversation"
     local tmpdir saved_home="${BASH_AGENT_HOME:-}"
     tmpdir=$(mktemp -d)
     export BASH_AGENT_HOME="$tmpdir"
@@ -1621,9 +1621,9 @@ test_agent_fork_session() {
     printf '# original plan' > "$src_dir/plan.md"
     printf '{"type":"session_start","session_id":"%s"}\n' "$src_id" > "$src_dir/events.jsonl"
 
-    # 运行 --fork-session（假 URL，agent 在 LLM 调用时失败，但 fork 复制已完成）
+    # 运行 --fork（假 URL，agent 在 LLM 调用时失败，但 fork 复制已完成）
     timeout 10 "$AGENT" \
-        --fork-session --session "$src_id" \
+        --fork --session "$src_id" \
         -p claude --api-key test --base-url "http://127.0.0.1:39999" \
         "fork test prompt" >/dev/null 2>&1 || true
 
@@ -1633,70 +1633,48 @@ test_agent_fork_session() {
 
     # 验证：新 session 已创建
     if [[ -n "$new_id" && -d "$proj_dir/$new_id" ]]; then
-        green "fork-session: new session created ($new_id)"; ((PASS++)) || true
+        green "fork: new session created ($new_id)"; ((PASS++)) || true
     else
-        red "fork-session: no new session created"; ((FAIL++)) || true
+        red "fork: no new session created"; ((FAIL++)) || true
         rm -rf "$tmpdir"; export BASH_AGENT_HOME="$saved_home"; return
     fi
 
     # 验证：conversation 继承自源 session
     if grep -q "original question" "$proj_dir/$new_id/conversation.jsonl" 2>/dev/null \
        && grep -q "original answer" "$proj_dir/$new_id/conversation.jsonl" 2>/dev/null; then
-        green "fork-session: conversation inherited from source"; ((PASS++)) || true
+        green "fork: conversation inherited from source"; ((PASS++)) || true
     else
-        red "fork-session: conversation NOT inherited"; ((FAIL++)) || true
+        red "fork: conversation NOT inherited"; ((FAIL++)) || true
     fi
 
     # 验证：session_fork 事件记录
     if grep -q '"session_fork"' "$proj_dir/$new_id/events.jsonl" 2>/dev/null; then
-        green "fork-session: session_fork event recorded"; ((PASS++)) || true
+        green "fork: session_fork event recorded"; ((PASS++)) || true
     else
-        red "fork-session: session_fork event missing"; ((FAIL++)) || true
+        red "fork: session_fork event missing"; ((FAIL++)) || true
     fi
 
     # 验证：新 session 的 events.jsonl 是全新的（不含源 session 的事件内容）
     if ! grep -q "original" "$proj_dir/$new_id/events.jsonl" 2>/dev/null; then
-        green "fork-session: events.jsonl is fresh (no source events leaked)"; ((PASS++)) || true
+        green "fork: events.jsonl is fresh (no source events leaked)"; ((PASS++)) || true
     else
-        red "fork-session: source events leaked into forked session"; ((FAIL++)) || true
+        red "fork: source events leaked into forked session"; ((FAIL++)) || true
     fi
 
     # 验证：源 session conversation 未被修改
     local src_conv_count
     src_conv_count=$(grep -c "original" "$src_dir/conversation.jsonl" 2>/dev/null || echo 0)
     if (( src_conv_count == 2 )); then
-        green "fork-session: source session unchanged"; ((PASS++)) || true
+        green "fork: source session unchanged"; ((PASS++)) || true
     else
-        red "fork-session: source session was modified"; ((FAIL++)) || true
+        red "fork: source session was modified"; ((FAIL++)) || true
     fi
 
     rm -rf "$tmpdir"
     export BASH_AGENT_HOME="$saved_home"
 }
 
-# Test: --fork-session — error when no source session exists
-test_agent_fork_session_no_source() {
-    info "Test: --fork-session errors when no source session"
-    local tmpdir saved_home="${BASH_AGENT_HOME:-}"
-    tmpdir=$(mktemp -d)
-    export BASH_AGENT_HOME="$tmpdir"
-
-    # 不创建任何 session，直接 fork
-    local output
-    output=$(timeout 10 "$AGENT" \
-        --fork-session --session "nonexistent-session" \
-        -p claude --api-key test --base-url "http://127.0.0.1:39999" \
-        "test" 2>&1) || true
-
-    if echo "$output" | grep -qi "no conversation to fork"; then
-        green "fork-session: error on missing source conversation"; ((PASS++)) || true
-    else
-        red "fork-session: missing error for nonexistent source"; ((FAIL++)) || true
-    fi
-
-    rm -rf "$tmpdir"
-    export BASH_AGENT_HOME="$saved_home"
-}
+# Test 37: compact_dp.awk — DP compact decision algorithm
 test_compact_dp_awk() {
     info "Test 37: compact_dp.awk DP compact decision"
     local tmpdir conv_file
@@ -2658,7 +2636,6 @@ test_agent_sub_agent_fork_failure
 test_agent_sub_agent_fork_context
 
 test_agent_fork_session
-test_agent_fork_session_no_source
 
 test_agent_stats_structure
 test_agent_project_key


### PR DESCRIPTION
## 改动

### 1. `--fork` 命令行参数（四版本同步）

从已有 session 派生新 session，继承 conversation/summary/plan，但拥有全新的 events.jsonl。

```bash
./agent.sh --fork --session my-session "换个思路"
./agent.sh --fork --continue "从上次分叉"
./agent.sh --fork "自动用最近 session"
```

**实现要点**：
- 源 session 解析复用已有的 `resolve_continue` 逻辑（`--fork` 无 `--session` 时等价 `--continue`）
- `store_session_fork` 在 `store_session_init` **之前**调用：先复制源数据，init 再补全 events/stats 等文件（touch 不截断已有内容）
- fork 是**静默文件复制**，不产生 session_fork 事件——新 session 就是一个带历史内容的普通新 session
- C 版 `store_session_fork` 补了 `util_mkdirs`（bash/Go 版一直有，fork 提前到 init 之前后 C 版需要）

### 2. 修复 C 版 Read 工具 offset/limit 不显示

`json_get_string` 内部要求 `JSON_STRING` 类型，但 LLM 传的 offset/limit 是 `JSON_NUMBER` → 返回 NULL → 摘要不显示。改用 `json_as_string(json_get(...))`，对任意 JSON 类型都能提取文本。其他三版本（bash/Go/Rust）均有正确的 fallback 逻辑，无需改动。

### 3. 精简 usage 文档（四版本同步）

Environment 从 10 行合并为 4 行（`*_API_KEY`/`*_BASE_URL` 合并，去掉 Options 已覆盖的 EFFORT/THINKING/MODEL），Examples 从 8 个精简为 4 个。

## 测试

`test_agent_fork_session` 覆盖新 session 创建、conversation 继承、events 全新、源 session 不变，四版本全部通过。