### PR TITLE
修复 Go 版本会话存储与入口行为不一致

### DIFF
--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -81,7 +81,9 @@ Examples:
 `)
 	}
 
-	flag.Parse()
+	if err := flag.CommandLine.Parse(normalizeSessionArgs(os.Args[1:])); err != nil {
+		os.Exit(2)
+	}
 
 	// 收集位置参数作为 prompt
 	userInput := strings.Join(flag.Args(), " ")
@@ -160,12 +162,6 @@ Examples:
 		}
 	}
 
-	// API key 校验
-	if cfg.APIKey == "" && cfg.BaseURL == "" {
-		fmt.Fprintf(os.Stderr, "No API key. Set %s_API_KEY or use --api-key\n", strings.ToUpper(provider))
-		os.Exit(1)
-	}
-
 	// 创建组件
 	home := os.Getenv("BASH_AGENT_HOME")
 	if home == "" {
@@ -173,6 +169,19 @@ Examples:
 	}
 	cwd, _ := os.Getwd()
 	store := agent.NewFileStore(home, cwd)
+
+	// --list-sessions 不需要 API key（对齐 bash/rust/c）
+	if listSessions {
+		listAllSessions(store)
+		return
+	}
+
+	// API key 校验
+	if cfg.APIKey == "" && cfg.BaseURL == "" {
+		fmt.Fprintf(os.Stderr, "No API key. Set %s_API_KEY or use --api-key\n", strings.ToUpper(provider))
+		os.Exit(1)
+	}
+
 	display := agent.NewTermDisplay()
 	if cfg.OutputFormat == "stream-json" {
 		display.SetSilent(true)
@@ -196,12 +205,6 @@ Examples:
 	}
 	if sessionID == "" {
 		sessionID = agent.UtilNewSessionID()
-	}
-
-	// --list-sessions
-	if listSessions {
-		listAllSessions(store)
-		return
 	}
 
 	// 初始化 session
@@ -386,6 +389,25 @@ func listAllSessions(store agent.SessionStore) {
 	for _, r := range rows {
 		fmt.Printf("%-40s %-16s %s\n", r.Name, r.Modified, r.Preview)
 	}
+}
+
+func normalizeSessionArgs(args []string) []string {
+	out := make([]string, 0, len(args)+1)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--session" {
+			out = append(out, arg)
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				out = append(out, args[i+1])
+				i++
+			} else {
+				out = append(out, agent.UtilNewSessionID())
+			}
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
 }
 
 // stringSlice 实现 flag.Value 接口，支持重复 -skill

--- a/go/display.go
+++ b/go/display.go
@@ -90,7 +90,7 @@ func (d *TermDisplay) SetTitle(title string) {
 	if d.silent {
 		return
 	}
-	fmt.Fprintf(os.Stderr, "\033]0;%s\007", title)
+	fmt.Fprint(os.Stderr, title)
 }
 
 func (d *TermDisplay) clearLineIfAtNewline() {

--- a/go/store.go
+++ b/go/store.go
@@ -208,6 +208,9 @@ func (s *FileStore) Fork(parentDir, childDir string) error {
 
 func (s *FileStore) GetDir() string {
 	cwd, _ := filepath.Abs(s.cwd)
+	if realCwd, err := filepath.EvalSymlinks(cwd); err == nil {
+		cwd = realCwd
+	}
 	projectKey := pathToProjectKey(cwd)
 	base := s.home
 	if base == "" {
@@ -793,11 +796,11 @@ func (s *FileStore) FormatTitle(model, status string) string {
 	if status == "idle" {
 		progress = 0
 	}
-	return fmt.Sprintf("%s%s T:%s R:%d I:%s(%s) O:%s C:%s\x1b]9;4;%d\x07",
+	return fmt.Sprintf("\x1b]0;%s%s T:%s R:%s I:%s(%s) O:%s C:%s\x07\x1b]9;4;%d\x07",
 		prefix,
 		model,
 		fmtInt(st.TurnCount),
-		st.TotalRequests,
+		fmtInt(st.TotalRequests),
 		fmtInt(cacheTotal),
 		cachePct,
 		fmtInt(st.OutputTokens),
@@ -1039,9 +1042,6 @@ func pathToProjectKey(absPath string) string {
 	}
 	key := strings.Trim(b.String(), "-")
 	key = "-" + key
-	if len(key) > 200 {
-		key = key[:200]
-	}
 	return key
 }
 


### PR DESCRIPTION
## 变更说明

修复 Go 版本与 Bash/C/Rust 在会话存储、入口参数和终端标题输出上的行为不一致问题。

主要变更：

- Go 会话目录计算时解析符号链接，确保 macOS 下 `/tmp` 与 Bash `pwd -P` 一致落到 `/private/tmp`
- 移除 Go 独有的 project key 200 字符截断，保持与 Bash/C/Rust 一致
- `--list-sessions` 提前到 API key 校验前执行，支持无 API key 列出本地会话
- 支持裸 `--session` 自动创建新 session，与 Bash/Rust/C 行为一致
- 修复 `--session <id>` 参数归一化，避免 session id 被重复当作 prompt
- 修复终端标题 OSC 嵌套问题，OSC 0 title 与 OSC 9;4 progress 分别独立输出
- `R` 请求计数改为千分位格式化，与其他 token 计数展示一致

## 验证

- `cd go && GOPROXY=off go test ./...`
- `make build-go`
- `make test-go-e2e`：176 passed, 0 failed
- 验证无 API key 时 `goagent --list-sessions` 可运行
- 验证 `/tmp` 下 Go `--list-sessions` 可看到 Bash/C/Rust 使用的同一 project session
- 验证裸 `goagent --session` 不再报 flag 缺少参数