### PR TITLE
fix: OpenAI SSE 兼容非标准 API + agent error 退出后 SubAgent 结果处理

### DIFF
--- a/c/transport.c
+++ b/c/transport.c
@@ -146,13 +146,19 @@ static void parse_openai_sse_event(StreamCtx *sctx, const char *data, size_t dat
                 char *id = json_get_string(tc, "id");
                 char *name = json_get_string(fn, "name");
                 char *arguments = json_get_string(fn, "arguments");
-                if (id) {
+                /* 非标准 OpenAI 兼容 API（如 sensenova）在后续 chunk 中
+                 * 发送空字符串 "" 而非省略字段，必须用 [0] 检查避免覆盖 */
+                if (id && id[0]) {
                     FREE_PTR(tool->id);
                     tool->id = id;
+                } else {
+                    FREE_PTR(id);
                 }
-                if (name) {
+                if (name && name[0]) {
                     FREE_PTR(tool->name);
                     tool->name = name;
+                } else {
+                    FREE_PTR(name);
                 }
                 if (arguments) {
                     sb_append(&tool->arguments, arguments);
@@ -161,7 +167,9 @@ static void parse_openai_sse_event(StreamCtx *sctx, const char *data, size_t dat
             }
         }
         char *finish = json_get_string(choice, "finish_reason");
-        if (finish) {
+        /* 非标准 API 可能用空字符串 "" 代替 null（如 sensenova），
+         * 空字符串不应触发 STOP */
+        if (finish && finish[0]) {
             if (strcmp(finish, "tool_calls") == 0) {
                 streamctx_emit_openai_tool_calls(sctx);
                 emit_simple_event(sctx->callback, sctx->ctx, SSE_STOP, "tool_use");

--- a/go/agent.go
+++ b/go/agent.go
@@ -952,6 +952,19 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 				a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", "Response truncated (max_tokens reached)"}})
 			}
 			a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, "idle"))
+			// error 退出后仍需消费 pending SubAgent 结果（对齐 C/Rust main_loop 的 active_sub_count 等待）
+			a.subMu.Lock()
+			hasPending := a.pendingSubAgents > 0
+			a.subMu.Unlock()
+			if hasPending {
+				select {
+				case r := <-a.subResultCh:
+					a.handleSubAgentResult(r)
+					continue
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
 			if loopErr != "" {
 				return fmt.Errorf("LLM error: %s", loopErr)
 			}

--- a/rust/src/sse.rs
+++ b/rust/src/sse.rs
@@ -456,15 +456,20 @@ pub mod openai {
                 for tc in tool_calls {
                     let idx = tc.get("index").and_then(Value::as_i64).unwrap_or(0);
                     let entry = pending_calls.entry(idx).or_default();
+                    /* 非标准 API（如 sensenova）在后续 chunk 发送空字符串 "" 而非省略字段 */
                     if let Some(v) = tc.get("id").and_then(Value::as_str) {
-                        entry.id = v.to_string();
+                        if !v.is_empty() {
+                            entry.id = v.to_string();
+                        }
                     }
                     if let Some(v) = tc
                         .get("function")
                         .and_then(|f| f.get("name"))
                         .and_then(Value::as_str)
                     {
-                        entry.name = v.to_string();
+                        if !v.is_empty() {
+                            entry.name = v.to_string();
+                        }
                     }
                     if let Some(v) = tc
                         .get("function")

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1435,6 +1435,7 @@ agent_loop_stream() {
         # Fatal stop reasons exit immediately
         case "$stop" in
             error|max_tokens|length)
+                rm -f "$AGENT_RUNNING_FLAG"
                 [[ "$stop" != "error" ]] && { util_write_msg "ERROR" "Response truncated (max_tokens reached)"; }
                 return 1
                 ;;

--- a/tests/fixtures/mock_server.py
+++ b/tests/fixtures/mock_server.py
@@ -726,6 +726,31 @@ class H(http.server.BaseHTTPRequestHandler):
                     'data: [DONE]\n\n',
                 ]: w.write(c.encode()); w.flush()
             return
+        # --- sensenova-style OpenAI SSE (finish_reason:"" + name:"" in subsequent chunks) ---
+        if b'SENSENOVA_STYLE_MARKER' in body and b'"tool_result"' not in body and b'"role":"tool"' not in body:
+            if path.startswith('/v1/chat/completions'):
+                for c in [
+                    # chunk 1: reasoning + tool_call start (id+name present, finish_reason="")
+                    'data: {\"id\":\"chatcmpl-sn\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"Calling tool.\"},\"finish_reason\":\"\"}]}\n\n',
+                    # chunk 2: tool_call with id+name (finish_reason="")
+                    'data: {\"id\":\"chatcmpl-sn\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_sn_1\",\"type\":\"function\",\"function\":{\"name\":\"Write\",\"arguments\":\"\"}}]},\"finish_reason\":\"\"}]}\n\n',
+                    # chunk 3: arguments delta — sensenova sends id:"" and name:"" instead of omitting
+                    'data: {\"id\":\"chatcmpl-sn\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"\",\"type\":\"function\",\"function\":{\"name\":\"\",\"arguments\":\"{\\\"path\\\":\\\"/tmp/bash-agent-sensenova-test.txt\\\"\"}}]},\"finish_reason\":\"\"}]}\n\n',
+                    # chunk 4: more arguments
+                    'data: {\"id\":\"chatcmpl-sn\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"\",\"type\":\"function\",\"function\":{\"name\":\"\",\"arguments\":\",\\\"content\\\":\\\"sn-ok\\\"}\"}}]},\"finish_reason\":\"\"}]}\n\n',
+                    # chunk 5: finish_reason=tool_calls
+                    'data: {\"id\":\"chatcmpl-sn\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\"},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":12}}\n\n',
+                    'data: [DONE]\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
+        if b'SENSENOVA_STYLE_MARKER' in body and (b'"tool_result"' in body or b'"role":"tool"' in body):
+            if path.startswith('/v1/chat/completions'):
+                for c in [
+                    'data: {\"id\":\"chatcmpl-sn-done\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Done.\"},\"finish_reason\":\"\"}]}\n\n',
+                    'data: {\"id\":\"chatcmpl-sn-done\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":12}}\n\n',
+                    'data: [DONE]\n\n',
+                ]: w.write(c.encode()); w.flush()
+            return
         if b'BASH_QUOTE_MARKER' in body and b'"tool_result"' not in body:
             if path.startswith('/v1/messages'):
                 for c in [

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -515,6 +515,24 @@ test_agent_openai_tool_write() {
     rm -f "$target_file"
 }
 
+test_agent_openai_sensenova_style() {
+    info "Test 11d: Agent e2e OpenAI sensenova-style SSE (finish_reason:\"\" + name:\"\" in subsequent chunks)"
+    local output target_file plain_output
+    target_file="/tmp/bash-agent-sensenova-test.txt"
+    rm -f "$target_file"
+    output=$("$AGENT" -p openai --base-url "$BASE/v1" -m test --api-key test -v 'SENSENOVA_STYLE_MARKER' 2>&1) || true
+    plain_output=$(printf '%s' "$output" | LC_ALL=C sed 's/\x1B\[[0-9;]*[[:alpha:]]//g')
+    if [[ -f "$target_file" ]] && \
+       grep -q 'sn-ok' "$target_file" && \
+       echo "$plain_output" | grep -Fq 'Write(/tmp/bash-agent-sensenova-test.txt) [' && \
+       echo "$plain_output" | grep -Fq 'Done.'; then
+        green "Agent e2e OpenAI sensenova-style SSE"; ((PASS++)) || true
+    else
+        red "Agent e2e OpenAI sensenova-style SSE"; echo "  Output: $output"; echo "  File: $(cat "$target_file" 2>/dev/null || true)"; ((FAIL++)) || true
+    fi
+    rm -f "$target_file"
+}
+
 test_agent_tool_result_persist_order() {
     info "Test 11c: assistant tool_use persisted before following tool_result"
     local output session_id conv_file
@@ -2606,6 +2624,7 @@ test_agent_e2e_claude
 test_agent_e2e_openai
 test_agent_openai_request_body
 test_agent_openai_tool_write
+test_agent_openai_sensenova_style
 test_agent_tool_result_persist_order
 test_agent_skill_injection
 test_agent_skill_injection_from_repo_skills_dir


### PR DESCRIPTION
## Bug 1: OpenAI SSE 非标准空字符串字段（C + Rust）

接入 sensenova 等 OpenAI 兼容 API 时，tool_call 解析失败（tool name 为空，`Unknown tool`）。

**根因**：sensenova 有两个非标准行为：
- `finish_reason: ""`（空字符串，标准是 `null`）
- 后续 tool_call chunk 中 `id: ""` / `name: ""`（空字符串，标准是省略）

| 版本 | `finish_reason:""` | `name:""` 覆盖 | 修复 |
|------|-------------------|---------------|------|
| Bash | ✅ `!= ""` | ✅ `!= ""` | 无需修 |
| Go | ✅ 只在 `[DONE]` 发 STOP | ✅ `!= ""` | 无需修 |
| C | ❌ `if(finish)` 触发提前 STOP | ❌ `if(name)` 空字符串覆盖 | `if(finish[0])` / `if(name[0])` |
| Rust | ✅ `!r.is_empty()` | ❌ `Some("")` 覆盖 | `if !v.is_empty()` |

**改动文件**：`c/transport.c`、`rust/src/sse.rs`

---

## Bug 2: agent error 退出后 SubAgent 结果无法触发新 loop（Bash + Go）

主 agent LLM 调用失败（curl timeout 等）后进入 idle，后台 SubAgent 结果到达后无法自动处理，用户必须手动输入。

**根因**：

- **Bash**：`agent_loop_stream` 的 `return 1` 跳过 `rm -f "$AGENT_RUNNING_FLAG"`，flag 残留导致 notify reader 不发 `NOTIFY_PENDING`。
- **Go**：`RunLoop` error `return` 跳过 pending SubAgent 检查。C/Rust 的 SubAgent 消费在 `main_loop` 层（`while active_sub_count > 0`），独立于退出原因，故无此 bug。

**改动文件**：`src/agent.sh`（+1 行）、`go/agent.go`（+13 行）

---

## 测试

- 新增 `SENSENOVA_STYLE_MARKER` mock 测试（`tests/fixtures/mock_server.py` + `tests/test.sh`）
- 模拟 sensenova 非标准 SSE 格式：`finish_reason:""` + 后续 chunk `name:""`/`id:""`
- 四版本 180/180 通过