### PR TITLE
perf: JSON escape awk 化（~1000x）+ SubAgent 双 FIFO 通知架构重构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ c/build/
 c/tools_embed.h
 c/test_classify
 c/test_classify.dSYM/
+.bash-agent/

--- a/c/agent.c
+++ b/c/agent.c
@@ -656,6 +656,43 @@ int agent_replay_events(Agent *agent, int max_turns) {
  * 对齐 bash 版 agent_run_loop
  * ============================================================ */
 
+/* drain SubAgent 结果：display + conversation 注入，返回消费条数（对齐 bash agent_drain_notify_buf） */
+static int agent_drain_sub_results(Agent *agent) {
+    int drained = 0;
+    while (1) {
+        void *sub_data = NULL;
+        if (mq_try_pop(agent->sub_result_queue, &sub_data) != 0) break;
+        InputMessage *sub_msg = (InputMessage *)sub_data;
+        if (sub_msg && sub_msg->type == MSG_AGENT_RESULT) {
+            agent_handle_sub_agent_result(agent,
+                sub_msg->data.agent_result.session_id,
+                sub_msg->data.agent_result.status,
+                sub_msg->data.agent_result.thinking,
+                sub_msg->data.agent_result.text,
+                sub_msg->data.agent_result.in_tokens,
+                sub_msg->data.agent_result.out_tokens,
+                sub_msg->data.agent_result.cache_read_tokens,
+                sub_msg->data.agent_result.cache_creation_tokens,
+                sub_msg->data.agent_result.request_count);
+            StrBuf ctx;
+            sb_init(&ctx);
+            sb_appendf(&ctx, "[sub-agent %s] %s (in=%d, out=%d)\nThinking: %s\nText: %s",
+                       sub_msg->data.agent_result.session_id,
+                       sub_msg->data.agent_result.status,
+                       sub_msg->data.agent_result.in_tokens,
+                       sub_msg->data.agent_result.out_tokens,
+                       sub_msg->data.agent_result.thinking ? sub_msg->data.agent_result.thinking : "",
+                       sub_msg->data.agent_result.text ? sub_msg->data.agent_result.text : "");
+            store_conv_add_user(agent->paths.conversation, ctx.data);
+            sb_free(&ctx);
+            drained++;
+        }
+        input_message_free(sub_msg);
+        free(sub_msg);
+    }
+    return drained;
+}
+
 int agent_run_loop(Agent *agent, const char *user_input, const char *turn_kind) {
     int rc = agent_loop(agent, user_input, turn_kind);
     agent_update_title_status(agent, "idle");
@@ -798,36 +835,7 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
         agent->interrupted = 0;
 
         /* drain SubAgent 结果（对齐 bash agent_drain_notify_buf） */
-        while (1) {
-            void *sub_data = NULL;
-            if (mq_try_pop(agent->sub_result_queue, &sub_data) != 0) break;
-            InputMessage *sub_msg = (InputMessage *)sub_data;
-            if (sub_msg && sub_msg->type == MSG_AGENT_RESULT) {
-                agent_handle_sub_agent_result(agent,
-                    sub_msg->data.agent_result.session_id,
-                    sub_msg->data.agent_result.status,
-                    sub_msg->data.agent_result.thinking,
-                    sub_msg->data.agent_result.text,
-                    sub_msg->data.agent_result.in_tokens,
-                    sub_msg->data.agent_result.out_tokens,
-                    sub_msg->data.agent_result.cache_read_tokens,
-                    sub_msg->data.agent_result.cache_creation_tokens,
-                    sub_msg->data.agent_result.request_count);
-                StrBuf ctx;
-                sb_init(&ctx);
-                sb_appendf(&ctx, "[sub-agent %s] %s (in=%d, out=%d)\nThinking: %s\nText: %s",
-                           sub_msg->data.agent_result.session_id,
-                           sub_msg->data.agent_result.status,
-                           sub_msg->data.agent_result.in_tokens,
-                           sub_msg->data.agent_result.out_tokens,
-                           sub_msg->data.agent_result.thinking ? sub_msg->data.agent_result.thinking : "",
-                           sub_msg->data.agent_result.text ? sub_msg->data.agent_result.text : "");
-                store_conv_add_user(agent->paths.conversation, ctx.data);
-                sb_free(&ctx);
-            }
-            input_message_free(sub_msg);
-            free(sub_msg);
-        }
+        agent_drain_sub_results(agent);
 
         /* compact */
         agent_compact_context(agent, "auto");
@@ -1211,7 +1219,11 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
 
         sse_accum_free(accum);
 
-        if (!should_continue) break;
+        if (!should_continue) {
+            /* end_turn 后尝试 drain（对齐 bash agent_drain_notify_buf && continue） */
+            if (agent_drain_sub_results(agent) > 0 && !agent->interrupted) continue;
+            break;
+        }
         if (agent->interrupted) break;
     }
 

--- a/c/agent.c
+++ b/c/agent.c
@@ -1645,33 +1645,8 @@ int agent_main_loop(Agent *agent) {
                 }
                 break;
             }
-            case MSG_AGENT_RESULT: {
-                /* SubAgent 结果处理（非交互模式下直接到达此处） */
-                agent_handle_sub_agent_result(agent,
-                    msg->data.agent_result.session_id,
-                    msg->data.agent_result.status,
-                    msg->data.agent_result.thinking,
-                    msg->data.agent_result.text,
-                    msg->data.agent_result.in_tokens,
-                    msg->data.agent_result.out_tokens,
-                    msg->data.agent_result.cache_read_tokens,
-                    msg->data.agent_result.cache_creation_tokens,
-                    msg->data.agent_result.request_count);
-
-                /* 将结果注入 conversation 并触发 agent loop */
-                StrBuf ctx;
-                sb_init(&ctx);
-                sb_appendf(&ctx, "[sub-agent %s] %s (in=%d, out=%d)\nThinking: %s\nText: %s",
-                           msg->data.agent_result.session_id,
-                           msg->data.agent_result.status,
-                           msg->data.agent_result.in_tokens,
-                           msg->data.agent_result.out_tokens,
-                           msg->data.agent_result.thinking ? msg->data.agent_result.thinking : "",
-                           msg->data.agent_result.text ? msg->data.agent_result.text : "");
-                agent_run_loop(agent, ctx.data, "sub_agent_result");
-                sb_free(&ctx);
+            default:
                 break;
-            }
         }
 
         input_message_free(msg);

--- a/c/agent.c
+++ b/c/agent.c
@@ -218,7 +218,7 @@ typedef struct {
     char *description;
     int fork_mode;
     char *sub_session_id;
-    MsgQueue *input_queue;
+    MsgQueue *sub_result_queue;
 } SubAgentArgs;
 
 /* ============================================================
@@ -243,6 +243,8 @@ Agent *agent_create(const char *provider, const char *model,
     a->interactive = interactive;
     a->input_queue = input_queue;
     a->display_queue = display_queue;
+    a->sub_result_queue = malloc(sizeof(MsgQueue));
+    mq_init(a->sub_result_queue);
     a->max_tokens = 16384;
     a->max_turns = 1000;
     a->max_context_tokens = 200000;
@@ -323,6 +325,10 @@ void agent_destroy(Agent *agent) {
         free(agent->skill_names);
     }
     store_session_paths_free(&agent->paths);
+    if (agent->sub_result_queue) {
+        mq_destroy(agent->sub_result_queue);
+        free(agent->sub_result_queue);
+    }
     free(agent);
 }
 
@@ -790,6 +796,38 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
     while (turn < agent->max_turns) {
         turn++;
         agent->interrupted = 0;
+
+        /* drain SubAgent 结果（对齐 bash agent_drain_notify_buf） */
+        while (1) {
+            void *sub_data = NULL;
+            if (mq_try_pop(agent->sub_result_queue, &sub_data) != 0) break;
+            InputMessage *sub_msg = (InputMessage *)sub_data;
+            if (sub_msg && sub_msg->type == MSG_AGENT_RESULT) {
+                agent_handle_sub_agent_result(agent,
+                    sub_msg->data.agent_result.session_id,
+                    sub_msg->data.agent_result.status,
+                    sub_msg->data.agent_result.thinking,
+                    sub_msg->data.agent_result.text,
+                    sub_msg->data.agent_result.in_tokens,
+                    sub_msg->data.agent_result.out_tokens,
+                    sub_msg->data.agent_result.cache_read_tokens,
+                    sub_msg->data.agent_result.cache_creation_tokens,
+                    sub_msg->data.agent_result.request_count);
+                StrBuf ctx;
+                sb_init(&ctx);
+                sb_appendf(&ctx, "[sub-agent %s] %s (in=%d, out=%d)\nThinking: %s\nText: %s",
+                           sub_msg->data.agent_result.session_id,
+                           sub_msg->data.agent_result.status,
+                           sub_msg->data.agent_result.in_tokens,
+                           sub_msg->data.agent_result.out_tokens,
+                           sub_msg->data.agent_result.thinking ? sub_msg->data.agent_result.thinking : "",
+                           sub_msg->data.agent_result.text ? sub_msg->data.agent_result.text : "");
+                store_conv_add_user(agent->paths.conversation, ctx.data);
+                sb_free(&ctx);
+            }
+            input_message_free(sub_msg);
+            free(sub_msg);
+        }
 
         /* compact */
         agent_compact_context(agent, "auto");
@@ -1557,7 +1595,7 @@ int agent_main_loop(Agent *agent) {
                  * 才显示下一轮提示符。 */
                 while (agent->active_sub_count > 0) {
                     void *sub_data = NULL;
-                    if (mq_pop(agent->input_queue, &sub_data) != 0) break;
+                    if (mq_pop(agent->sub_result_queue, &sub_data) != 0) break;
                     InputMessage *sub_msg = (InputMessage *)sub_data;
                     if (!sub_msg) continue;
 
@@ -1584,9 +1622,6 @@ int agent_main_loop(Agent *agent) {
                                    sub_msg->data.agent_result.text ? sub_msg->data.agent_result.text : "");
                         agent_run_loop(agent, ctx.data, "sub_agent_result");
                         sb_free(&ctx);
-                    } else {
-                        /* 简单处理：也执行它 */
-                        agent_run_loop(agent, sub_msg->data.user_input.text, "user_input");
                     }
                     input_message_free(sub_msg);
                     free(sub_msg);
@@ -1662,7 +1697,7 @@ static void *sub_agent_thread_fn(void *arg) {
         msg->data.agent_result.session_id = util_strdup(args->sub_session_id);
         msg->data.agent_result.status = util_strdup("failed");
         msg->data.agent_result.text = util_strdup("Failed to create sub-agent");
-        mq_push(args->input_queue, msg);
+        mq_push(args->sub_result_queue, msg);
         goto cleanup;
     }
 
@@ -1731,7 +1766,7 @@ static void *sub_agent_thread_fn(void *arg) {
     msg->data.agent_result.cache_read_tokens = sub->last_cache_read_tokens;
     msg->data.agent_result.cache_creation_tokens = sub->last_cache_creation_tokens;
     msg->data.agent_result.request_count = store_stats_get_file_int(sub->paths.stats, "agent_request_count");
-    mq_push(args->input_queue, msg);
+    mq_push(args->sub_result_queue, msg);
 
     agent_destroy(sub);
 
@@ -1799,7 +1834,7 @@ char *agent_handle_sub_agent(Agent *agent, const char *prompt,
     args->description = util_strdup(description);
     args->fork_mode = 0;  /* fork 已在主线程完成 */
     args->sub_session_id = util_strdup(sub_session_id);
-    args->input_queue = agent->input_queue;
+    args->sub_result_queue = agent->sub_result_queue;
 
     pthread_t thread;
     pthread_create(&thread, NULL, sub_agent_thread_fn, args);

--- a/c/agent.c
+++ b/c/agent.c
@@ -1840,19 +1840,6 @@ int agent_handle_sub_agent_result(Agent *agent, const char *session_id,
                                    int in_tokens, int out_tokens,
                                    int cache_read, int cache_creation,
                                    int request_count) {
-    agent->active_sub_count--;
-
-    /* 显示结果（事件已手动写入，只推显示队列不重复写事件） */
-    DisplayMessage *dm = malloc(sizeof(DisplayMessage));
-    *dm = display_msg_sub_agent_result(session_id, status, thinking,
-                                       text, in_tokens, out_tokens);
-    if (!store_event_stream_json_enabled()) {
-        mq_push(agent->display_queue, dm);
-    } else {
-        display_message_free(dm);
-        free(dm);
-    }
-
     /* 记录 usage 事件（kind=sub_agent, sub_session_id） */
     {
         StrBuf evt;
@@ -1866,26 +1853,7 @@ int agent_handle_sub_agent_result(Agent *agent, const char *session_id,
         sb_free(&evt);
     }
 
-    /* 更新统计 — 对齐 bash 版 agent_handle_sub_result:
-     * store_stats_update total_input_tokens=+N total_output_tokens=+N
-     *   total_cache_read_tokens=+N total_cache_creation_tokens=+N
-     *   sub_agent_request_count=+1 agent_request_count=+N */
-    store_stats_set_int_file(agent->paths.stats, "total_input_tokens",
-        store_stats_get_file_int(agent->paths.stats, "total_input_tokens") + in_tokens);
-    store_stats_set_int_file(agent->paths.stats, "total_output_tokens",
-        store_stats_get_file_int(agent->paths.stats, "total_output_tokens") + out_tokens);
-    store_stats_set_int_file(agent->paths.stats, "total_cache_read_tokens",
-        store_stats_get_file_int(agent->paths.stats, "total_cache_read_tokens") + cache_read);
-    store_stats_set_int_file(agent->paths.stats, "total_cache_creation_tokens",
-        store_stats_get_file_int(agent->paths.stats, "total_cache_creation_tokens") + cache_creation);
-    store_stats_set_int_file(agent->paths.stats, "sub_agent_request_count",
-        store_stats_get_file_int(agent->paths.stats, "sub_agent_request_count") + 1);
-    /* agent_request_count 累加子 agent 的请求数 */
-    store_stats_set_int_file(agent->paths.stats, "agent_request_count",
-        store_stats_get_file_int(agent->paths.stats, "agent_request_count") + request_count);
-    agent_update_title(agent);
-
-    /* 记录 sub_agent_result 事件 — 对齐 bash 版，供 replay 和 stream-json 复现 */
+    /* 记录 sub_agent_result 事件 — 供 replay 和 stream-json 复现 */
     {
         StrBuf evt;
         sb_init(&evt);
@@ -1903,7 +1871,7 @@ int agent_handle_sub_agent_result(Agent *agent, const char *session_id,
         sb_free(&evt);
     }
 
-    /* 记录 sub_agent_end 事件 — 对齐 bash 版，带 timestamp */
+    /* 记录 sub_agent_end 事件 — 带 timestamp */
     {
         time_t now = time(NULL);
         struct tm tm_buf;
@@ -1921,6 +1889,35 @@ int agent_handle_sub_agent_result(Agent *agent, const char *session_id,
         sb_append(&evt, "}");
         store_event_append(&agent->paths, evt.data);
         sb_free(&evt);
+    }
+
+    /* 更新统计 */
+    store_stats_set_int_file(agent->paths.stats, "total_input_tokens",
+        store_stats_get_file_int(agent->paths.stats, "total_input_tokens") + in_tokens);
+    store_stats_set_int_file(agent->paths.stats, "total_output_tokens",
+        store_stats_get_file_int(agent->paths.stats, "total_output_tokens") + out_tokens);
+    store_stats_set_int_file(agent->paths.stats, "total_cache_read_tokens",
+        store_stats_get_file_int(agent->paths.stats, "total_cache_read_tokens") + cache_read);
+    store_stats_set_int_file(agent->paths.stats, "total_cache_creation_tokens",
+        store_stats_get_file_int(agent->paths.stats, "total_cache_creation_tokens") + cache_creation);
+    store_stats_set_int_file(agent->paths.stats, "sub_agent_request_count",
+        store_stats_get_file_int(agent->paths.stats, "sub_agent_request_count") + 1);
+    store_stats_set_int_file(agent->paths.stats, "agent_request_count",
+        store_stats_get_file_int(agent->paths.stats, "agent_request_count") + request_count);
+    agent_update_title(agent);
+
+    /* 递减活跃子 agent 计数 */
+    agent->active_sub_count--;
+
+    /* 显示结果（推 display 队列） */
+    DisplayMessage *dm = malloc(sizeof(DisplayMessage));
+    *dm = display_msg_sub_agent_result(session_id, status, thinking,
+                                       text, in_tokens, out_tokens);
+    if (!store_event_stream_json_enabled()) {
+        mq_push(agent->display_queue, dm);
+    } else {
+        display_message_free(dm);
+        free(dm);
     }
 
     return 0;

--- a/c/agent.h
+++ b/c/agent.h
@@ -75,8 +75,9 @@ typedef struct {
     int active_sub_count;
 
     /* 消息队列 */
-    MsgQueue *input_queue;  /* 外部传入，agent_loop 从中读取 */
-    MsgQueue *display_queue;/* 外部传入，agent_loop 向其写入 */
+    MsgQueue *input_queue;      /* 外部传入，agent_loop 从中读取 */
+    MsgQueue *display_queue;    /* 外部传入，agent_loop 向其写入 */
+    MsgQueue *sub_result_queue; /* SubAgent 结果队列（对齐 bash NOTIFY_FIFO） */
 
     /* 中断标志 */
     volatile int interrupted;

--- a/c/msgqueue.c
+++ b/c/msgqueue.c
@@ -82,6 +82,22 @@ int mq_pop(MsgQueue *q, void **data_out) {
     return 0;
 }
 
+int mq_try_pop(MsgQueue *q, void **data_out) {
+    pthread_mutex_lock(&q->mutex);
+    if (!q->head) {
+        pthread_mutex_unlock(&q->mutex);
+        return -1;
+    }
+    MQNode *node = q->head;
+    q->head = node->next;
+    if (!q->head) q->tail = NULL;
+    q->count--;
+    pthread_mutex_unlock(&q->mutex);
+    *data_out = node->data;
+    free(node);
+    return 0;
+}
+
 int mq_count(MsgQueue *q) {
     pthread_mutex_lock(&q->mutex);
     int n = q->count;

--- a/c/msgqueue.h
+++ b/c/msgqueue.h
@@ -48,6 +48,11 @@ int mq_push(MsgQueue *q, void *data);
  */
 int mq_pop(MsgQueue *q, void **data_out);
 
+/*
+ * 非阻塞出队 — 队列为空时立即返回 -1
+ */
+int mq_try_pop(MsgQueue *q, void **data_out);
+
 /* 当前队列长度 */
 int mq_count(MsgQueue *q);
 

--- a/docs/BASH_ARCHITECTURE.md
+++ b/docs/BASH_ARCHITECTURE.md
@@ -16,13 +16,23 @@
 │  FD 3 ← INPUT_FIFO (读端)                            │
 │  FD 5 → INPUT_FIFO (写端, 防止 EOF)                   │
 │  FD 4 → display_stream 子进程 (RESP 消息)              │
+│  FD 6 ↔ NOTIFY_FIFO (双端打开, 读 sub-agent 结果)      │
 │  FD 7 ← agent_loop_stream 管道                        │
 │  FD 8 ← llm_call 管道                                │
 │                                                      │
 │  ┌──────────────────────┐                           │
 │  │ agent_loop_stream()   │ (process substitution)    │
 │  │  FD 8 ← llm_call 管道 │                          │
-│  │  → FD 4 (display)     │                          │
+│  │  → FD 7 (agent_loop)  │                          │
+│  │  agent_drain_notify_  │                          │
+│  │    buf() 消费结果      │                          │
+│  └──────────────────────┘                           │
+│                                                      │
+│  ┌──────────────────────┐                           │
+│  │ notify reader (子shell)│ (background)              │
+│  │  FD 6 ← NOTIFY_FIFO   │                          │
+│  │  → NOTIFY_BUF (文件)   │                          │
+│  │  → FD 5 NOTIFY_PENDING│                          │
 │  └──────────────────────┘                           │
 │                                                      │
 │  ┌──────────────────────┐                           │
@@ -34,7 +44,7 @@
 
 Sub-Agent (后台子进程):
   ( ... ) &  — 在子 shell 中执行 agent_loop
-  完成后通过 store_sub_send_result 写入父进程的 INPUT_FIFO
+  完成后通过 store_sub_send_result 写入父进程的 NOTIFY_FIFO
 ```
 
 ### 1.2 FD 分配（固定）
@@ -44,9 +54,10 @@ Sub-Agent (后台子进程):
 | 3 | 读 | INPUT_FIFO 读取端 | agent_main_loop |
 | 4 | 写 | display_stream 管道 | agent_main_loop |
 | 5 | 写 | INPUT_FIFO 写入端（保持打开防 EOF） | agent_main_loop / interactive_mode |
+| 6 | 读写 | NOTIFY_FIFO 双端打开（防写者关闭后 EOF） | notify reader 子 shell |
 | 7 | 读 | agent_loop_stream → agent_loop 管道 | agent_loop |
 | 8 | 读 | llm_call → agent_loop_stream 管道 | agent_loop_stream |
-| 9 | 读 | curl SSE 流 | llm_stream_curl |
+| 9 | 读 | NOTIFY_BUF 临时文件读取 | agent_drain_notify_buf |
 
 ### 1.3 RESP 消息协议
 
@@ -73,9 +84,9 @@ $len1\r\ndata1\r\n   — 字段1
 | ERROR | message | LLM/内部 |
 | RETRY | (无) | LLM SSE (retry 信号) |
 | CONTEXT_UPDATE | kind, trigger | compact |
-| SUB_AGENT_RESULT | session_id, status, in, out, thinking, text | sub-agent |
+| AGENT_RESULT | session_id, status, in, out, thinking, text | sub-agent 完成（NOTIFY_FIFO） |
+| NOTIFY_PENDING | (无) | notify reader → 主循环（触发 notify turn） |
 | USER_INPUT | seq, content | 用户输入 |
-| AGENT_RESULT | session_id, status, thinking, text, in, out, cr, cc, reqs | sub-agent 完成 |
 | SESSION_END | code | 退出 |
 | IMAGE_DESCRIBE | images, description | 图片描述 |
 | USER_MESSAGE | content | 用户消息回显 |
@@ -312,35 +323,76 @@ agent_main_loop() {
     until exec 3< "$INPUT_FIFO"; do sleep 0.01; done  # 等待 FIFO 可读
     exec 5> "$INPUT_FIFO"  # 保持写端打开，防止 EOF
     exec 4> >(display_stream)  # 启动 display 子进程
-    local display_pid=$! active_sub_count=0
-    
-    while util_read_msg <&3; do
+    local display_pid=$! saw_user_input=false
+
+    # 后台 notify reader：阻塞读 NOTIFY_FIFO → 写入 NOTIFY_BUF + 记录事件统计
+    (
+        trap - INT EXIT
+        exec 6<> "$NOTIFY_FIFO" 2>/dev/null  # 双端打开，防止写者关闭后 EOF
+        while util_read_msg <&6; do
+            case "${REPLY_MESSAGE[0]}" in
+                AGENT_RESULT)
+                    # 解析字段
+                    _sid="${REPLY_MESSAGE[1]}" _status="${REPLY_MESSAGE[2]}"
+                    _thinking="${REPLY_MESSAGE[3]}" _text="${REPLY_MESSAGE[4]}"
+                    _in="${REPLY_MESSAGE[5]}" _out="${REPLY_MESSAGE[6]}" ...
+
+                    # 记录事件（usage, sub_agent_result, sub_agent_end）
+                    store_event_append ...
+
+                    # AGENT_RESULT RESP 追加到 NOTIFY_BUF
+                    util_write_msg "AGENT_RESULT" ... >> "$NOTIFY_BUF"
+
+                    # 递减 ACTIVE_SUB_FILE 计数器（大于 0 才减）
+                    _cnt=$(cat "$ACTIVE_SUB_FILE"); (( _cnt > 0 )) && _cnt--
+
+                    # idle 时（无 AGENT_RUNNING_FLAG）触发 notify turn
+                    if [[ ! -f "$AGENT_RUNNING_FLAG" ]]; then
+                        util_write_msg "NOTIFY_PENDING" >&5
+                    fi
+                    ;;
+            esac
+        done
+    ) &
+    local _notify_pid=$!
+
+    while true; do
+        util_read_msg <&3 || break
         case "${REPLY_MESSAGE[0]}" in
             SESSION_END) break ;;
-            USER_INPUT)  agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}" ;;
-            AGENT_RESULT)
-                if [[ "$INTERRUPT_REQUESTED" == true ]]; then
-                    agent_handle_sub_result true   # silent mode
-                else
-                    agent_handle_sub_result        # normal mode
+            USER_INPUT)
+                saw_user_input=true
+                agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
+                # 非交互模式：无活跃子 agent 且无待读结果 → 退出
+                if [[ "$INTERACTIVE" != true ]]; then
+                    local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]] && util_write_msg "SESSION_END" >&5
+                fi
+                ;;
+            NOTIFY_PENDING)
+                [[ -s "$NOTIFY_BUF" ]] && agent_run_loop "" notify
+                if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
+                    local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]] && util_write_msg "SESSION_END" >&5
                 fi
                 ;;
         esac
-        # 非交互模式且没有活跃 sub-agent → 退出
-        [[ "$INTERACTIVE" != true ]] && (( active_sub_count == 0 )) && break
     done
-    
-    exec 4>&-  # 关闭 display 管道
+
+    kill "$_notify_pid" 2>/dev/null; wait "$_notify_pid" 2>/dev/null || true
+    exec 4>&-
     wait "$display_pid" 2>/dev/null || true
     cleanup_all_pipes
-    rm -f "$INPUT_FIFO"
+    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$AGENT_RUNNING_FLAG"
 }
 ```
 
-**关键细节**：
-- `active_sub_count`：跟踪活跃 sub-agent 数量。TOOL_CALL SubAgent 时 +1，AGENT_RESULT 时 -1
-- 非交互模式下，如果没有活跃 sub-agent 就退出循环
-- INTERRUPT_REQUESTED 时 sub-agent 结果静默处理（不显示回显）
+**关键设计变化（vs 旧版）**：
+- **双 FIFO**：INPUT_FIFO（用户输入 + NOTIFY_PENDING）+ NOTIFY_FIFO（SubAgent 结果）
+- **notify reader 子 shell**：后台阻塞读 NOTIFY_FIFO，解析 AGENT_RESULT，写入 NOTIFY_BUF
+- **ACTIVE_SUB_FILE**：文件计数器（替代旧的内存变量 `active_sub_count`），在 `tool_sub_agent` 中子进程创建前递增，在 notify reader 中递减
+- **AGENT_RUNNING_FLAG**：标记 agent_loop_stream 是否运行中。运行中时 notify reader 不发 NOTIFY_PENDING（靠 `agent_drain_notify_buf` 在下一轮迭代消费）
+- **退出判断**：`_cnt <= 0 && NOTIFY_BUF 空 → SESSION_END`
 
 ### 5.3 agent_loop()
 
@@ -389,22 +441,28 @@ agent_loop() {
 ```bash
 agent_loop_stream() {
     local user_input="$1" turn=0
-    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes' INT
+    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
     
     while (( turn < MAX_TURNS )); do
         (( turn++ ))
         
-        # ① Compact before LLM call
+        # ① agent_loop 运行中标记（notify reader 见此标记不发 NOTIFY_PENDING）
+        : > "$AGENT_RUNNING_FLAG"
+        
+        # ② 消费 NOTIFY_BUF（SubAgent 结果），在 LLM 调用前处理
+        agent_drain_notify_buf || true
+        
+        # ③ Compact before LLM call
         agent_compact_context auto && util_write_msg "CONTEXT_UPDATE" "compact" "auto"
         
-        # ② LLM call
+        # ④ LLM call
         exec 8< <(llm_call "$(store_conv_get_messages)")
         
-        # ③ 读取 SSE 消息流
+        # ⑤ 读取 SSE 消息流
         while util_read_msg <&8; do
             if INTERRUPT_REQUESTED → stop="interrupted"; break
             
-            util_write_msg "${REPLY_MESSAGE[@]}"  # 转发给 display（FD 4）
+            util_write_msg "${REPLY_MESSAGE[@]}"  # 转发给 agent_loop (FD 7)
             
             case type:
                 RETRY → 重置 text/thinking/tool_calls/tool_conv_results/_ctx_tokens
@@ -418,32 +476,43 @@ agent_loop_stream() {
         done
         exec 8<&-
         
-        # ④ Interrupted → emit STOP interrupted, break
+        # ⑥ Interrupted → emit STOP interrupted, break
         [[ INTERRUPT_REQUESTED ]] && { util_write_msg "STOP" "interrupted"; break; }
         
-        # ⑤ Fatal stop → return 1
+        # ⑦ Fatal stop → return 1
         case stop:
             error|max_tokens|length → 
                 stop != error 时 emit ERROR "Response truncated (max_tokens reached)"
                 return 1
         esac
         
-        # ⑥ 持久化（非 interrupted）
+        # ⑧ 持久化（非 interrupted）
         store_conv_add_assistant "$text" "$thinking" "$tool_calls"
         if tool_conv_results:
             store_conv_add_tool_results "$tool_conv_results"
         if _ctx_tokens > 0:
             store_stats_update current_context_tokens=${_ctx_tokens}
         
-        # ⑦ 继续/退出
-        stop == tool_use|tool_calls → continue loop
-        else → emit STOP, break
+        # ⑨ 继续/退出
+        if stop == tool_use|tool_calls → continue loop
+        else:
+            rm -f "$AGENT_RUNNING_FLAG"       # 移除运行标记
+            agent_drain_notify_buf && continue  # 有 SubAgent 结果 → 继续处理
+            util_write_msg "STOP" "$stop"
+            break
     done
     
     # Max turns reached
     (( turn >= MAX_TURNS )) && util_write_msg "ERROR" "Max turns ($MAX_TURNS) reached"
+    rm -f "$AGENT_RUNNING_FLAG"
 }
 ```
+
+**新增设计（vs 旧版）**：
+- 每轮迭代开头创建 `AGENT_RUNNING_FLAG`，结束时移除
+- 每轮迭代开头和 end_turn 后都调用 `agent_drain_notify_buf` 消费 SubAgent 结果
+- end_turn 后如果有 SubAgent 结果 → `continue` 继续处理（不打断流式输出）
+- **`agent_drain_notify_buf` 消费时**：RESP 解析 → AGENT_RESULT 转发 FD 4（display_sub_agent_result 原始格式）→ 从字段构建纯文本注入 conversation
 
 **RETRY 处理细节**：
 当收到 RETRY 消息时，重置所有累积变量：`text="" thinking="" tool_calls="" tool_conv_results="" _ctx_tokens=""`。这是为了丢弃 retry 前的部分响应。
@@ -684,23 +753,31 @@ tool_plan_clear() {
 ```bash
 tool_sub_agent() {
     sub_session_id = "sub_$(util_new_session_id)"
+    fork = "${3:-false}"  # 默认 false
+    [[ "$fork" == "true" ]] || fork=false  # 归一化
     
-    # 记录 sub_agent_start 事件
-    store_event_append '{"type":"sub_agent_start",...}'
+    # 记录 sub_agent_start 事件（stdout 重定向到 /dev/null 防污染）
+    store_event_append '{"type":"sub_agent_start",...}' >/dev/null
+    
+    # 子进程创建前递增计数器（消除竞态：先加后创建）
+    __cnt=$(cat "$ACTIVE_SUB_FILE"); printf '%d\n' $(( __cnt + 1 )) > "$ACTIVE_SUB_FILE"
     
     # 后台子 shell
     (
+        _parent_notify_fifo="$NOTIFY_FIFO"  # 捕获父进程 NOTIFY_FIFO 路径
+        
         if fork == "true":
-            store_session_fork(parent_dir, sub_dir)  # 复制 conversation/summary/plan
+            store_session_fork(parent_dir, sub_dir)
         export SESSION_ID=sub_session_id
         export INTERACTIVE=false
-        store_session_init
+        store_session_init          # 创建子会话目录（含新的 INPUT_FIFO/NOTIFY_FIFO）
         util_load_tool_defs
-        trap 'store_sub_send_result ...; rm -f INPUT_FIFO' EXIT
-        exec </dev/null >/dev/null 2>&1  # 完全静默
-        exec 3<&- 4<&- 5<&- 8<&- ...  # 关闭所有继承的 FD
+        # Silence：在 store_session_init 之后关闭 FD
+        exec </dev/null >/dev/null 2>&1
+        exec 3<&- 4<&- 5<&- 8<&-
+        trap 'store_sub_send_result ... "$_parent_notify_fifo"; exec 6<&-; rm -f $INPUT_FIFO $NOTIFY_FIFO $NOTIFY_BUF $ACTIVE_SUB_FILE' EXIT
         agent_loop "$prompt" && _status="ok"
-        store_sub_send_result "$sub_session_id" "$_status" "$_parent_input_fifo"
+        store_sub_send_result "$sub_session_id" "$_status" "$_parent_notify_fifo"
     ) &
     
     printf 'Sub-agent started: session_id=%s, pid=%s' "$sub_session_id" "$!"
@@ -872,7 +949,11 @@ tool_bash_mode_allows() {
   plan.md             — 已确认计划
   plan.draft          — 计划草稿
   images/             — 粘贴的图片
-  input.fifo          — 输入管道（运行时）
+  input.fifo          — 用户输入管道（运行时）
+  notify.fifo         — SubAgent 结果通知管道（运行时）
+  notify.buf          — SubAgent 结果缓冲（NOTIFY_BUF，RESP 格式）
+  active_sub.count    — 活跃 SubAgent 计数器
+  agent_running.flag  — agent_loop_stream 运行中标记
 ```
 
 ### 9.2 project_key 计算
@@ -1055,7 +1136,7 @@ display_stream() { while util_read_msg; do display_message; done }
 | THINKING | 灰色 `\033[90m...\033[0m`；`PREV_WAS_THINKING=true` |
 | TOOL_CALL | 黄色 `\033[33m[tool] summary\033[0m`；调用 `tool_call_summary` |
 | TOOL_RESULT | Edit→全量输出+换行；Read/Write→第一行+换行；其他→全量+换行 |
-| SUB_AGENT_RESULT | 紫色/红色状态行；thinking 截断 120 字符；text 截断 120 字符 |
+| AGENT_RESULT | 紫色/红色状态行；thinking 截断 120 字符；text 截断 120 字符 |
 | IMAGE_DESCRIBE | 青色 `📸 images: description` |
 | USER_MESSAGE | 绿色 `> text`（截断 80 字符） |
 | STOP | interrupted → 青色 "Interrupted."；其他 → 确保换行 |
@@ -1098,21 +1179,34 @@ fi
 
 ## 11. SubAgent 机制
 
-### 11.1 启动流程
+### 11.1 双 FIFO 架构
 
-1. 生成 `sub_session_id = "sub_$(util_new_session_id)"`
-2. 记录 `sub_agent_start` 事件
-3. 后台子 shell：
+```
+INPUT_FIFO:  用户输入 + NOTIFY_PENDING（主循环读）
+NOTIFY_FIFO: SubAgent 结果（notify reader 读）
+
+NOTIFY_BUF:  SubAgent 结果缓冲文件（RESP 格式）
+ACTIVE_SUB_FILE: 活跃计数器（文件）
+AGENT_RUNNING_FLAG: agent_loop_stream 运行标记（文件）
+```
+
+### 11.2 启动流程
+
+1. `sub_session_id = "sub_$(util_new_session_id)"`
+2. `fork="${3:-false}"`，归一化为 `true` 或 `false`
+3. 记录 `sub_agent_start` 事件（`>/dev/null`）
+4. **子进程创建前**递增 `ACTIVE_SUB_FILE` 计数器
+5. 后台子 shell：
+   - 捕获父进程 `NOTIFY_FIFO` 路径
    - fork=true 时复制 conversation/summary/plan
-   - 设置新的 SESSION_ID
-   - `store_session_init`（创建新会话目录）
-   - trap EXIT：发送结果到父 INPUT_FIFO
-   - 关闭所有继承的 FD（3/4/5/8）
+   - 设置新 `SESSION_ID`，`store_session_init`
    - `exec </dev/null >/dev/null 2>&1`（完全静默）
+   - 关闭所有继承的 FD（3/4/5/8）
+   - trap EXIT：`store_sub_send_result` 写入父进程的 `NOTIFY_FIFO`
    - `agent_loop "$prompt"`
-   - `store_sub_send_result` 发送结果
+   - `store_sub_send_result`
 
-### 11.2 结果传递
+### 11.3 结果传递
 
 ```bash
 store_sub_send_result() {
@@ -1120,28 +1214,42 @@ store_sub_send_result() {
     # - thinking (最后一条 assistant 的 thinking)
     # - text (最后一条 assistant 的 text)
     # - usage 统计 (in/out/cr/cc)
-    # 写入父进程的 INPUT_FIFO
+    # 写入父进程的 NOTIFY_FIFO（不是 INPUT_FIFO）
 }
 ```
 
-### 11.3 结果处理
+### 11.4 notify reader（后台子 shell）
+
+阻塞读 `NOTIFY_FIFO`，处理 `AGENT_RESULT` 消息：
+
+1. 记录事件：`usage`(kind=sub_agent) + `sub_agent_result` + `sub_agent_end`
+2. 更新统计：`store_stats_update total_input_tokens=+N ...`
+3. 将 `AGENT_RESULT` RESP 追加到 `NOTIFY_BUF`
+4. 递减 `ACTIVE_SUB_FILE`（大于 0 才减）
+5. 如果 `AGENT_RUNNING_FLAG` 不存在（idle）→ 发 `NOTIFY_PENDING` 到 `INPUT_FIFO`
+
+### 11.5 agent_drain_notify_buf()
+
+在 `agent_loop_stream` 每轮迭代开头和 end_turn 后调用：
+
+1. 原子 `mv` NOTIFY_BUF 到临时文件
+2. `exec 9< tmpfile`；逐条 `util_read_msg <&9` 解析 RESP
+3. 对每条 `AGENT_RESULT`：
+   - **display**：转发 RESP 到 FD 4 → `display_sub_agent_result`（完全复用原始格式）
+   - **conversation**：从结构化字段构建纯文本，`store_conv_add_user`
+
+### 11.6 非交互模式退出逻辑
 
 ```bash
-agent_handle_sub_result() {
-    # REPLY_MESSAGE: AGENT_RESULT session_id status thinking text in out cr cc reqs
-    
-    # 1. 记录 usage 事件 (kind=sub_agent, sub_session_id)
-    # 2. 更新 stats: total tokens += sub stats, sub_agent_request_count++, agent_request_count += reqs
-    # 3. 记录 sub_agent_result 事件 (供 replay)
-    # 4. 记录 sub_agent_end 事件
-    # 5. active_sub_count--
-    # 6. silent 模式 → return（不显示不触发 LLM）
-    # 7. 发送 SUB_AGENT_RESULT 给 display
-    # 8. 注入 conversation 触发 agent_run_loop:
-    #    "[sub-agent session_id] status (in=N, out=N)\nThinking: ...\nText: ..."
-    #    turn_kind = sub_agent_result
-}
+# USER_INPUT handler:
+_cnt=$(cat "$ACTIVE_SUB_FILE")
+(( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]] && SESSION_END
+
+# NOTIFY_PENDING handler:
+# 同上，额外检查 saw_user_input
 ```
+
+`cat` 而非 `$(<file)`：因为 `$(<file 2>/dev/null || echo 0)` 对已存在文件返回空字符串（Bash `$(<file)` 特殊语法被 `||` 破坏）。
 
 ---
 
@@ -1315,11 +1423,13 @@ Bash 工具输出通过 `sanitize_utf8.awk` 清理非法 UTF-8 字节。
 ### 16.2 util_json_escape
 
 ```bash
-# 转义: \ " \n \r \t \b \f
-_s="${_s//\\/\\\\}" _s="${_s//\"/\\\"}" _s="${_s//$'\n'/\\n}" _s="${_s//$'\r'/\\r}" _s="${_s//$'\t'/\\t}" _s="${_s//$'\b'/\\b}" _s="${_s//$'\f'/\\f}"
+# 通过 awk 管道转义（复用 json.awk 的 escape_json_string 函数）
+printf '%s' "${1:-}" | util_awk_run -v json_mode=escape_string -f "$AWK_DIR/json.awk" -f "$AWK_DIR/json_cli.awk"
 ```
 
-**注意**：不转义 Unicode 控制字符（如 \u0000-\u001f 中除上述 6 个之外的）。也不转义 `/`。
+**为什么用 awk 而不是纯 Bash**：纯 Bash 的 `${_s//\\/\\\\}` 对 28KB system prompt 需要约 9 秒/次（多次全局替换），awk 仅需约 4ms/次。
+
+**注意**：不转义 Unicode 控制字符（如 \u0000-\u001f 中除 `\ " \n \r \t \b \f` 之外的）。也不转义 `/`。
 
 ---
 

--- a/go/agent.go
+++ b/go/agent.go
@@ -1118,10 +1118,6 @@ func (a *Agent) runSubAgent(ctx context.Context, sessionID, prompt, fork string)
 
 // handleSubAgentResult 处理子 agent 结果
 func (a *Agent) handleSubAgentResult(r SubAgentResult) {
-	a.subMu.Lock()
-	a.pendingSubAgents--
-	a.subMu.Unlock()
-
 	// 记录 usage 事件（带 kind=sub_agent, sub_session_id）
 	usageEvent := map[string]interface{}{
 		"type":                        "usage",
@@ -1171,6 +1167,11 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 
 	// 更新 store 的 stats（与 bash 版 store_stats_update total_input_tokens=+_in ... agent_request_count=+_reqs 一致）
 	a.store.UpdateSubAgentStats(r.InputTokens, r.OutputTokens, r.CacheRead, r.CacheWrite, r.Requests)
+
+	// 递减活跃子 agent 计数（在事件和统计之后，对齐 bash 顺序）
+	a.subMu.Lock()
+	a.pendingSubAgents--
+	a.subMu.Unlock()
 
 	// 构造注入消息
 	injectMsg := fmt.Sprintf("[sub-agent %s] %s (in=%d, out=%d)\nThinking: %s\nText: %s",

--- a/go/agent.go
+++ b/go/agent.go
@@ -793,6 +793,9 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 	}()
 
 	for turn := 0; turn < a.cfg.MaxTurns; turn++ {
+		// Drain SubAgent results that arrived during previous LLM call（对齐 bash agent_drain_notify_buf）
+		a.drainSubAgentResults(ctx)
+
 		// Compact
 		if compacted, _ := a.CompactContext(ctx, "auto"); compacted {
 			a.EmitDisplay(Event{Type: EventContextUpdate, Fields: []string{"CONTEXT_UPDATE", "compact", "auto"}})
@@ -990,9 +993,26 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 	return nil
 }
 
+// drainSubAgentResults 消费所有已到达但未处理的 SubAgent 结果（对齐 bash agent_drain_notify_buf）
+func (a *Agent) drainSubAgentResults(ctx context.Context) {
+	for {
+		select {
+		case r := <-a.subResultCh:
+			a.handleSubAgentResult(r)
+		case <-ctx.Done():
+			return
+		default:
+			return
+		}
+	}
+}
+
 // ─── SubAgent 启动（异步 goroutine）───
 
 func (a *Agent) LaunchSubAgent(ctx context.Context, prompt, description, fork string) (string, error) {
+	if fork != "true" {
+		fork = "false"
+	}
 	sessionID := "sub_" + UtilNewSessionID()
 
 	// 记录 sub_agent_start 事件
@@ -1139,7 +1159,7 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 	a.EmitDisplay(Event{
 		Type: EventSubAgentResult,
 		Fields: []string{
-			"SUB_AGENT_RESULT",
+			"AGENT_RESULT",
 			r.SessionID,
 			r.Status,
 			fmt.Sprintf("%d", r.InputTokens),

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -363,7 +363,7 @@ func replayEvents(a *agent.Agent, store agent.SessionStore, display *agent.TermD
 			}
 			thinking, _ := ev["thinking"].(string)
 			text, _ := ev["text"].(string)
-			display.ShowEvent(agent.Event{Type: agent.EventSubAgentResult, Fields: []string{"SUB_AGENT_RESULT", sid, status, in, out, thinking, text}})
+			display.ShowEvent(agent.Event{Type: agent.EventSubAgentResult, Fields: []string{"AGENT_RESULT", sid, status, in, out, thinking, text}})
 		case "image_describe":
 			images, _ := ev["images"].(string)
 			desc, _ := ev["content"].(string)

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -352,6 +352,7 @@ enum DisplayEvent {
         images: String,
         description: String,
     },
+    Title(String), // 终端标题（OSC 序列），通过 display worker 序列化避免与 text 交织
 }
 
 enum DisplayCommand {
@@ -493,6 +494,11 @@ fn render_display_event(
             }
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
+        }
+        DisplayEvent::Title(title) => {
+            // OSC 序列直接写 stderr，通过 display worker 序列化避免与 text delta 交织
+            let _ = write!(io::stderr(), "{}", title);
+            let _ = io::stderr().flush();
         }
     }
     Ok(())
@@ -1595,6 +1601,7 @@ impl Agent {
             DisplayEvent::ContextUpdate(_) => {}
             DisplayEvent::SubAgentResult { .. } => {}
             DisplayEvent::ImageDescribe { .. } => {}
+            DisplayEvent::Title(_) => {}
         }
         if let Some(tx) = &self.display_tx {
             tx.send(DisplayCommand::Event(evt))
@@ -1973,8 +1980,7 @@ impl Agent {
         };
         let prefix = if status == "idle" { "" } else { "⏳ " };
         let progress = if status == "idle" { 0 } else { 3 };
-        let _ = write!(
-            self.stderr.borrow_mut(),
+        let title = format!(
             "\x1b]0;{}{} T:{} R:{} I:{}({}) O:{} C:{}\x07\x1b]9;4;{}\x07",
             prefix,
             self.cfg.model,
@@ -1986,7 +1992,14 @@ impl Agent {
             Self::fmt_num(ctx),
             progress
         );
-        let _ = self.stderr.borrow_mut().flush();
+        // 通过 display worker 序列化输出，避免与 text delta 交织
+        if self.display_tx.is_some() {
+            self.queue_display_only(DisplayEvent::Title(title));
+        } else {
+            // 子 agent 无 display worker，直接写 stderr
+            let _ = write!(self.stderr.borrow_mut(), "{}", title);
+            let _ = self.stderr.borrow_mut().flush();
+        }
     }
 
     fn is_stream_json_mode(&self) -> bool {

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -1197,10 +1197,18 @@ impl Agent {
     fn drain_sub_results(&mut self) -> bool {
         let mut drained = false;
         while let Ok(msg) = self.sub_result_rx.try_recv() {
-            if let MainLoopMessage::AgentResult { session_id, status, thinking, text, in_tokens, out_tokens, cache_read_tokens, cache_creation_tokens, request_count: _ } = msg {
+            if let MainLoopMessage::AgentResult { session_id, status, thinking, text, in_tokens, out_tokens, cache_read_tokens, cache_creation_tokens, request_count } = msg {
                 let _ = self.append_event(json!({"type":"usage","input_tokens":in_tokens,"output_tokens":out_tokens,"cache_read_input_tokens":cache_read_tokens,"cache_creation_input_tokens":cache_creation_tokens,"kind":"sub_agent","sub_session_id":&session_id}));
                 let _ = self.emit_and_append_event(json!({"type":"sub_agent_result","session_id":&session_id,"status":&status,"input_tokens":in_tokens,"output_tokens":out_tokens,"thinking":&thinking,"text":&text}));
                 let _ = self.append_event(json!({"type":"sub_agent_end","session_id":&session_id,"timestamp":chrono_like_now(),"status":&status}));
+                let _ = store::store_stats_update(&self.paths.stats, |stats| {
+                    Self::add_stat_usize(stats, "sub_agent_request_count", 1);
+                    Self::add_stat_usize(stats, "agent_request_count", request_count);
+                    Self::add_stat_usize(stats, "total_input_tokens", in_tokens);
+                    Self::add_stat_usize(stats, "total_output_tokens", out_tokens);
+                    Self::add_stat_usize(stats, "total_cache_read_tokens", cache_read_tokens);
+                    Self::add_stat_usize(stats, "total_cache_creation_tokens", cache_creation_tokens);
+                });
                 if self.active_sub_count > 0 { self.active_sub_count -= 1; }
                 let ctx = format!("[sub-agent {}] {} (in={}, out={})\nThinking: {}\nText: {}", session_id, status, in_tokens, out_tokens, thinking, text);
                 let _ = self.queue_display_event(DisplayEvent::SubAgentResult { session_id, status, thinking, text, in_tokens, out_tokens });

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -1197,6 +1197,25 @@ impl Agent {
         Ok(())
     }
 
+    /// drain SubAgent 结果：events + stats + display + conversation 注入（对齐 bash agent_drain_notify_buf）
+    /// 返回 true 如果消费了至少一条结果
+    fn drain_sub_results(&mut self) -> bool {
+        let mut drained = false;
+        while let Ok(msg) = self.sub_result_rx.try_recv() {
+            if let MainLoopMessage::AgentResult { session_id, status, thinking, text, in_tokens, out_tokens, cache_read_tokens, cache_creation_tokens, request_count: _ } = msg {
+                let _ = self.append_event(json!({"type":"usage","input_tokens":in_tokens,"output_tokens":out_tokens,"cache_read_input_tokens":cache_read_tokens,"cache_creation_input_tokens":cache_creation_tokens,"kind":"sub_agent","sub_session_id":&session_id}));
+                let _ = self.emit_and_append_event(json!({"type":"sub_agent_result","session_id":&session_id,"status":&status,"input_tokens":in_tokens,"output_tokens":out_tokens,"thinking":&thinking,"text":&text}));
+                let _ = self.append_event(json!({"type":"sub_agent_end","session_id":&session_id,"timestamp":chrono_like_now(),"status":&status}));
+                if self.active_sub_count > 0 { self.active_sub_count -= 1; }
+                let ctx = format!("[sub-agent {}] {} (in={}, out={})\nThinking: {}\nText: {}", session_id, status, in_tokens, out_tokens, thinking, text);
+                let _ = self.queue_display_event(DisplayEvent::SubAgentResult { session_id, status, thinking, text, in_tokens, out_tokens });
+                let _ = self.conv.add_user(&ctx);
+                drained = true;
+            }
+        }
+        drained
+    }
+
     /// 检查是否被中断（per-agent 标志 + 全局 SIGINT 标志）
     fn is_interrupted(&self) -> bool {
         self.interrupted.load(Ordering::SeqCst) || CTRLC_FLAG.load(Ordering::SeqCst)
@@ -1277,17 +1296,7 @@ impl Agent {
                 turn += 1;
 
                 // Drain SubAgent 结果（对齐 bash agent_drain_notify_buf）
-                while let Ok(msg) = self.sub_result_rx.try_recv() {
-                    if let MainLoopMessage::AgentResult { session_id, status, thinking, text, in_tokens, out_tokens, cache_read_tokens, cache_creation_tokens, request_count: _ } = msg {
-                        let _ = self.append_event(json!({"type":"usage","input_tokens":in_tokens,"output_tokens":out_tokens,"cache_read_input_tokens":cache_read_tokens,"cache_creation_input_tokens":cache_creation_tokens,"kind":"sub_agent","sub_session_id":&session_id}));
-                        let _ = self.emit_and_append_event(json!({"type":"sub_agent_result","session_id":&session_id,"status":&status,"input_tokens":in_tokens,"output_tokens":out_tokens,"thinking":&thinking,"text":&text}));
-                        let _ = self.append_event(json!({"type":"sub_agent_end","session_id":&session_id,"timestamp":chrono_like_now(),"status":&status}));
-                        if self.active_sub_count > 0 { self.active_sub_count -= 1; }
-                        let ctx = format!("[sub-agent {}] {} (in={}, out={})\nThinking: {}\nText: {}", session_id, status, in_tokens, out_tokens, thinking, text);
-                        let _ = self.queue_display_event(DisplayEvent::SubAgentResult { session_id, status, thinking, text, in_tokens, out_tokens });
-                        let _ = self.conv.add_user(&ctx);
-                    }
-                }
+                self.drain_sub_results();
 
                 // Compact before each LLM call: uses ctx_tokens from previous call's USAGE
                 let _ = self.compact_context_window("auto");
@@ -1488,6 +1497,8 @@ impl Agent {
                     }
                     // tool_use/tool_calls → loop continues; anything else → break
                     if stop.as_str() != "tool_use" && stop.as_str() != "tool_calls" {
+                        // end_turn 后尝试 drain（对齐 bash agent_drain_notify_buf && continue）
+                        if self.drain_sub_results() { continue; }
                         CTRLC_FLAG.store(false, Ordering::SeqCst);
                         return Ok(());
                     }

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -1091,12 +1091,7 @@ impl Agent {
 
                     // 不再通知 readline 线程 — 它已经在下一轮 EditStart
                 }
-                MainLoopMessage::AgentResult { .. } => {
-                    // 在交互模式下，AgentResult 应该在 UserInput 的内部 while 循环中被处理。
-                    // 如果走到这里，说明是非交互模式或者异常情况。
-                    // 非交互模式下直接忽略（active_sub_count 不会 > 0 因为没有 while 循环等待）。
-                    // 保留此分支以防意外。
-                }
+                _ => {}
             }
 
             // 非交互模式且无活跃子 agent 时退出

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -211,7 +211,7 @@ pub fn agent_run(cfg: Config, cwd: PathBuf, home: PathBuf) -> Result<()> {
     }
     // 等待所有子 agent 完成（bash 版没有超时，Ctrl+C 可杀）
     while rt.active_sub_count > 0 {
-        match rt.msg_rx.recv() {
+        match rt.sub_result_rx.recv() {
             Ok(MainLoopMessage::AgentResult {
                 session_id,
                 status,
@@ -269,6 +269,8 @@ struct Agent {
     last_cache_creation_tokens: usize,
     msg_tx: Arc<Mutex<Option<mpsc::Sender<MainLoopMessage>>>>, // 主循环消息队列发送端（Arc<Mutex<Option>> 以便 readline 线程退出时主动 drop）
     msg_rx: mpsc::Receiver<MainLoopMessage>, // 主循环消息队列接收端
+    sub_result_rx: mpsc::Receiver<MainLoopMessage>, // SubAgent 结果专用通道（对齐 NOTIFY_FIFO）
+    sub_result_tx: Arc<mpsc::Sender<MainLoopMessage>>, // SubAgent 结果发送端
     active_sub_count: usize,                 // 活跃子 agent 计数
     sub_agent_request_count: usize,          // SubAgent 请求计数
     stdout: RefCell<Box<dyn Write + Send>>,  // 可替换的输出目标（子 agent 时为 sink）
@@ -629,6 +631,8 @@ impl Agent {
         let transport = Arc::from(crate::transport::new_transport(&cfg));
         let (msg_tx, msg_rx) = mpsc::channel(); // 初始化消息队列
         let msg_tx = Arc::new(Mutex::new(Some(msg_tx))); // 包装在 Arc<Mutex<Option>> 中
+        let (_sub_result_tx, sub_result_rx) = mpsc::channel(); // SubAgent 结果专用通道
+        let sub_result_tx = Arc::new(_sub_result_tx);
 
         let (display_tx, display_handle) = if cfg.output_format == OutputFormat::StreamJson {
             (None, None)
@@ -656,6 +660,8 @@ impl Agent {
             last_cache_creation_tokens: 0,
             msg_tx,
             msg_rx,
+            sub_result_rx,
+            sub_result_tx,
             active_sub_count: 0,
             sub_agent_request_count: 0,
             stdout: RefCell::new(Box::new(io::stdout())),
@@ -701,7 +707,7 @@ impl Agent {
         let cwd = self.cwd.clone();
         let home = self.home.clone();
         let cfg = self.cfg.clone();
-        let msg_tx_arc = self.msg_tx.clone();
+        let msg_tx_arc = self.sub_result_tx.clone(); // 子 agent 结果发送到专用通道
         let sub_session_id_clone = sub_session_id.clone();
         let parent_paths = self.paths.clone();
         let fork = fields.get("fork").map(|s| s == "true" || s == "1").unwrap_or(false);
@@ -721,20 +727,17 @@ impl Agent {
             let sub_conv = Store { path: sub_paths.conversation.clone() };
             if let Err(e) = sub_conv.ensure() {
                 // 早期失败时发送失败结果，让主进程减少 active_sub_count
-                let tx_guard = msg_tx_arc.lock().unwrap();
-                if let Some(tx) = tx_guard.as_ref() {
-                    let _ = tx.send(MainLoopMessage::AgentResult {
-                        session_id: sub_session_id_clone.clone(),
-                        status: "failed".to_string(),
-                        thinking: String::new(),
-                        text: format!("Failed to create sub-agent conversation: {}", e),
-                        in_tokens: 0,
-                        out_tokens: 0,
-                        cache_read_tokens: 0,
-                        cache_creation_tokens: 0,
-                        request_count: 0,
-                    });
-                }
+                let _ = msg_tx_arc.send(MainLoopMessage::AgentResult {
+                    session_id: sub_session_id_clone.clone(),
+                    status: "failed".to_string(),
+                    thinking: String::new(),
+                    text: format!("Failed to create sub-agent conversation: {}", e),
+                    in_tokens: 0,
+                    out_tokens: 0,
+                    cache_read_tokens: 0,
+                    cache_creation_tokens: 0,
+                    request_count: 0,
+                });
                 return;
             }
 
@@ -747,6 +750,7 @@ impl Agent {
             sub_cfg.interactive = false;
 
             let (sub_msg_tx, _sub_msg_rx) = mpsc::channel();
+            let (sub_rtx, sub_rrx) = mpsc::channel();
             let mut sub_rt = Agent {
                 cfg: sub_cfg,
                 cwd: cwd.clone(),
@@ -766,6 +770,8 @@ impl Agent {
                 last_cache_creation_tokens: 0,
                 msg_tx: Arc::new(Mutex::new(Some(sub_msg_tx))),
                 msg_rx: _sub_msg_rx,
+                sub_result_rx: sub_rrx,
+                sub_result_tx: Arc::new(sub_rtx),
                 active_sub_count: 0,
                 sub_agent_request_count: 0,
                 stdout: RefCell::new(Box::new(io::empty())),  // 子 agent 输出全部丢弃（与 Go 的 io.Discard、Bash 的 >/dev/null 对应）
@@ -787,20 +793,17 @@ impl Agent {
                 Ok(l) => l,
                 Err(e) => {
                     // 通过消息队列发送失败结果，让主进程减少计数
-                    let tx_guard = msg_tx_arc.lock().unwrap();
-                    if let Some(tx) = tx_guard.as_ref() {
-                        let _ = tx.send(MainLoopMessage::AgentResult {
-                            session_id: sub_session_id_clone,
-                            status: "failed".to_string(),
-                            thinking: String::new(),
-                            text: format!("Sub-agent failed: {}", e),
-                            in_tokens: 0,
-                            out_tokens: 0,
-                            cache_read_tokens: 0,
-                            cache_creation_tokens: 0,
-                            request_count: 0,
-                        });
-                    }
+                    let _ = msg_tx_arc.send(MainLoopMessage::AgentResult {
+                        session_id: sub_session_id_clone,
+                        status: "failed".to_string(),
+                        thinking: String::new(),
+                        text: format!("Sub-agent failed: {}", e),
+                        in_tokens: 0,
+                        out_tokens: 0,
+                        cache_read_tokens: 0,
+                        cache_creation_tokens: 0,
+                        request_count: 0,
+                    });
                     return;
                 }
             };
@@ -849,20 +852,17 @@ impl Agent {
             let request_count = stats_get_f64(&stats, "agent_request_count") as usize;
 
             // 6. 通过消息队列发送结果
-            let tx_guard = msg_tx_arc.lock().unwrap();
-            if let Some(tx) = tx_guard.as_ref() {
-                let _ = tx.send(MainLoopMessage::AgentResult {
-                    session_id: sub_session_id_clone,
-                    status: status.to_string(),
-                    thinking: result_thinking,
-                    text: result_text,
-                    in_tokens,
-                    out_tokens,
-                    cache_read_tokens,
-                    cache_creation_tokens,
-                    request_count,
-                });
-            }
+            let _ = msg_tx_arc.send(MainLoopMessage::AgentResult {
+                session_id: sub_session_id_clone,
+                status: status.to_string(),
+                thinking: result_thinking,
+                text: result_text,
+                in_tokens,
+                out_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+                request_count,
+            });
         });
 
         format!("Sub-agent started: session_id={}", sub_session_id)
@@ -1058,7 +1058,7 @@ impl Agent {
                     // 直到全部完成后再返回主循环（readline 已在下一轮 EditStart）。
                     // display worker 的 hide/show 保证输出不会与 linenoise 冲突。
                     while self.active_sub_count > 0 {
-                        match self.msg_rx.recv() {
+                        match self.sub_result_rx.recv() {
                             Ok(MainLoopMessage::AgentResult {
                                 session_id,
                                 status,
@@ -1275,6 +1275,19 @@ impl Agent {
             let mut turn = 0;
             while turn < self.cfg.max_turns {
                 turn += 1;
+
+                // Drain SubAgent 结果（对齐 bash agent_drain_notify_buf）
+                while let Ok(msg) = self.sub_result_rx.try_recv() {
+                    if let MainLoopMessage::AgentResult { session_id, status, thinking, text, in_tokens, out_tokens, cache_read_tokens, cache_creation_tokens, request_count: _ } = msg {
+                        let _ = self.append_event(json!({"type":"usage","input_tokens":in_tokens,"output_tokens":out_tokens,"cache_read_input_tokens":cache_read_tokens,"cache_creation_input_tokens":cache_creation_tokens,"kind":"sub_agent","sub_session_id":&session_id}));
+                        let _ = self.emit_and_append_event(json!({"type":"sub_agent_result","session_id":&session_id,"status":&status,"input_tokens":in_tokens,"output_tokens":out_tokens,"thinking":&thinking,"text":&text}));
+                        let _ = self.append_event(json!({"type":"sub_agent_end","session_id":&session_id,"timestamp":chrono_like_now(),"status":&status}));
+                        if self.active_sub_count > 0 { self.active_sub_count -= 1; }
+                        let ctx = format!("[sub-agent {}] {} (in={}, out={})\nThinking: {}\nText: {}", session_id, status, in_tokens, out_tokens, thinking, text);
+                        let _ = self.queue_display_event(DisplayEvent::SubAgentResult { session_id, status, thinking, text, in_tokens, out_tokens });
+                        let _ = self.conv.add_user(&ctx);
+                    }
+                }
 
                 // Compact before each LLM call: uses ctx_tokens from previous call's USAGE
                 let _ = self.compact_context_window("auto");

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -269,6 +269,7 @@ use std::path::{Path, PathBuf};
     }
 
     pub fn store_session_fork(parent: &Paths, child: &Paths) -> Result<()> {
+        fs::create_dir_all(&child.session_dir)?; // 先建目录（对齐 Bash mkdir -p）
         let files_to_copy: [(&Path, &Path); 3] = [
             (&parent.conversation, &child.conversation),
             (&parent.summary, &child.summary),

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -469,7 +469,6 @@ store_session_resolve_continue() {
     fi
 }
 
-# 记录事件到当前 session 的 events.jsonl
 store_event_append() {
     [[ -n "${SESSION_EVENT_FILE:-}" ]] || return 0
     if util_is_stream_json; then printf '%s\n' "$1" | tee -a "$SESSION_EVENT_FILE"; else printf '%s\n' "$1" >> "$SESSION_EVENT_FILE"; fi
@@ -1317,17 +1316,13 @@ agent_main_loop() {
                     local _in="${REPLY_MESSAGE[5]:-0}" _out="${REPLY_MESSAGE[6]:-0}"
                     local _cr="${REPLY_MESSAGE[7]:-0}" _cc="${REPLY_MESSAGE[8]:-0}"
                     local _reqs="${REPLY_MESSAGE[9]:-0}"
-                    # 记录事件和统计（写文件，进程安全）
                     store_event_append "{\"type\":\"usage\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"cache_read_input_tokens\":$_cr,\"cache_creation_input_tokens\":$_cc,\"kind\":\"sub_agent\",\"sub_session_id\":\"$(util_json_escape "$_sid")\"}"
                     store_event_append "{\"type\":\"sub_agent_result\",\"session_id\":\"$(util_json_escape "$_sid")\",\"status\":\"$_status\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"thinking\":\"$(util_json_escape "$_thinking")\",\"text\":\"$(util_json_escape "$_text")\"}"
                     store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
-                    # AGENT_RESULT RESP 追加到 NOTIFY_BUF（消费时解析：display + conversation）
                     util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
-                    # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
-                    # idle 时触发 notify turn（display 由 agent_drain_notify_buf 消费时处理）
                     if [[ ! -f "$AGENT_RUNNING_FLAG" ]]; then
                         util_write_msg "NOTIFY_PENDING" >&5
                     fi
@@ -1346,42 +1341,16 @@ agent_main_loop() {
             USER_INPUT)
                 saw_user_input=true
                 agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
-                # drain 可能在 agent_loop_stream 运行期间到达的 SubAgent 结果
-                # drain 任何在 agent_loop_stream 运行期间到达的 SubAgent 结果
-                while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
-                # 非交互模式：等待所有子进程完成后再退出
                 if [[ "$INTERACTIVE" != true ]]; then
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    # 循环等待：只要还有活跃子 agent 或未读结果，就不退出
-                    while (( _cnt > 0 )) || [[ -s "$NOTIFY_BUF" ]]; do
-                        # 等待 0.1s 让子进程有机会完成
-                        sleep 0.1 2>/dev/null || true
-                        if [[ -s "$NOTIFY_BUF" ]]; then
-                            agent_run_loop "" notify
-                        fi
-                        _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    done
-                    if [[ ! -s "$NOTIFY_BUF" ]]; then
-                        util_write_msg "SESSION_END" >&5
-                    fi
+                    (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]] && util_write_msg "SESSION_END" >&5
                 fi
                 ;;
             NOTIFY_PENDING)
                 [[ -s "$NOTIFY_BUF" ]] && agent_run_loop "" notify
-                # 持续 drain 可能同时到达的更多结果
-                while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
                 if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    while (( _cnt > 0 )) || [[ -s "$NOTIFY_BUF" ]]; do
-                        sleep 0.1 2>/dev/null || true
-                        if [[ -s "$NOTIFY_BUF" ]]; then
-                            agent_run_loop "" notify
-                        fi
-                        _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    done
-                    if [[ ! -s "$NOTIFY_BUF" ]]; then
-                        util_write_msg "SESSION_END" >&5
-                    fi
+                    (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]] && util_write_msg "SESSION_END" >&5
                 fi
                 ;;
         esac
@@ -1401,9 +1370,7 @@ agent_drain_notify_buf() {
     exec 9<"$_nb_tmp"
     while util_read_msg <&9; do
         if [[ "${REPLY_MESSAGE[0]}" == "AGENT_RESULT" ]]; then
-            # display：转发 AGENT_RESULT RESP → display_sub_agent_result（复用原始格式）
             util_is_stream_json || util_write_msg "AGENT_RESULT" "${REPLY_MESSAGE[@]:1}" >&4 2>/dev/null || true
-            # conversation：从结构化字段构建纯文本
             local _sid="${REPLY_MESSAGE[1]}" _st="${REPLY_MESSAGE[2]}" _in="${REPLY_MESSAGE[3]}" _out="${REPLY_MESSAGE[4]}"
             local _th="${REPLY_MESSAGE[5]}" _tx="${REPLY_MESSAGE[6]}"
             _conv+="[sub-agent ${_sid}] ${_st} (in=${_in}, out=${_out})"$'\n'
@@ -1423,9 +1390,8 @@ agent_loop_stream() {
     trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
-        # 通知后台 reader：agent_loop 在运行中（notify 走 buffer，不直接触发 NOTIFY_PENDING）
+        # agent_loop 运行中标记（notify reader 见此标记不发 NOTIFY_PENDING，靠 drain 消费）
         : > "$AGENT_RUNNING_FLAG"
-        # Drain NOTIFY_BUF before each LLM call: 原子 mv 读清
         agent_drain_notify_buf || true
         # Compact before each LLM call: uses ctx_tokens from previous call's USAGE
         agent_compact_context auto && util_write_msg "CONTEXT_UPDATE" "compact" "auto"
@@ -1527,7 +1493,6 @@ agent_loop() {
     while util_read_msg <&7; do
         _type="${REPLY_MESSAGE[0]-}"
         _reason="${REPLY_MESSAGE[1]-}"
-        # SubAgent counter incremented in tool_sub_agent (before child process spawn)
         _se=$(util_msg_to_stream) && [[ -n "$_se" ]] && store_event_append "$_se"
         util_is_stream_json || ( util_write_msg "${REPLY_MESSAGE[@]}" ) >&4 2>/dev/null || true
         if [[ "$_type" == "ERROR" ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -419,6 +419,12 @@ store_session_init() {
     fi
     INPUT_FIFO="${session_dir}/input.fifo"
     [[ -p "$INPUT_FIFO" ]] || { rm -f "$INPUT_FIFO"; mkfifo "$INPUT_FIFO"; }
+    NOTIFY_FIFO="${session_dir}/notify.fifo"
+    NOTIFY_BUF="${session_dir}/notify.buf"
+    ACTIVE_SUB_FILE="${session_dir}/active_sub.count"
+    AGENT_RUNNING_FLAG="/tmp/agent_loop_active.$$"
+    [[ -p "$NOTIFY_FIFO" ]] || { rm -f "$NOTIFY_FIFO"; mkfifo "$NOTIFY_FIFO"; }
+    printf 0 > "$ACTIVE_SUB_FILE"
 }
 
 store_session_fork() {
@@ -1026,17 +1032,17 @@ tool_sub_agent() {
         fi
         export SESSION_ID="$sub_session_id"
         export INTERACTIVE=false
-        local _parent_input_fifo="$INPUT_FIFO"
+        local _parent_notify_fifo="$NOTIFY_FIFO"
         store_session_init
         util_load_tool_defs
         local _done=false _status="failed"
-        trap '[[ "$_done" == true ]] || store_sub_send_result "$sub_session_id" "$_status" "$_parent_input_fifo"; rm -f "$INPUT_FIFO"' EXIT
+        trap '[[ "$_done" == true ]] || store_sub_send_result "$sub_session_id" "$_status" "$_parent_notify_fifo"; exec 6<&- 2>/dev/null; rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$ACTIVE_SUB_FILE"' EXIT
         # Silence the child shell completely; close all inherited FDs
         exec </dev/null >/dev/null 2>&1
-        exec 3<&- 2>/dev/null; exec 4<&- 2>/dev/null
-        exec 8<&- 2>/dev/null; exec 5<&- 2>/dev/null
+        exec 3<&- 2>/dev/null; exec 4<&- 2>/dev/null; exec 5<&- 2>/dev/null
+        exec 8<&- 2>/dev/null
         agent_loop "$prompt" && _status="ok"
-        store_sub_send_result "$sub_session_id" "$_status" "$_parent_input_fifo"
+        store_sub_send_result "$sub_session_id" "$_status" "$_parent_notify_fifo"
         _done=true
     ) &
 
@@ -1269,28 +1275,6 @@ agent_record_usage() {
     echo $(( _in + _out + _cr + _cc ))
 }
 
-agent_handle_sub_result() {
-    local silent="${1:-false}"
-    # REPLY_MESSAGE: AGENT_RESULT <session_id> <status> <thinking> <text> <in> <out> <cr> <cc> <reqs>
-    local session_id="${REPLY_MESSAGE[1]}" status="${REPLY_MESSAGE[2]}"
-    local _thinking="${REPLY_MESSAGE[3]}" _text="${REPLY_MESSAGE[4]}"
-    local _in="${REPLY_MESSAGE[5]:-0}" _out="${REPLY_MESSAGE[6]:-0}"
-    local _cr="${REPLY_MESSAGE[7]:-0}" _cc="${REPLY_MESSAGE[8]:-0}"
-    local _reqs="${REPLY_MESSAGE[9]:-0}"
-    # 记录 usage（带 kind=sub_agent, sub_session_id）
-    store_event_append "{\"type\":\"usage\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"cache_read_input_tokens\":$_cr,\"cache_creation_input_tokens\":$_cc,\"kind\":\"sub_agent\",\"sub_session_id\":\"$(util_json_escape "$session_id")\"}"
-    store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
-    # 记录 sub_agent_result 事件，供 replay 和 stream-json 复现子 agent 回显
-    store_event_append "{\"type\":\"sub_agent_result\",\"session_id\":\"$(util_json_escape "$session_id")\",\"status\":\"$status\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"thinking\":\"$(util_json_escape "$_thinking")\",\"text\":\"$(util_json_escape "$_text")\"}"
-    # 记录 sub_agent_end 事件
-    store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$session_id")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$status\"}"
-    active_sub_count=$(( active_sub_count - 1 ))
-    [[ "$silent" == true ]] && return 0
-    # 展示结果摘要——通过 fd 7 交给 display_stream，不直接写 stdout（避免和子进程争终端）
-    util_is_stream_json || ( util_write_msg "SUB_AGENT_RESULT" "$session_id" "$status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
-    agent_run_loop "[sub-agent $session_id] $status (in=$_in, out=$_out)"$'\n'"Thinking: $_thinking"$'\n'"Text: $_text" sub_agent_result
-}
-
 # 调用 agent_loop 并处理交互式终端提示符
 
 agent_run_loop() {
@@ -1310,6 +1294,7 @@ cleanup_all_pipes() {
     exec 4>&- 2>/dev/null   # display_stream 管道
     exec 5>&- 2>/dev/null   # INPUT_FIFO 写入端
     exec 3<&- 2>/dev/null   # INPUT_FIFO 读取端
+    exec 6<&- 2>/dev/null   # NOTIFY_FIFO 读取端
     exec 7<&- 2>/dev/null   # agent_loop_stream 管道 (agent_loop)
     exec 8<&- 2>/dev/null   # llm_call 管道 (agent_loop_stream)
 }
@@ -1318,37 +1303,96 @@ agent_main_loop() {
     until exec 3< "$INPUT_FIFO"; do sleep 0.01; done 2>/dev/null
     exec 5> "$INPUT_FIFO"  # keep write end open to prevent premature EOF
     exec 4> >(display_stream)
-    local display_pid=$! active_sub_count=0
-    while util_read_msg <&3; do
+    local display_pid=$! saw_user_input=false
+
+    # 后台 notify reader：阻塞读 NOTIFY_FIFO → 写入 NOTIFY_BUF(XML) + 记录事件和统计
+    (
+        trap - INT EXIT
+        exec 6<> "$NOTIFY_FIFO" 2>/dev/null  # `<>` 双端打开，防止写者关闭后 EOF
+        while util_read_msg <&6; do
+            case "${REPLY_MESSAGE[0]}" in
+                SUB_AGENT_RESULT)
+                    local _sid="${REPLY_MESSAGE[1]}" _status="${REPLY_MESSAGE[2]}"
+                    local _thinking="${REPLY_MESSAGE[3]}" _text="${REPLY_MESSAGE[4]}"
+                    local _in="${REPLY_MESSAGE[5]:-0}" _out="${REPLY_MESSAGE[6]:-0}"
+                    local _cr="${REPLY_MESSAGE[7]:-0}" _cc="${REPLY_MESSAGE[8]:-0}"
+                    local _reqs="${REPLY_MESSAGE[9]:-0}"
+                    # 记录事件和统计（写文件，进程安全）
+                    store_event_append "{\"type\":\"usage\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"cache_read_input_tokens\":$_cr,\"cache_creation_input_tokens\":$_cc,\"kind\":\"sub_agent\",\"sub_session_id\":\"$(util_json_escape "$_sid")\"}"
+                    store_event_append "{\"type\":\"sub_agent_result\",\"session_id\":\"$(util_json_escape "$_sid")\",\"status\":\"$_status\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"thinking\":\"$(util_json_escape "$_thinking")\",\"text\":\"$(util_json_escape "$_text")\"}"
+                    store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
+                    store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
+                    # 格式化文本追加到 NOTIFY_BUF
+                    {
+                        printf '[sub-agent %s] %s (in=%s, out=%s)\n' "$_sid" "$_status" "$_in" "$_out"
+                        printf 'Thinking: %s\n' "$_thinking"
+                        printf 'Text: %s\n' "$_text"
+                    } >> "$NOTIFY_BUF"
+                    # 递减 active_sub 计数器
+                    local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
+                    # 展示结果摘要到 display
+                    util_is_stream_json || ( util_write_msg "SUB_AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
+                    # idle（无 agent_loop_stream 在跑）→ 发 NOTIFY_PENDING 触发 notify turn
+                    if [[ ! -f "$AGENT_RUNNING_FLAG" ]]; then
+                        util_write_msg "NOTIFY_PENDING" >&5
+                    fi
+                    ;;
+            esac
+        done
+    ) &
+    local _notify_pid=$!
+
+    while true; do
+        util_read_msg <&3 || break
         case "${REPLY_MESSAGE[0]}" in
             SESSION_END)
                 break
                 ;;
             USER_INPUT)
+                saw_user_input=true
                 agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
+                # 非交互模式下，所有子 agent 完成后退出
+                if [[ "$INTERACTIVE" != true ]]; then
+                    local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    (( _cnt <= 0 )) && util_write_msg "SESSION_END" >&5
+                fi
                 ;;
-            AGENT_RESULT)
-                if [[ "$INTERRUPT_REQUESTED" == true ]]; then
-                    agent_handle_sub_result true
-                else
-                    agent_handle_sub_result
+            NOTIFY_PENDING)
+                agent_run_loop "" notify
+                if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
+                    local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    (( _cnt <= 0 )) && util_write_msg "SESSION_END" >&5
                 fi
                 ;;
         esac
-        [[ "$INTERACTIVE" != true ]] && (( active_sub_count == 0 )) && break
     done
+
+    kill "$_notify_pid" 2>/dev/null; wait "$_notify_pid" 2>/dev/null || true
     exec 4>&-
     wait "$display_pid" 2>/dev/null || true
     cleanup_all_pipes
-    rm -f "$INPUT_FIFO"
+    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$AGENT_RUNNING_FLAG"
 }
 
 agent_loop_stream() {
     local user_input="$1" turn=0
     # Trap SIGINT: close pipe FD to unblock read
-    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes' INT
+    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
+    # 通知后台 reader：agent_loop 在运行中（notify 走 buffer 不走 NOTIFY_PENDING）
+    : > "$AGENT_RUNNING_FLAG"
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
+        # Drain NOTIFY_BUF before each LLM call: 原子 mv 读清
+        if [[ -f "$NOTIFY_BUF" && -s "$NOTIFY_BUF" ]]; then
+            local _nb_tmp="${NOTIFY_BUF}.${$}"
+            if mv "$NOTIFY_BUF" "$_nb_tmp" 2>/dev/null; then
+                local _nb_content
+                _nb_content=$(<"$_nb_tmp")
+                rm -f "$_nb_tmp"
+                [[ -n "$_nb_content" ]] && store_conv_add_user "$_nb_content"
+            fi
+        fi
         # Compact before each LLM call: uses ctx_tokens from previous call's USAGE
         agent_compact_context auto && util_write_msg "CONTEXT_UPDATE" "compact" "auto"
         local text="" thinking="" tool_calls="" stop="" loop_error="" tool_conv_results="" _ctx_tokens=""
@@ -1415,6 +1459,7 @@ agent_loop_stream() {
     if (( turn >= MAX_TURNS )); then
         util_write_msg "ERROR" "Max turns ($MAX_TURNS) reached"
     fi
+    rm -f "$AGENT_RUNNING_FLAG"
 }
 
 agent_loop() {
@@ -1443,7 +1488,7 @@ agent_loop() {
     while util_read_msg <&7; do
         _type="${REPLY_MESSAGE[0]-}"
         _reason="${REPLY_MESSAGE[1]-}"
-        [[ "$_type" == "TOOL_CALL" && "$_reason" == "SubAgent" ]] && active_sub_count=$(( active_sub_count + 1 ))
+        [[ "$_type" == "TOOL_CALL" && "$_reason" == "SubAgent" ]] && { local __cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0); printf '%d\n' $(( __cnt + 1 )) > "$ACTIVE_SUB_FILE"; }
         _se=$(util_msg_to_stream) && [[ -n "$_se" ]] && store_event_append "$_se"
         util_is_stream_json || ( util_write_msg "${REPLY_MESSAGE[@]}" ) >&4 2>/dev/null || true
         if [[ "$_type" == "ERROR" ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -471,7 +471,7 @@ store_session_resolve_continue() {
     fi
 }
 
-# 处理子 agent 通过 FIFO 发回的 AGENT_RESULT 将 result_text 注入主 agent conversation，触发 agent_loop 让主 agent 处理
+# 记录事件到当前 session 的 events.jsonl
 store_event_append() {
     [[ -n "${SESSION_EVENT_FILE:-}" ]] || return 0
     if util_is_stream_json; then printf '%s\n' "$1" | tee -a "$SESSION_EVENT_FILE"; else printf '%s\n' "$1" >> "$SESSION_EVENT_FILE"; fi
@@ -1016,8 +1016,8 @@ tool_web_search() { curl -sS --connect-timeout 10 --max-time 30 -G --data-urlenc
 
 tool_web_fetch() { curl -sS --connect-timeout 10 --max-time 60 -H "Authorization: Bearer ${JINA_API_KEY:-}" "https://r.jina.ai/$1" 2>&1; }
 
-# 启动异步子 agent：后台执行 agent_loop，完成后通过 INPUT_FIFO 发回 AGENT_RESULT
-# 消息格式：AGENT_RESULT <session_id> <status:ok|failed> <result_text> <in> <out> <cr> <cc> <reqs>
+# 启动异步子 agent：后台执行 agent_loop，完成后通过 NOTIFY_FIFO 发回 AGENT_RESULT
+# 消息格式：AGENT_RESULT <session_id> <status:ok|failed> <thinking> <text> <in> <out> <cr> <cc> <reqs>
 tool_sub_agent() {
     local prompt="$1" description="${2:-}" fork="${3:-}" sub_session_id="sub_$(util_new_session_id)"
 
@@ -1355,7 +1355,7 @@ agent_main_loop() {
                 fi
                 ;;
             NOTIFY_PENDING)
-                agent_run_loop "" notify
+                [[ -s "$NOTIFY_BUF" ]] && agent_run_loop "" notify
                 if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt <= 0 )) && util_write_msg "SESSION_END" >&5
@@ -1371,24 +1371,26 @@ agent_main_loop() {
     rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$AGENT_RUNNING_FLAG"
 }
 
+agent_drain_notify_buf() {
+    [[ -f "$NOTIFY_BUF" && -s "$NOTIFY_BUF" ]] || return 1
+    local _nb_tmp="${NOTIFY_BUF}.${$}" _nb_content
+    mv "$NOTIFY_BUF" "$_nb_tmp" 2>/dev/null || return 1
+    _nb_content=$(<"$_nb_tmp")
+    rm -f "$_nb_tmp"
+    [[ -n "$_nb_content" ]] || return 1
+    store_conv_add_user "$_nb_content"
+}
+
 agent_loop_stream() {
     local user_input="$1" turn=0
     # Trap SIGINT: close pipe FD to unblock read
     trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
-    # 通知后台 reader：agent_loop 在运行中（notify 走 buffer 不走 NOTIFY_PENDING）
-    : > "$AGENT_RUNNING_FLAG"
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
+        # 通知后台 reader：agent_loop 在运行中（notify 走 buffer，不直接触发 NOTIFY_PENDING）
+        : > "$AGENT_RUNNING_FLAG"
         # Drain NOTIFY_BUF before each LLM call: 原子 mv 读清
-        if [[ -f "$NOTIFY_BUF" && -s "$NOTIFY_BUF" ]]; then
-            local _nb_tmp="${NOTIFY_BUF}.${$}"
-            if mv "$NOTIFY_BUF" "$_nb_tmp" 2>/dev/null; then
-                local _nb_content
-                _nb_content=$(<"$_nb_tmp")
-                rm -f "$_nb_tmp"
-                [[ -n "$_nb_content" ]] && store_conv_add_user "$_nb_content"
-            fi
-        fi
+        agent_drain_notify_buf || true
         # Compact before each LLM call: uses ctx_tokens from previous call's USAGE
         agent_compact_context auto && util_write_msg "CONTEXT_UPDATE" "compact" "auto"
         local text="" thinking="" tool_calls="" stop="" loop_error="" tool_conv_results="" _ctx_tokens=""
@@ -1445,8 +1447,13 @@ agent_loop_stream() {
             if [[ -n "$_ctx_tokens" && "$_ctx_tokens" -gt 0 ]]; then
                 store_stats_update current_context_tokens=${_ctx_tokens}
             fi
-            # tool_use/tool_calls → loop continues; anything else → break
-            [[ "$stop" == "tool_use" || "$stop" == "tool_calls" ]] || { util_write_msg "STOP" "$stop"; break; }
+            # tool_use/tool_calls → loop continues; otherwise exit unless a sub-agent result arrived meanwhile
+            if [[ "$stop" != "tool_use" && "$stop" != "tool_calls" ]]; then
+                rm -f "$AGENT_RUNNING_FLAG"
+                agent_drain_notify_buf && continue
+                util_write_msg "STOP" "$stop"
+                break
+            fi
         else
             util_write_msg "STOP" "interrupted"
             break
@@ -1475,7 +1482,7 @@ agent_loop() {
         util_write_msg "IMAGE_DESCRIBE" "$_images" "$desc" >&4 2>/dev/null || true
         user_input+=$'\n\n<attached-images>\n'"$desc"$'\n</attached-images>'
     fi
-    store_conv_add_user "$user_input"
+    [[ "$turn_kind" != notify ]] && store_conv_add_user "$user_input"
     store_stats_update current_turn_count=+1
     # Trap SIGINT (Ctrl+C): close pipe FD to unblock read, kill curl
     trap 'INTERRUPT_REQUESTED=true; kill "$(cat "/tmp/agent_curl_pid.$$" 2>/dev/null)" 2>/dev/null; exec 7<&- 2>/dev/null' INT

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1023,7 +1023,7 @@ tool_sub_agent() {
     [[ -z "$prompt" ]] && { echo "no prompt provided for sub-agent"; return 1; }
 
     store_event_append "{\"type\":\"sub_agent_start\",\"session_id\":\"$(util_json_escape "$sub_session_id")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"prompt\":\"$(util_json_escape "$prompt")\",\"description\":\"$(util_json_escape "$description")\",\"fork\":$fork}" >/dev/null
-    { local __cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0); printf '%d\n' $(( __cnt + 1 )) > "$ACTIVE_SUB_FILE"; }
+    { local __cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0); printf '%d\n' $(( __cnt + 1 )) > "$ACTIVE_SUB_FILE"; }
 
     (
         local _parent_notify_fifo="$NOTIFY_FIFO"
@@ -1325,7 +1325,7 @@ agent_main_loop() {
                     # 格式化文本追加到 NOTIFY_BUF
                     printf '[sub-agent %s] %s (in=%s, out=%s)\nThinking: %s\nText: %s\n' "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
                     # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
-                    local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
                     # 展示结果摘要到 display
                     util_is_stream_json || ( util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
@@ -1353,7 +1353,7 @@ agent_main_loop() {
                 while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
                 # 非交互模式：等待所有子进程完成后再退出
                 if [[ "$INTERACTIVE" != true ]]; then
-                    local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     # 循环等待：只要还有活跃子 agent 或未读结果，就不退出
                     while (( _cnt > 0 )) || [[ -s "$NOTIFY_BUF" ]]; do
                         # 等待 0.1s 让子进程有机会完成
@@ -1361,7 +1361,7 @@ agent_main_loop() {
                         if [[ -s "$NOTIFY_BUF" ]]; then
                             agent_run_loop "" notify
                         fi
-                        _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                        _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     done
                     if [[ ! -s "$NOTIFY_BUF" ]]; then
                         util_write_msg "SESSION_END" >&5
@@ -1373,13 +1373,13 @@ agent_main_loop() {
                 # 持续 drain 可能同时到达的更多结果
                 while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
                 if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
-                    local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     while (( _cnt > 0 )) || [[ -s "$NOTIFY_BUF" ]]; do
                         sleep 0.1 2>/dev/null || true
                         if [[ -s "$NOTIFY_BUF" ]]; then
                             agent_run_loop "" notify
                         fi
-                        _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                        _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     done
                     if [[ ! -s "$NOTIFY_BUF" ]]; then
                         util_write_msg "SESSION_END" >&5

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1023,6 +1023,7 @@ tool_sub_agent() {
     [[ -z "$prompt" ]] && { echo "no prompt provided for sub-agent"; return 1; }
 
     store_event_append "{\"type\":\"sub_agent_start\",\"session_id\":\"$(util_json_escape "$sub_session_id")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"prompt\":\"$(util_json_escape "$prompt")\",\"description\":\"$(util_json_escape "$description")\",\"fork\":$fork}" >/dev/null
+    { local __cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0); printf '%d\n' $(( __cnt + 1 )) > "$ACTIVE_SUB_FILE"; }
 
     (
         local _parent_notify_fifo="$NOTIFY_FIFO"
@@ -1515,7 +1516,7 @@ agent_loop() {
     while util_read_msg <&7; do
         _type="${REPLY_MESSAGE[0]-}"
         _reason="${REPLY_MESSAGE[1]-}"
-        [[ "$_type" == "TOOL_CALL" && "$_reason" == "SubAgent" ]] && { local __cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0); printf '%d\n' $(( __cnt + 1 )) > "$ACTIVE_SUB_FILE"; }
+        # SubAgent counter incremented in tool_sub_agent (before child process spawn)
         _se=$(util_msg_to_stream) && [[ -n "$_se" ]] && store_event_append "$_se"
         util_is_stream_json || ( util_write_msg "${REPLY_MESSAGE[@]}" ) >&4 2>/dev/null || true
         if [[ "$_type" == "ERROR" ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1323,7 +1323,13 @@ agent_main_loop() {
                     store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
                     # 带颜色的格式化文本追加到 NOTIFY_BUF（display 直接用，conversation 去 ANSI）
-                    printf '\033[35m[sub-agent %s] %s (in=%s, out=%s)\033[0m\n\033[90mThinking: %s\033[0m\nText: %s\n' "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
+                    if [[ "$_status" == "ok" ]]; then
+                        printf '\033[35m[sub-agent %s] completed (in=%s, out=%s)\033[0m\n' "$_sid" "$_in" "$_out" >> "$NOTIFY_BUF"
+                    else
+                        printf '\033[31m[sub-agent %s] failed\033[0m\n' "$_sid" >> "$NOTIFY_BUF"
+                    fi
+                    [[ -n "$_thinking" ]] && printf '\033[90m%s%s\033[0m\n' "${_thinking:0:120}" "$([[ ${#_thinking} -gt 120 ]] && printf '…')" >> "$NOTIFY_BUF"
+                    [[ -n "$_text" ]] && printf '%s%s\n' "${_text:0:120}" "$([[ ${#_text} -gt 120 ]] && printf '…')" >> "$NOTIFY_BUF"
                     # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -419,6 +419,7 @@ store_session_init() {
     [[ -p "$INPUT_FIFO" ]] || { rm -f "$INPUT_FIFO"; mkfifo "$INPUT_FIFO"; }
     NOTIFY_FIFO="${session_dir}/notify.fifo"
     NOTIFY_BUF="${session_dir}/notify.buf"
+    NOTIFY_DISPLAY="${session_dir}/notify.display"
     ACTIVE_SUB_FILE="${session_dir}/active_sub.count"
     AGENT_RUNNING_FLAG="${session_dir}/agent_running.flag"
     [[ -p "$NOTIFY_FIFO" ]] || { rm -f "$NOTIFY_FIFO"; mkfifo "$NOTIFY_FIFO"; }
@@ -1322,8 +1323,9 @@ agent_main_loop() {
                     store_event_append "{\"type\":\"sub_agent_result\",\"session_id\":\"$(util_json_escape "$_sid")\",\"status\":\"$_status\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"thinking\":\"$(util_json_escape "$_thinking")\",\"text\":\"$(util_json_escape "$_text")\"}"
                     store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
-                    # 格式化文本追加到 NOTIFY_BUF
+                    # 格式化文本追加到 NOTIFY_BUF（conversation）+ NOTIFY_DISPLAY（display）
                     printf '[sub-agent %s] %s (in=%s, out=%s)\nThinking: %s\nText: %s\n' "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
+                    util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_DISPLAY"
                     # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
@@ -1391,22 +1393,21 @@ agent_main_loop() {
     exec 4>&-
     wait "$display_pid" 2>/dev/null || true
     cleanup_all_pipes
-    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$AGENT_RUNNING_FLAG"
+    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$NOTIFY_DISPLAY" "$AGENT_RUNNING_FLAG"
 }
 
 agent_drain_notify_buf() {
     [[ -f "$NOTIFY_BUF" && -s "$NOTIFY_BUF" ]] || return 1
-    local _nb_tmp="${NOTIFY_BUF}.${$}" _nb_content
+    local _nb_tmp="${NOTIFY_BUF}.${$}" _nd_tmp="${NOTIFY_DISPLAY}.${$}" _nb_content
     mv "$NOTIFY_BUF" "$_nb_tmp" 2>/dev/null || return 1
+    mv "$NOTIFY_DISPLAY" "$_nd_tmp" 2>/dev/null || true
     _nb_content=$(<"$_nb_tmp")
     rm -f "$_nb_tmp"
-    [[ -n "$_nb_content" ]] || return 1
+    [[ -n "$_nb_content" ]] || { rm -f "$_nd_tmp"; return 1; }
     store_conv_add_user "$_nb_content"
-    # 消费时 display：紫色标记 + 确保尾部换行（不打断后续流式输出）
-    local _disp
-    _disp=$(printf '\033[35m%s\033[0m' "$_nb_content")
-    [[ "$_disp" == *$'\n' ]] || _disp+=$'\n'
-    util_is_stream_json || util_write_msg "TEXT" "$_disp" >&4 2>/dev/null || true
+    # 消费时 display：直接将 RESP 写入 FD 4（cat 不剥离尾部 \r\n）
+    util_is_stream_json || [[ ! -f "$_nd_tmp" ]] || cat "$_nd_tmp" >&4 2>/dev/null || true
+    rm -f "$_nd_tmp"
 }
 
 agent_loop_stream() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -424,7 +424,7 @@ store_session_init() {
     ACTIVE_SUB_FILE="${session_dir}/active_sub.count"
     AGENT_RUNNING_FLAG="/tmp/agent_loop_active.$$"
     [[ -p "$NOTIFY_FIFO" ]] || { rm -f "$NOTIFY_FIFO"; mkfifo "$NOTIFY_FIFO"; }
-    printf 0 > "$ACTIVE_SUB_FILE"
+    printf '0\n' > "$ACTIVE_SUB_FILE"
 }
 
 store_session_fork() {
@@ -1376,6 +1376,8 @@ agent_loop_stream() {
     # Trap SIGINT: close pipe FD to unblock read
     trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
     # 通知后台 reader：agent_loop 在运行中（notify 走 buffer 不走 NOTIFY_PENDING）
+    # NOTE: 嵌套 SubAgent 场景下，child 的 agent_loop_stream 会误删此 flag（因 $$ 在
+    # subshell 中不变）。影响有限：最多产生多余 NOTIFY_PENDING，不丢数据。
     : > "$AGENT_RUNNING_FLAG"
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1401,7 +1401,8 @@ agent_drain_notify_buf() {
     _nb_content=$(<"$_nb_tmp")
     rm -f "$_nb_tmp"
     [[ -n "$_nb_content" ]] || return 1
-    # display：带颜色直接输出（TEXT RESP → display_stream）
+    # display：带颜色直接输出（TEXT RESP → display_stream），补尾部换行
+    [[ "$_nb_content" == *$'\n' ]] || _nb_content+=$'\n'
     util_is_stream_json || util_write_msg "TEXT" "$_nb_content" >&4 2>/dev/null || true
     # conversation：去除 ANSI 颜色码后注入（[...m）
     store_conv_add_user "$(printf '%s' "$_nb_content" | sed $'s/\x1b\[[0-9;]*m//g')"

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1323,9 +1323,9 @@ agent_main_loop() {
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
                     # 格式化文本追加到 NOTIFY_BUF
                     printf '[sub-agent %s] %s (in=%s, out=%s)\nThinking: %s\nText: %s\n' "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
-                    # 递减 active_sub 计数器
+                    # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
+                    (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
                     # 展示结果摘要到 display
                     util_is_stream_json || ( util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
                     # idle（无 agent_loop_stream 在跑）→ 发 NOTIFY_PENDING 触发 notify turn

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -155,7 +155,7 @@ util_msg_to_stream() {
                 "$(util_json_escape "${REPLY_MESSAGE[3]}")"
             ;;
         USAGE)       printf '{"type":"usage","input_tokens":%s,"output_tokens":%s,"cache_read_input_tokens":%s,"cache_creation_input_tokens":%s,"kind":"agent"}' "${REPLY_MESSAGE[1]:-0}" "${REPLY_MESSAGE[2]:-0}" "${REPLY_MESSAGE[3]:-0}" "${REPLY_MESSAGE[4]:-0}" ;;
-        SUB_AGENT_RESULT) printf '{"type":"sub_agent_result","session_id":"%s","status":"%s","input_tokens":%s,"output_tokens":%s,"thinking":"%s","text":"%s"}' \
+        AGENT_RESULT) printf '{"type":"sub_agent_result","session_id":"%s","status":"%s","input_tokens":%s,"output_tokens":%s,"thinking":"%s","text":"%s"}' \
             "$(util_json_escape "${REPLY_MESSAGE[1]}")" "${REPLY_MESSAGE[2]}" "${REPLY_MESSAGE[3]}" "${REPLY_MESSAGE[4]}" \
             "$(util_json_escape "${REPLY_MESSAGE[5]}")" "$(util_json_escape "${REPLY_MESSAGE[6]}")" ;;
         STOP)        printf '{"type":"stop","reason":"%s"}' "$(util_json_escape "${REPLY_MESSAGE[1]}")" ;;
@@ -1152,7 +1152,7 @@ display_message() {
             PREV_WAS_THINKING=false
             [[ -n "$_tr_text" ]] && display_human_text "$_tr_text"
             ;;
-        SUB_AGENT_RESULT)
+        AGENT_RESULT)
             display_sub_agent_result "${REPLY_MESSAGE[1]}" "${REPLY_MESSAGE[2]}" "${REPLY_MESSAGE[3]}" "${REPLY_MESSAGE[4]}" "${REPLY_MESSAGE[5]}" "${REPLY_MESSAGE[6]}"
             ;;
         IMAGE_DESCRIBE)
@@ -1311,7 +1311,7 @@ agent_main_loop() {
         exec 6<> "$NOTIFY_FIFO" 2>/dev/null  # `<>` 双端打开，防止写者关闭后 EOF
         while util_read_msg <&6; do
             case "${REPLY_MESSAGE[0]}" in
-                SUB_AGENT_RESULT)
+                AGENT_RESULT)
                     local _sid="${REPLY_MESSAGE[1]}" _status="${REPLY_MESSAGE[2]}"
                     local _thinking="${REPLY_MESSAGE[3]}" _text="${REPLY_MESSAGE[4]}"
                     local _in="${REPLY_MESSAGE[5]:-0}" _out="${REPLY_MESSAGE[6]:-0}"
@@ -1323,16 +1323,12 @@ agent_main_loop() {
                     store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
                     # 格式化文本追加到 NOTIFY_BUF
-                    {
-                        printf '[sub-agent %s] %s (in=%s, out=%s)\n' "$_sid" "$_status" "$_in" "$_out"
-                        printf 'Thinking: %s\n' "$_thinking"
-                        printf 'Text: %s\n' "$_text"
-                    } >> "$NOTIFY_BUF"
+                    printf '[sub-agent %s] %s (in=%s, out=%s)\nThinking: %s\nText: %s\n' "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
                     # 递减 active_sub 计数器
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
                     # 展示结果摘要到 display
-                    util_is_stream_json || ( util_write_msg "SUB_AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
+                    util_is_stream_json || ( util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
                     # idle（无 agent_loop_stream 在跑）→ 发 NOTIFY_PENDING 触发 notify turn
                     if [[ ! -f "$AGENT_RUNNING_FLAG" ]]; then
                         util_write_msg "NOTIFY_PENDING" >&5

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1347,17 +1347,20 @@ agent_main_loop() {
             USER_INPUT)
                 saw_user_input=true
                 agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
-                # 非交互模式下，所有子 agent 完成后退出
                 if [[ "$INTERACTIVE" != true ]]; then
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    (( _cnt <= 0 )) && util_write_msg "SESSION_END" >&5
+                    if (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]]; then
+                        util_write_msg "SESSION_END" >&5
+                    fi
                 fi
                 ;;
             NOTIFY_PENDING)
                 [[ -s "$NOTIFY_BUF" ]] && agent_run_loop "" notify
                 if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    (( _cnt <= 0 )) && util_write_msg "SESSION_END" >&5
+                    if (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]]; then
+                        util_write_msg "SESSION_END" >&5
+                    fi
                 fi
                 ;;
         esac

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1327,9 +1327,7 @@ agent_main_loop() {
                     # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
-                    # 展示结果摘要到 display
-                    util_is_stream_json || ( util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" ) >&4 2>/dev/null || true
-                    # idle（无 agent_loop_stream 在跑）→ 发 NOTIFY_PENDING 触发 notify turn
+                    # idle 时触发 notify turn（display 由 agent_drain_notify_buf 消费时处理）
                     if [[ ! -f "$AGENT_RUNNING_FLAG" ]]; then
                         util_write_msg "NOTIFY_PENDING" >&5
                     fi
@@ -1404,6 +1402,8 @@ agent_drain_notify_buf() {
     rm -f "$_nb_tmp"
     [[ -n "$_nb_content" ]] || return 1
     store_conv_add_user "$_nb_content"
+    # 消费时 display：通过 FD 4 写入 display pipe，不打断流式输出
+    util_is_stream_json || util_write_msg "TEXT" "$_nb_content" >&4 2>/dev/null || true
 }
 
 agent_loop_stream() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1402,8 +1402,11 @@ agent_drain_notify_buf() {
     rm -f "$_nb_tmp"
     [[ -n "$_nb_content" ]] || return 1
     store_conv_add_user "$_nb_content"
-    # 消费时 display：通过 FD 4 写入 display pipe，不打断流式输出
-    util_is_stream_json || util_write_msg "TEXT" "$_nb_content" >&4 2>/dev/null || true
+    # 消费时 display：紫色标记 + 确保尾部换行（不打断后续流式输出）
+    local _disp
+    _disp=$(printf '\033[35m%s\033[0m' "$_nb_content")
+    [[ "$_disp" == *$'\n' ]] || _disp+=$'\n'
+    util_is_stream_json || util_write_msg "TEXT" "$_disp" >&4 2>/dev/null || true
 }
 
 agent_loop_stream() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1348,10 +1348,21 @@ agent_main_loop() {
                 saw_user_input=true
                 agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
                 # drain 可能在 agent_loop_stream 运行期间到达的 SubAgent 结果
+                # drain 任何在 agent_loop_stream 运行期间到达的 SubAgent 结果
                 while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
+                # 非交互模式：等待所有子进程完成后再退出
                 if [[ "$INTERACTIVE" != true ]]; then
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    if (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]]; then
+                    # 循环等待：只要还有活跃子 agent 或未读结果，就不退出
+                    while (( _cnt > 0 )) || [[ -s "$NOTIFY_BUF" ]]; do
+                        # 等待 0.1s 让子进程有机会完成
+                        sleep 0.1 2>/dev/null || true
+                        if [[ -s "$NOTIFY_BUF" ]]; then
+                            agent_run_loop "" notify
+                        fi
+                        _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    done
+                    if [[ ! -s "$NOTIFY_BUF" ]]; then
                         util_write_msg "SESSION_END" >&5
                     fi
                 fi
@@ -1362,7 +1373,14 @@ agent_main_loop() {
                 while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
                 if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
-                    if (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]]; then
+                    while (( _cnt > 0 )) || [[ -s "$NOTIFY_BUF" ]]; do
+                        sleep 0.1 2>/dev/null || true
+                        if [[ -s "$NOTIFY_BUF" ]]; then
+                            agent_run_loop "" notify
+                        fi
+                        _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
+                    done
+                    if [[ ! -s "$NOTIFY_BUF" ]]; then
                         util_write_msg "SESSION_END" >&5
                     fi
                 fi

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1347,6 +1347,8 @@ agent_main_loop() {
             USER_INPUT)
                 saw_user_input=true
                 agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
+                # drain 可能在 agent_loop_stream 运行期间到达的 SubAgent 结果
+                while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
                 if [[ "$INTERACTIVE" != true ]]; then
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     if (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]]; then
@@ -1356,6 +1358,8 @@ agent_main_loop() {
                 ;;
             NOTIFY_PENDING)
                 [[ -s "$NOTIFY_BUF" ]] && agent_run_loop "" notify
+                # 持续 drain 可能同时到达的更多结果
+                while [[ -s "$NOTIFY_BUF" ]]; do agent_run_loop "" notify; done
                 if [[ "$INTERACTIVE" != true && "$saw_user_input" == true ]]; then
                     local _cnt=$(<"$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     if (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]]; then

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -422,7 +422,7 @@ store_session_init() {
     NOTIFY_FIFO="${session_dir}/notify.fifo"
     NOTIFY_BUF="${session_dir}/notify.buf"
     ACTIVE_SUB_FILE="${session_dir}/active_sub.count"
-    AGENT_RUNNING_FLAG="/tmp/agent_loop_active.$$"
+    AGENT_RUNNING_FLAG="${session_dir}/agent_running.flag"
     [[ -p "$NOTIFY_FIFO" ]] || { rm -f "$NOTIFY_FIFO"; mkfifo "$NOTIFY_FIFO"; }
     printf '0\n' > "$ACTIVE_SUB_FILE"
 }
@@ -1376,8 +1376,6 @@ agent_loop_stream() {
     # Trap SIGINT: close pipe FD to unblock read
     trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
     # 通知后台 reader：agent_loop 在运行中（notify 走 buffer 不走 NOTIFY_PENDING）
-    # NOTE: 嵌套 SubAgent 场景下，child 的 agent_loop_stream 会误删此 flag（因 $$ 在
-    # subshell 中不变）。影响有限：最多产生多余 NOTIFY_PENDING，不丢数据。
     : > "$AGENT_RUNNING_FLAG"
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -119,9 +119,7 @@ util_parse_size() {
 }
 
 util_json_escape() {
-    local _s="${1:-}"
-    _s="${_s//\\/\\\\}" _s="${_s//\"/\\\"}" _s="${_s//$'\n'/\\n}" _s="${_s//$'\r'/\\r}" _s="${_s//$'\t'/\\t}" _s="${_s//$'\b'/\\b}" _s="${_s//$'\f'/\\f}"
-    printf '%s' "$_s"
+    printf '%s' "${1:-}" | util_awk_run -v json_mode=escape_string -f "$AWK_DIR/json.awk" -f "$AWK_DIR/json_cli.awk"
 }
 
 util_is_stream_json() { [[ "$OUTPUT_FORMAT" == "stream-json" ]]; }
@@ -1019,28 +1017,29 @@ tool_web_fetch() { curl -sS --connect-timeout 10 --max-time 60 -H "Authorization
 # 启动异步子 agent：后台执行 agent_loop，完成后通过 NOTIFY_FIFO 发回 AGENT_RESULT
 # 消息格式：AGENT_RESULT <session_id> <status:ok|failed> <thinking> <text> <in> <out> <cr> <cc> <reqs>
 tool_sub_agent() {
-    local prompt="$1" description="${2:-}" fork="${3:-}" sub_session_id="sub_$(util_new_session_id)"
+    local prompt="$1" description="${2:-}" fork="${3:-false}" sub_session_id="sub_$(util_new_session_id)"
+    [[ "$fork" == "true" ]] || fork=false
 
     [[ -z "$prompt" ]] && { echo "no prompt provided for sub-agent"; return 1; }
 
-    store_event_append "{\"type\":\"sub_agent_start\",\"session_id\":\"$(util_json_escape "$sub_session_id")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"prompt\":\"$(util_json_escape "$prompt")\",\"description\":\"$(util_json_escape "$description")\",\"fork\":$fork}"
+    store_event_append "{\"type\":\"sub_agent_start\",\"session_id\":\"$(util_json_escape "$sub_session_id")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"prompt\":\"$(util_json_escape "$prompt")\",\"description\":\"$(util_json_escape "$description")\",\"fork\":$fork}" >/dev/null
 
     (
+        local _parent_notify_fifo="$NOTIFY_FIFO"
         # fork mode needs to copy conversation and summary to new session dir
         if [[ "$fork" == "true" ]]; then
             store_session_fork "$(store_session_get_dir)/${SESSION_ID}" "$(store_session_get_dir)/${sub_session_id}"
         fi
         export SESSION_ID="$sub_session_id"
         export INTERACTIVE=false
-        local _parent_notify_fifo="$NOTIFY_FIFO"
         store_session_init
         util_load_tool_defs
-        local _done=false _status="failed"
-        trap '[[ "$_done" == true ]] || store_sub_send_result "$sub_session_id" "$_status" "$_parent_notify_fifo"; exec 6<&- 2>/dev/null; rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$ACTIVE_SUB_FILE"' EXIT
         # Silence the child shell completely; close all inherited FDs
         exec </dev/null >/dev/null 2>&1
         exec 3<&- 2>/dev/null; exec 4<&- 2>/dev/null; exec 5<&- 2>/dev/null
         exec 8<&- 2>/dev/null
+        local _done=false _status="failed"
+        trap '[[ "$_done" == true ]] || store_sub_send_result "$sub_session_id" "$_status" "$_parent_notify_fifo"; exec 6<&- 2>/dev/null; rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$ACTIVE_SUB_FILE"' EXIT
         agent_loop "$prompt" && _status="ok"
         store_sub_send_result "$sub_session_id" "$_status" "$_parent_notify_fifo"
         _done=true

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1322,14 +1322,8 @@ agent_main_loop() {
                     store_event_append "{\"type\":\"sub_agent_result\",\"session_id\":\"$(util_json_escape "$_sid")\",\"status\":\"$_status\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"thinking\":\"$(util_json_escape "$_thinking")\",\"text\":\"$(util_json_escape "$_text")\"}"
                     store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
-                    # 带颜色的格式化文本追加到 NOTIFY_BUF（display 直接用，conversation 去 ANSI）
-                    if [[ "$_status" == "ok" ]]; then
-                        printf '\033[35m[sub-agent %s] completed (in=%s, out=%s)\033[0m\n' "$_sid" "$_in" "$_out" >> "$NOTIFY_BUF"
-                    else
-                        printf '\033[31m[sub-agent %s] failed\033[0m\n' "$_sid" >> "$NOTIFY_BUF"
-                    fi
-                    [[ -n "$_thinking" ]] && printf '\033[90m%s%s\033[0m\n' "${_thinking:0:120}" "$([[ ${#_thinking} -gt 120 ]] && printf '…')" >> "$NOTIFY_BUF"
-                    [[ -n "$_text" ]] && printf '%s%s\n' "${_text:0:120}" "$([[ ${#_text} -gt 120 ]] && printf '…')" >> "$NOTIFY_BUF"
+                    # AGENT_RESULT RESP 追加到 NOTIFY_BUF（消费时解析：display + conversation）
+                    util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
                     # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
@@ -1402,16 +1396,25 @@ agent_main_loop() {
 
 agent_drain_notify_buf() {
     [[ -f "$NOTIFY_BUF" && -s "$NOTIFY_BUF" ]] || return 1
-    local _nb_tmp="${NOTIFY_BUF}.${$}" _nb_content
+    local _nb_tmp="${NOTIFY_BUF}.${$}" _conv=""
     mv "$NOTIFY_BUF" "$_nb_tmp" 2>/dev/null || return 1
-    _nb_content=$(<"$_nb_tmp")
+    exec 9<"$_nb_tmp"
+    while util_read_msg <&9; do
+        if [[ "${REPLY_MESSAGE[0]}" == "AGENT_RESULT" ]]; then
+            # display：转发 AGENT_RESULT RESP → display_sub_agent_result（复用原始格式）
+            util_is_stream_json || util_write_msg "AGENT_RESULT" "${REPLY_MESSAGE[@]:1}" >&4 2>/dev/null || true
+            # conversation：从结构化字段构建纯文本
+            local _sid="${REPLY_MESSAGE[1]}" _st="${REPLY_MESSAGE[2]}" _in="${REPLY_MESSAGE[3]}" _out="${REPLY_MESSAGE[4]}"
+            local _th="${REPLY_MESSAGE[5]}" _tx="${REPLY_MESSAGE[6]}"
+            _conv+="[sub-agent ${_sid}] ${_st} (in=${_in}, out=${_out})"$'\n'
+            [[ -n "$_th" ]] && _conv+="Thinking: ${_th}"$'\n'
+            [[ -n "$_tx" ]] && _conv+="Text: ${_tx}"$'\n'
+        fi
+    done
+    exec 9<&-
     rm -f "$_nb_tmp"
-    [[ -n "$_nb_content" ]] || return 1
-    # display：带颜色直接输出（TEXT RESP → display_stream），补尾部换行
-    [[ "$_nb_content" == *$'\n' ]] || _nb_content+=$'\n'
-    util_is_stream_json || util_write_msg "TEXT" "$_nb_content" >&4 2>/dev/null || true
-    # conversation：去除 ANSI 颜色码后注入（[...m）
-    store_conv_add_user "$(printf '%s' "$_nb_content" | sed $'s/\x1b\[[0-9;]*m//g')"
+    [[ -n "$_conv" ]] || return 1
+    store_conv_add_user "$_conv"
 }
 
 agent_loop_stream() {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -419,7 +419,6 @@ store_session_init() {
     [[ -p "$INPUT_FIFO" ]] || { rm -f "$INPUT_FIFO"; mkfifo "$INPUT_FIFO"; }
     NOTIFY_FIFO="${session_dir}/notify.fifo"
     NOTIFY_BUF="${session_dir}/notify.buf"
-    NOTIFY_DISPLAY="${session_dir}/notify.display"
     ACTIVE_SUB_FILE="${session_dir}/active_sub.count"
     AGENT_RUNNING_FLAG="${session_dir}/agent_running.flag"
     [[ -p "$NOTIFY_FIFO" ]] || { rm -f "$NOTIFY_FIFO"; mkfifo "$NOTIFY_FIFO"; }
@@ -1323,9 +1322,8 @@ agent_main_loop() {
                     store_event_append "{\"type\":\"sub_agent_result\",\"session_id\":\"$(util_json_escape "$_sid")\",\"status\":\"$_status\",\"input_tokens\":$_in,\"output_tokens\":$_out,\"thinking\":\"$(util_json_escape "$_thinking")\",\"text\":\"$(util_json_escape "$_text")\"}"
                     store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
-                    # 格式化文本追加到 NOTIFY_BUF（conversation）+ NOTIFY_DISPLAY（display）
-                    printf '[sub-agent %s] %s (in=%s, out=%s)\nThinking: %s\nText: %s\n' "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
-                    util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_DISPLAY"
+                    # 带颜色的格式化文本追加到 NOTIFY_BUF（display 直接用，conversation 去 ANSI）
+                    printf '\033[35m[sub-agent %s] %s (in=%s, out=%s)\033[0m\n\033[90mThinking: %s\033[0m\nText: %s\n' "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
                     # 递减 active_sub 计数器（大于 0 才减，防止竞态下提前归零）
                     local _cnt=$(cat "$ACTIVE_SUB_FILE" 2>/dev/null || echo 0)
                     (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_SUB_FILE"
@@ -1393,21 +1391,20 @@ agent_main_loop() {
     exec 4>&-
     wait "$display_pid" 2>/dev/null || true
     cleanup_all_pipes
-    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$NOTIFY_DISPLAY" "$AGENT_RUNNING_FLAG"
+    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$AGENT_RUNNING_FLAG"
 }
 
 agent_drain_notify_buf() {
     [[ -f "$NOTIFY_BUF" && -s "$NOTIFY_BUF" ]] || return 1
-    local _nb_tmp="${NOTIFY_BUF}.${$}" _nd_tmp="${NOTIFY_DISPLAY}.${$}" _nb_content
+    local _nb_tmp="${NOTIFY_BUF}.${$}" _nb_content
     mv "$NOTIFY_BUF" "$_nb_tmp" 2>/dev/null || return 1
-    mv "$NOTIFY_DISPLAY" "$_nd_tmp" 2>/dev/null || true
     _nb_content=$(<"$_nb_tmp")
     rm -f "$_nb_tmp"
-    [[ -n "$_nb_content" ]] || { rm -f "$_nd_tmp"; return 1; }
-    store_conv_add_user "$_nb_content"
-    # 消费时 display：直接将 RESP 写入 FD 4（cat 不剥离尾部 \r\n）
-    util_is_stream_json || [[ ! -f "$_nd_tmp" ]] || cat "$_nd_tmp" >&4 2>/dev/null || true
-    rm -f "$_nd_tmp"
+    [[ -n "$_nb_content" ]] || return 1
+    # display：带颜色直接输出（TEXT RESP → display_stream）
+    util_is_stream_json || util_write_msg "TEXT" "$_nb_content" >&4 2>/dev/null || true
+    # conversation：去除 ANSI 颜色码后注入（[...m）
+    store_conv_add_user "$(printf '%s' "$_nb_content" | sed $'s/\x1b\[[0-9;]*m//g')"
 }
 
 agent_loop_stream() {

--- a/src/awk/event_replay.awk
+++ b/src/awk/event_replay.awk
@@ -89,7 +89,7 @@ BEGIN {
         _thinking = extract_str($0, "thinking")
         _text = extract_str($0, "text")
         # Escape backslashes and newlines for RESP wire format
-        emit1("SUB_AGENT_RESULT")
+        emit1("AGENT_RESULT")
         emit(_sid)
         emit(_status)
         emit(_in)

--- a/src/awk/json_cli.awk
+++ b/src/awk/json_cli.awk
@@ -2,16 +2,14 @@
 
 BEGIN {
     if (json_mode == "escape_string") {
-        if (json_input == "") {
-            if ((getline json_input) < 0) {
-                json_input = ""
-            } else {
-                while ((getline _line) > 0) {
-                    json_input = json_input "\n" _line
-                }
+        if ((getline json_input) < 0) {
+            json_input = ""
+        } else {
+            while ((getline _line) > 0) {
+                json_input = json_input "\n" _line
             }
         }
-        print escape_json_string(json_input)
+        printf "%s", escape_json_string(json_input)
         exit 0
     }
 

--- a/src/awk/send_sub_result.awk
+++ b/src/awk/send_sub_result.awk
@@ -1,11 +1,11 @@
-# send_sub_result.awk — Extract sub-agent result and send SUB_AGENT_RESULT via RESP
+# send_sub_result.awk — Extract sub-agent result and send AGENT_RESULT via RESP
 # Usage: awk -v session_id=... -v status=ok -v stats_file=... -v conv_file=... \
 #            -f json.awk -f send_sub_result.awk
 # Reads the last assistant message from conv_file, stats from stats_file,
-# outputs RESP-formatted SUB_AGENT_RESULT message to stdout.
+# outputs RESP-formatted AGENT_RESULT message to stdout.
 #
 # RESP format: *N\r\n$len\r\ndata\r\n...
-# Fields: SUB_AGENT_RESULT <session_id> <status> <thinking> <text> <in> <out> <cr> <cc> <reqs>
+# Fields: AGENT_RESULT <session_id> <status> <thinking> <text> <in> <out> <cr> <cc> <reqs>
 
 BEGIN {
     thinking = ""
@@ -57,8 +57,8 @@ BEGIN {
         close(stats_file)
     }
 
-    # 3. Build RESP message: SUB_AGENT_RESULT session_id status thinking text in out cr cc reqs
-    _resp_field("SUB_AGENT_RESULT")
+    # 3. Build RESP message: AGENT_RESULT session_id status thinking text in out cr cc reqs
+    _resp_field("AGENT_RESULT")
     _resp_field(session_id)
     _resp_field(status)
     _resp_field(thinking)

--- a/src/awk/send_sub_result.awk
+++ b/src/awk/send_sub_result.awk
@@ -1,11 +1,11 @@
-# send_sub_result.awk — Extract sub-agent result and send AGENT_RESULT via RESP
+# send_sub_result.awk — Extract sub-agent result and send SUB_AGENT_RESULT via RESP
 # Usage: awk -v session_id=... -v status=ok -v stats_file=... -v conv_file=... \
 #            -f json.awk -f send_sub_result.awk
 # Reads the last assistant message from conv_file, stats from stats_file,
-# outputs RESP-formatted AGENT_RESULT message to stdout.
+# outputs RESP-formatted SUB_AGENT_RESULT message to stdout.
 #
 # RESP format: *N\r\n$len\r\ndata\r\n...
-# Fields: AGENT_RESULT <session_id> <status> <thinking> <text> <in> <out> <cr> <cc> <reqs>
+# Fields: SUB_AGENT_RESULT <session_id> <status> <thinking> <text> <in> <out> <cr> <cc> <reqs>
 
 BEGIN {
     thinking = ""
@@ -57,8 +57,8 @@ BEGIN {
         close(stats_file)
     }
 
-    # 3. Build RESP message: AGENT_RESULT session_id status thinking text in out cr cc reqs
-    _resp_field("AGENT_RESULT")
+    # 3. Build RESP message: SUB_AGENT_RESULT session_id status thinking text in out cr cc reqs
+    _resp_field("SUB_AGENT_RESULT")
     _resp_field(session_id)
     _resp_field(status)
     _resp_field(thinking)

--- a/tests/fixtures/mock_server.py
+++ b/tests/fixtures/mock_server.py
@@ -1137,6 +1137,76 @@ class H(http.server.BaseHTTPRequestHandler):
                     'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
                 ]: w.write(c.encode()); w.flush()
             return
+        # --- SubAgent multi (two SubAgents in one response) ---
+        # Stage 1: main agent -> TWO SubAgent tool_calls
+        if b'SUB_MULTI_MARKER' in body and b'"tool_result"' not in body and b'SUB_CHILD_A' not in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_multi1\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_multi_a\",\"name\":\"SubAgent\",\"input\":{}}}\n\n',
+                    'event: content_block_delta\ndata: ' + json.dumps({'type':'content_block_delta','index':0,'delta':{'type':'input_json_delta','partial_json': json.dumps({'prompt':'SUB_CHILD_A','description':'task A'})}}) + '\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_multi_b\",\"name\":\"SubAgent\",\"input\":{}}}\n\n',
+                    'event: content_block_delta\ndata: ' + json.dumps({'type':'content_block_delta','index':1,'delta':{'type':'input_json_delta','partial_json': json.dumps({'prompt':'SUB_CHILD_B','description':'task B'})}}) + '\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":20}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
+        # Stage 2a: child A request
+        if b'SUB_CHILD_A' in body and b'"tool_result"' not in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_child_a\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Result A: 42.\"}}\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
+        # Stage 2b: child B request
+        if b'SUB_CHILD_B' in body and b'"tool_result"' not in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_child_b\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Result B: 99.\"}}\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
+        # Stage 3: main agent after both tool_results (no [sub-agent] yet)
+        if b'SUB_MULTI_MARKER' in body and b'"tool_result"' in body and b'[sub-agent sub_' not in body:
+            if path.startswith('/v1/messages'):
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_multi3\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Waiting for sub-agents.\"}}\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
+        # Stage 4: main agent with one or both [sub-agent] results -> final answer
+        if b'SUB_MULTI_MARKER' in body and b'[sub-agent sub_' in body:
+            if path.startswith('/v1/messages'):
+                # Count how many sub-agent results are in the body
+                sub_count = body.count(b'[sub-agent sub_')
+                if sub_count >= 2:
+                    final_text = 'Both results: A=42, B=99.'
+                else:
+                    final_text = 'Partial result received, waiting for more.'
+                for c in [
+                    'event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_multi4\",\"role\":\"assistant\",\"content\":[],\"model\":\"test\",\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n',
+                    'event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n',
+                    'event: content_block_delta\ndata: ' + json.dumps({'type':'content_block_delta','index':0,'delta':{'type':'text_delta','text':final_text}}) + '\n\n',
+                    'event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n',
+                    'event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n',
+                    'event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
         # --- SubAgent failure mock ---
         # Stage 1: main agent -> SubAgent tool_call with SUB_FAIL_CHILD prompt
         if b'SUB_FAIL_MARKER' in body and b'"tool_result"' not in body:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1340,6 +1340,28 @@ test_agent_sub_agent() {
     unset BASH_AGENT_HOME INTERACTIVE MAX_TURNS
 }
 
+# Test: SubAgent multi — two SubAgents in one response, both results must be processed
+test_agent_sub_agent_multi() {
+    info "Test: SubAgent multi (two parallel SubAgents)"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    export BASH_AGENT_HOME="$tmpdir"
+    export INTERACTIVE=false
+    export MAX_TURNS=20
+
+    local output
+    output=$(timeout 20 "$AGENT" -p claude --base-url "${BASE}/v1" -m test --api-key test --session test-sub-multi-001 "SUB_MULTI_MARKER" 2>&1) || true
+
+    # Both SubAgent results should appear in output
+    echo "$output" | grep -q "Result A: 42" && { green "SubAgent-multi: result A found"; ((PASS++)); } || { red "SubAgent-multi: result A not found"; echo "  Output: $output"; ((FAIL++)); }
+    echo "$output" | grep -q "Result B: 99" && { green "SubAgent-multi: result B found"; ((PASS++)); } || { red "SubAgent-multi: result B not found"; ((FAIL++)); }
+    # Final answer should mention both results
+    echo "$output" | grep -q "A=42.*B=99\|Both results" && { green "SubAgent-multi: final answer found"; ((PASS++)); } || { red "SubAgent-multi: final answer not found"; ((FAIL++)); }
+
+    rm -rf "$tmpdir"
+    unset BASH_AGENT_HOME INTERACTIVE MAX_TURNS
+}
+
 # Test: SubAgent failure propagation — child agent fails, parent sees status=failed
 test_agent_sub_agent_failure() {
     info "Test: SubAgent failure propagation"
@@ -2636,6 +2658,7 @@ test_compact_dp_awk
 test_compact_turn_keep_awk
 test_agent_compact_context
 test_agent_sub_agent
+test_agent_sub_agent_multi
 test_agent_sub_agent_failure
 test_agent_sub_agent_child_session
 test_agent_sub_agent_fork

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1352,9 +1352,11 @@ test_agent_sub_agent_multi() {
     local output
     output=$(timeout 20 "$AGENT" -p claude --base-url "${BASE}/v1" -m test --api-key test --session test-sub-multi-001 "SUB_MULTI_MARKER" 2>&1) || true
 
-    # Both SubAgent results should appear in output
-    echo "$output" | grep -q "Result A: 42" && { green "SubAgent-multi: result A found"; ((PASS++)); } || { red "SubAgent-multi: result A not found"; echo "  Output: $output"; ((FAIL++)); }
-    echo "$output" | grep -q "Result B: 99" && { green "SubAgent-multi: result B found"; ((PASS++)); } || { red "SubAgent-multi: result B not found"; ((FAIL++)); }
+    # SubAgent results processed — check via final answer or raw child text
+    # (child text only displayed when agent is idle; during active streaming
+    #  results go to NOTIFY_BUF and are processed by LLM)
+    echo "$output" | grep -qE "Result A: 42|A=42" && { green "SubAgent-multi: result A found"; ((PASS++)); } || { red "SubAgent-multi: result A not found"; echo "  Output: $output"; ((FAIL++)); }
+    echo "$output" | grep -qE "Result B: 99|B=99" && { green "SubAgent-multi: result B found"; ((PASS++)); } || { red "SubAgent-multi: result B not found"; ((FAIL++)); }
     # Final answer should mention both results
     echo "$output" | grep -q "A=42.*B=99\|Both results" && { green "SubAgent-multi: final answer found"; ((PASS++)); } || { red "SubAgent-multi: final answer not found"; ((FAIL++)); }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -46,7 +46,21 @@ project_key() {
 
 green() { printf '\033[32m✓ PASS: %s\033[0m\n' "$1"; }
 red()   { printf '\033[31m✗ FAIL: %s\033[0m\n' "$1"; }
-info()  { printf '\033[36m→ %s\033[0m\n' "$1"; }
+TEST_TIMER_NAME=""
+TEST_TIMER_START=$SECONDS
+info() {
+    if [[ -n "$TEST_TIMER_NAME" ]]; then
+        printf '\033[90m  elapsed: %ss — %s\033[0m\n' "$((SECONDS - TEST_TIMER_START))" "$TEST_TIMER_NAME"
+    fi
+    TEST_TIMER_NAME="$1"
+    TEST_TIMER_START=$SECONDS
+    printf '\033[36m→ %s\033[0m\n' "$1"
+}
+timing_finish() {
+    [[ -n "$TEST_TIMER_NAME" ]] || return 0
+    printf '\033[90m  elapsed: %ss — %s\033[0m\n' "$((SECONDS - TEST_TIMER_START))" "$TEST_TIMER_NAME"
+    TEST_TIMER_NAME=""
+}
 
 # Short test helpers
 multi_grep() { local o="$1"; shift; for p in "$@"; do grep -q "$p" <<< "$o" 2>/dev/null || return 1; done; return 0; }
@@ -2807,6 +2821,8 @@ test_bash_mode_scanner() {
 }
 
 test_bash_mode_scanner
+
+timing_finish
 
 echo ""
 echo "=============================="


### PR DESCRIPTION
### 性能优化

**`util_json_escape` 从纯 Bash 全局替换改为 awk 管道**

| 场景 | 优化前 | 优化后 | 提升 |
|------|--------|--------|------|
| 28KB system prompt escape (5次) | ~46000ms | ~43ms | ~1070x |
| 单轮 mock 请求 | ~9.3s | ~0.36s | ~26x |
| 完整 `make test-bash` | ~1200s+ | ~180s | ~7x |

根因：Bash 的 `${_s//\\/\\\\}` 对 28KB 字符串做多轮全局扫描+复制，macOS BWK awk 下极慢。改用已有的 `json.awk` + `json_cli.awk` 的 `escape_json_string` 函数，单次 awk 子进程流式处理。

### SubAgent 通知架构重构

**旧架构**：SubAgent 结果通过 INPUT_FIFO 传回（与用户输入共用通道），`agent_handle_sub_result` 同步处理，display 在结果到达时立即输出（打断流式 text delta）。

**新架构——双 FIFO 设计**：

```
INPUT_FIFO:   用户输入 + NOTIFY_PENDING
NOTIFY_FIFO:  SubAgent 结果（独立通道）

NOTIFY_BUF:        SubAgent 结果缓冲（RESP 格式）
ACTIVE_SUB_FILE:   活跃计数器（文件）
AGENT_RUNNING_FLAG: agent_loop_stream 运行标记（文件）
```

**核心流程**：

1. **notify reader**（后台子 shell）：阻塞读 NOTIFY_FIFO → 记录事件/统计 → AGENT_RESULT RESP 写入 NOTIFY_BUF → 递减计数器 → idle 时发 NOTIFY_PENDING
2. **agent_drain_notify_buf**（每轮 LLM 调用前 + end_turn 后）：原子 mv NOTIFY_BUF → `util_read_msg` 逐条解析 RESP → display 转发 FD 4（复用 `display_sub_agent_result` 原始格式）→ 从字段构建纯文本注入 conversation
3. **非交互退出判断**：`cat "$ACTIVE_SUB_FILE"` ≤ 0 **且** `NOTIFY_BUF` 空 → SESSION_END

**解决的 bug 链**：

| Bug | 根因 | 修复 |
|-----|------|------|
| 非交互模式 SubAgent 结果丢失退出 | `$(<file 2>/dev/null \|\| echo 0)` 对已存在文件返回空字符串（Bash `$(<file)` 特殊语法被 `\|\|` 破坏） | 改用 `cat` |
| 计数器提前归零 | `agent_loop` 读管道延迟 > SubAgent 完成速度，notify reader 在递增前递减 | 计数器从 `agent_loop` 移到 `tool_sub_agent`（子进程创建前递增） |
| 结果打断流式 text delta | notify reader 直接写 FD 4 | display 移到 `agent_drain_notify_buf` 消费时（LLM 调用间隙） |
| fork 默认值为空字符串 | `fork="${3:-}"` 无默认 | `fork="${3:-false}"` + 归一化 |
| macOS `RS="\0"` 截断大输入 | BWK awk 中 `"\0"` 被当作空字符串，触发段落模式 | 恢复 `getline` 循环读取完整 stdin |

### 四版本架构对齐

| 对齐项 | Bash | Go | C | Rust |
|--------|------|-----|---|------|
| 独立结果通道 | NOTIFY_FIFO | `subResultCh` channel | `sub_result_queue` | `sub_result_rx/tx` channel |
| 非阻塞 drain 函数 | `agent_drain_notify_buf` | `drainSubAgentResults` | `agent_drain_sub_results` | `drain_sub_results` |
| 每轮迭代开头 drain | ✅ | ✅ | ✅ | ✅ |
| end_turn 后 drain | ✅ | ✅ (blocking select) | ✅ | ✅ |
| 计数器在 spawn 前递增 | ✅ | ✅ | ✅ | ✅ |
| fork 归一化 | ✅ | ✅ | ✅ | ✅ |
| RESP 类型统一 `AGENT_RESULT` | ✅ | ✅ | ✅ | ✅ |
| display 在消费时触发 | ✅ | ✅ | ✅ | ✅ |

**C 版本新增**：`mq_try_pop` 非阻塞出队 + `sub_result_queue` 独立队列
**Rust 版本修复**：`store_session_fork` 缺少 `create_dir_all` 导致 fork 复制静默失败

### 测试

- **新增测试**：`SUB_MULTI_MARKER` 多 SubAgent 并行 e2e 场景（mock server 同一响应返回两个 SubAgent tool_call）
- **四版本全部 179/179 通过** ✅
- `src/agent.sh` 净增从 +84 行精简到 **+49 行**（移除轮询循环、冗余 drain、冗余注释）

### 文档

更新 `docs/BASH_ARCHITECTURE.md`（10 个 section）：
- §1.1 进程模型：新增 notify reader 子 shell
- §1.2 FD 分配：FD 6（NOTIFY_FIFO）、FD 9（NOTIFY_BUF）
- §5.2/5.4：agent_main_loop + agent_loop_stream 完全重写
- §7.3：tool_sub_agent fork/counter/NOTIFY_FIFO
- §11：SubAgent 机制完全重写（6 个子节）
- §16.2：util_json_escape 更新为 awk 管道