### PR TITLE
feat: Ctrl+O inject input via notify pending channel

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -734,6 +734,16 @@ static int agent_drain_sub_results(Agent *agent) {
             store_conv_add_user(agent->paths.conversation, ctx.data);
             sb_free(&ctx);
             drained++;
+        } else if (sub_msg && sub_msg->type == MSG_USER_NOTIFY) {
+            /* 用户 Ctrl+O 中间介入 */
+            const char *text = sub_msg->data.user_notify.text ? sub_msg->data.user_notify.text : "";
+            /* display */
+            DisplayMessage *dm = malloc(sizeof(DisplayMessage));
+            *dm = display_msg_user_notify(text);
+            push_display_event(&agent->paths, agent->display_queue, dm);
+            /* conversation 注入：保留原始用户文本，不污染上下文 */
+            store_conv_add_user(agent->paths.conversation, text);
+            drained++;
         }
         input_message_free(sub_msg);
         free(sub_msg);
@@ -752,7 +762,9 @@ int agent_run_loop(Agent *agent, const char *user_input, const char *turn_kind) 
  * ============================================================ */
 
 int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
-    if (!user_input || !user_input[0]) return 0;
+    int is_notify = (turn_kind != NULL && strcmp(turn_kind, "notify") == 0);
+    if ((!user_input || !user_input[0]) && !is_notify) return 0;
+    if (is_notify && agent_drain_sub_results(agent) <= 0) return 0;
 
     /* 记录 user_input 事件 — 仅当 turn_kind 为 "user_input" 时记录
      * （与 bash 版对齐：sub_agent_result turn 不记录 user_input 事件） */
@@ -850,7 +862,9 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
     agent->interrupted = 0;
 
     /* 添加 user 消息到 conversation */
-    store_conv_add_user(agent->paths.conversation, user_input);
+    if (!is_notify) {
+        store_conv_add_user(agent->paths.conversation, user_input);
+    }
 
     /* 递增 turn 计数 — 对齐 bash 版 store_stats_update current_turn_count=+1 */
     store_stats_set_int_file(agent->paths.stats, "current_turn_count",
@@ -1746,12 +1760,29 @@ int agent_main_loop(Agent *agent) {
                                    sub_msg->data.async_task_result.output ? sub_msg->data.async_task_result.output : "");
                         agent_run_loop(agent, ctx.data, "async_task_result");
                         sb_free(&ctx);
+                    } else if (sub_msg->type == MSG_USER_NOTIFY) {
+                        /* 用户 Ctrl+O 介入：display + 原文 conversation 注入 + 触发一轮 */
+                        const char *ntext = sub_msg->data.user_notify.text ? sub_msg->data.user_notify.text : "";
+                        DisplayMessage *dm = malloc(sizeof(DisplayMessage));
+                        *dm = display_msg_user_notify(ntext);
+                        push_display_event(&agent->paths, agent->display_queue, dm);
+                        agent_run_loop(agent, ntext, "user_notify");
                     }
                     input_message_free(sub_msg);
                     free(sub_msg);
                 }
 
                 /* 所有轮次完成：等待 display 队列写完 */
+                if (agent->interactive) {
+                    display_flush(agent->display_queue);
+                }
+                break;
+            }
+            case MSG_NOTIFY_PENDING: {
+                agent->interrupted = 0;
+                agent->running = 1;
+                agent_run_loop(agent, "", "notify");
+                agent->running = 0;
                 if (agent->interactive) {
                     display_flush(agent->display_queue);
                 }

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -347,6 +347,10 @@ int main(int argc, char *argv[]) {
         linenoiseSetImagePasteCallback(image_paste_wrapper);
         g_paste_session_dir = agent->paths.session_dir;
 
+        /* 注册 Ctrl+O inject callback */
+        readline_set_inject_queues(agent->sub_result_queue, &input_queue);
+        linenoiseSetInjectCallback(inject_callback);
+
         readline_thread_start(&readline_thread, &rcfg);
 
         /* 主循环 */

--- a/c/display.c
+++ b/c/display.c
@@ -158,6 +158,10 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
             signal_flush(msg);
             sb_free(&buf);
             return;
+        case DISPLAY_USER_NOTIFY:
+            /* USER_NOTIFY 不输出到 stream-json（与 Rust/Go 一致） */
+            sb_free(&buf);
+            return;
         }
         fprintf(out, "%s\n", buf.data);
         fflush(out);
@@ -323,6 +327,15 @@ static void render_message(FILE *out, DisplayState *ds, OutputFormat format,
         case DISPLAY_FLUSH:
             signal_flush(msg);
             break;
+
+        case DISPLAY_USER_NOTIFY: {
+            ensure_newline(ds);
+            linenoisePrintf("\x1b[33m[user inject] %s\x1b[0m\n",
+                    msg->content ? msg->content : "");
+            ds->last_char[0] = '\n';
+            ds->prev_was_thinking = 0;
+            break;
+        }
     }
 }
 

--- a/c/protocol.c
+++ b/c/protocol.c
@@ -23,6 +23,11 @@ void input_message_free(InputMessage *msg) {
             FREE_PTR(msg->data.async_task_result.task_id);
             FREE_PTR(msg->data.async_task_result.output);
             break;
+        case MSG_USER_NOTIFY:
+            FREE_PTR(msg->data.user_notify.text);
+            break;
+        case MSG_NOTIFY_PENDING:
+            break;
     }
 }
 
@@ -126,6 +131,14 @@ DisplayMessage display_msg_async_task_result(const char *task_id, int exit_code,
     m.session_id = util_strdup(task_id);
     m.tool_exit_code = exit_code;
     m.content = util_strdup(output ? output : "");
+    return m;
+}
+
+DisplayMessage display_msg_user_notify(const char *text) {
+    DisplayMessage m;
+    memset(&m, 0, sizeof(m));
+    m.type = DISPLAY_USER_NOTIFY;
+    m.content = util_strdup(text ? text : "");
     return m;
 }
 

--- a/c/protocol.h
+++ b/c/protocol.h
@@ -19,6 +19,8 @@ typedef enum {
     MSG_USER_INPUT,       /* 用户从 stdin 输入 */
     MSG_AGENT_RESULT,     /* SubAgent 完成后发送结果 */
     MSG_ASYNC_TASK_RESULT,/* 异步 Bash 任务完成 */
+    MSG_USER_NOTIFY,      /* 用户 Ctrl+O 中间介入（走 sub_result_queue） */
+    MSG_NOTIFY_PENDING,   /* 唤醒主循环消费 pending notify */
 } InputMsgType;
 
 typedef struct {
@@ -43,6 +45,9 @@ typedef struct {
             int exit_code;
             char *output;           /* 可能为 NULL */
         } async_task_result;
+        struct {
+            char *text;             /* 用户 Ctrl+O 介入的文本 */
+        } user_notify;
     } data;
 } InputMessage;
 
@@ -67,6 +72,7 @@ typedef enum {
     DISPLAY_CONTEXT_UPDATE,      /* 上下文压缩通知 */
     DISPLAY_FLUSH,               /* display 队列同步屏障 */
     DISPLAY_IMAGE_DESCRIBE,      /* 图片描述结果 */
+    DISPLAY_USER_NOTIFY,         /* 用户 Ctrl+O 介入输入 */
 } DisplayMsgType;
 
 typedef struct {
@@ -108,6 +114,7 @@ DisplayMessage display_msg_async_task_result(const char *task_id, int exit_code,
                                              const char *output);
 DisplayMessage display_msg_context_update(const char *trigger);
 DisplayMessage display_msg_image_describe(const char *images, const char *description);
+DisplayMessage display_msg_user_notify(const char *text);
 
 /* 释放 DisplayMessage 内部动态分配的内存 */
 void display_message_free(DisplayMessage *msg);

--- a/c/readline.c
+++ b/c/readline.c
@@ -30,9 +30,19 @@ static volatile sig_atomic_t g_sigint_received = 0;
 static volatile int *g_agent_interrupted = NULL;
 static const volatile int *g_agent_running = NULL;
 
+/* sub_result_queue 指针 — 供 inject callback 写入 USER_NOTIFY */
+static MsgQueue *g_inject_sub_queue = NULL;
+/* input_queue 指针 — 供 inject callback 发送 MSG_NOTIFY_PENDING 唤醒主循环 */
+static MsgQueue *g_inject_input_queue = NULL;
+
 void readline_set_agent_interrupted(volatile int *interrupted, const volatile int *running) {
     g_agent_interrupted = interrupted;
     g_agent_running = running;
+}
+
+void readline_set_inject_queues(MsgQueue *sub_queue, MsgQueue *input_queue) {
+    g_inject_sub_queue = sub_queue;
+    g_inject_input_queue = input_queue;
 }
 
 static void sigint_handler(int sig) {
@@ -61,6 +71,41 @@ static char *build_history_path(const char *home) {
     sb_init(&path);
     sb_appendf(&path, "%s/.bash-agent/history", home ? home : "/");
     return path.data; /* 调用者负责 free */
+}
+
+/* ============================================================
+ * Ctrl+O inject callback — linenoise calls this
+ * when the user presses Ctrl+O. The current edit buffer text is always
+ * queued as pending notify, then the main loop is woken up.
+ * ============================================================ */
+
+int inject_callback(char *buf, size_t len) {
+    if (!buf || len == 0 || !g_inject_sub_queue || !g_inject_input_queue) return 1;
+
+    char *text = malloc(len + 1);
+    if (!text) return 1;
+    memcpy(text, buf, len);
+    text[len] = '\0';
+
+    InputMessage *msg = calloc(1, sizeof(InputMessage));
+    if (!msg) { free(text); return 1; }
+    msg->type = MSG_USER_NOTIFY;
+    msg->data.user_notify.text = text;
+    if (mq_push(g_inject_sub_queue, msg) != 0) {
+        input_message_free(msg);
+        free(msg);
+        return 1;
+    }
+
+    InputMessage *wakeup = calloc(1, sizeof(InputMessage));
+    if (wakeup) {
+        wakeup->type = MSG_NOTIFY_PENDING;
+        if (mq_push(g_inject_input_queue, wakeup) != 0) {
+            input_message_free(wakeup);
+            free(wakeup);
+        }
+    }
+    return 0;
 }
 
 /* ============================================================

--- a/c/readline.h
+++ b/c/readline.h
@@ -26,4 +26,12 @@ int readline_thread_start(pthread_t *thread, const ReadlineConfig *cfg);
  * running: agent_loop 执行中为 1，readline 据此判断 Ctrl+C 是否应中断 */
 void readline_set_agent_interrupted(volatile int *interrupted, const volatile int *running);
 
+/* 设置 inject callback 使用的队列指针（Ctrl+O 中间介入）
+ * sub_queue: 写入 USER_NOTIFY pending
+ * input_queue: 写入 MSG_NOTIFY_PENDING 唤醒主循环 */
+void readline_set_inject_queues(MsgQueue *sub_queue, MsgQueue *input_queue);
+
+/* Ctrl+O inject callback — 供 linenoise 调用 */
+int inject_callback(char *buf, size_t len);
+
 #endif /* READLINE_H */

--- a/docs/BASH_ARCHITECTURE.md
+++ b/docs/BASH_ARCHITECTURE.md
@@ -11,57 +11,85 @@
 ### 1.1 进程模型
 
 ```mermaid
-graph TB
-    subgraph Main["主进程 (agent_main_loop)"]
-        MainLoop["main loop<br/>util_read_msg &lt;&amp;3"]
-        FD3["FD 3 ← INPUT_FIFO (读)"]
-        FD5["FD 5 → INPUT_FIFO (写, 防 EOF)"]
-        FD4["FD 4 → display_stream"]
-        FD7["FD 7 ← agent_loop_stream"]
-        FD8["FD 8 ← llm_call"]
-        FD9["FD 9 ← NOTIFY_BUF"]
-
-        MainLoop --- FD3
-        MainLoop --- FD7
-
-        subgraph ALS["agent_loop_stream (process sub)"]
-            ALSBody["LLM 调用 + 工具执行<br/>agent_drain_notify_buf()"]
-            Flag["AGENT_RUNNING_FLAG<br/>(运行中标记)"]
-            ALSBody --- Flag
-        end
-
-        subgraph NR["notify reader (background)"]
-            NRBody["阻塞读 NOTIFY_FIFO<br/>写 NOTIFY_BUF<br/>更新 ACTIVE_TASK_FILE"]
-            NRCheck{"AGENT_RUNNING_FLAG<br/>不存在?"}
-            NRBody --> NRCheck
-            NRCheck -- "是" --> NPPending["发 NOTIFY_PENDING → FD 5"]
-            NRCheck -- "否" --> NRSkip["不发 (靠 drain 消费)"]
-        end
-
-        subgraph DS["display_stream (process sub)"]
-            DSBody["RESP → 终端渲染"]
-        end
-
-        MainLoop --> FD4
-        ALSBody --> FD8
-        ALSBody --> FD7
-        NRBody --> FD5
+graph LR
+    subgraph Input["输入 / 唤醒"]
+        direction TB
+        TTY["终端 stdin"]
+        StdinReader["stdin_reader<br/>readline → USER_INPUT / SESSION_END"]
+        InputFIFO["INPUT_FIFO<br/>FD3 读 / FD5 写保活"]
+        TTY --> StdinReader -->|"USER_INPUT / SESSION_END"| InputFIFO
     end
 
-    subgraph SA["Sub-Agent (后台子进程)"]
-        SABody["agent_loop (子 shell)<br/>完成后 store_sub_send_result"]
+    subgraph Main["主进程：agent_main_loop / agent_loop"]
+        direction TB
+        MainLoop["agent_main_loop<br/>util_read_msg &lt;&amp;3"]
+        RunLoop["agent_run_loop"]
+        AgentLoop["agent_loop<br/>写 user_input / 读 FD7 / 转发 FD4"]
+        DisplayPipe["FD4 → display_stream"]
+        MainLoop -->|"USER_INPUT"| RunLoop --> AgentLoop
+        MainLoop -->|"NOTIFY_PENDING"| RunLoop
+        AgentLoop --> DisplayPipe
     end
 
-    Terminal["终端 stdin"]
-    StdinReader["stdin_reader (background)<br/>readline → USER_INPUT"]
+    subgraph Stream["agent_loop_stream 子进程"]
+        direction TB
+        Running["AGENT_RUNNING_FLAG<br/>进入每轮 LLM 前创建；结束/error 删除"]
+        Drain["agent_drain_notify_buf<br/>LLM 调用前 + end_turn 后"]
+        Compact["agent_compact_context auto"]
+        LLM["llm_call<br/>FD8 读取 SSE 解析结果"]
+        Tools["tool dispatch<br/>SubAgent / Bash background=true"]
+        FD7["stdout RESP → FD7"]
+        Running --> Drain --> Compact --> LLM --> Tools --> FD7
+        Drain -->|"AGENT_RESULT / ASYNC_TASK_RESULT<br/>写 stdout"| FD7
+    end
 
-    Terminal --> StdinReader
-    StdinReader -->|FD 5| FD5
-    SABody -->|写入| NOTIFY_FIFO
-    NOTIFY_FIFO -->|FD 6| NRBody
+    subgraph Notify["notify 通道"]
+        direction TB
+        NotifyFIFO["NOTIFY_FIFO<br/>FD6 双端打开"]
+        NotifyReader["notify reader<br/>阻塞读 FD6"]
+        NotifyBuf["NOTIFY_BUF<br/>RESP 结果缓冲"]
+        Store["events.jsonl / stats.json<br/>记录事件；SubAgent 统计"]
+        Active["ACTIVE_TASK_FILE<br/>SubAgent + bg-bash 活跃计数"]
+        IdleCheck{"AGENT_RUNNING_FLAG 存在?"}
+        Hold["不唤醒<br/>等待 agent_drain_notify_buf"]
+        NotifyFIFO --> NotifyReader
+        NotifyReader -->|"写结果 RESP"| NotifyBuf
+        NotifyReader --> Store
+        NotifyReader -->|"递减"| Active
+        NotifyReader --> IdleCheck
+        IdleCheck -->|"否：idle，写 NOTIFY_PENDING"| InputFIFO
+        IdleCheck -->|"是：运行中"| Hold
+    end
 
-    style Flag fill:#ff9,stroke:#333
-    style NRCheck fill:#fdf,stroke:#333
+    subgraph Workers["后台任务"]
+        direction TB
+        SubAgent["SubAgent 子 shell<br/>store_sub_send_result"]
+        BgBash["bg-bash 子 shell<br/>Bash background=true"]
+        SubAgent -->|"AGENT_RESULT<br/>sid status thinking text in out cr cc reqs"| NotifyFIFO
+        BgBash -->|"ASYNC_TASK_RESULT<br/>task_id exit_code output"| NotifyFIFO
+    end
+
+    subgraph Display["输出"]
+        direction TB
+        DisplayStream["display_stream 子进程"]
+        Terminal["终端 stderr"]
+        DisplayStream --> Terminal
+    end
+
+    DisplayPipe --> DisplayStream
+    InputFIFO --> MainLoop
+    AgentLoop -->|"启动 process substitution"| Running
+    FD7 -->|"util_read_msg &lt;&amp;7"| AgentLoop
+    LLM -->|"HTTP stream"| API["LLM API"]
+    Tools -.->|"启动后台任务；递增 ACTIVE_TASK_FILE"| SubAgent
+    Tools -.->|"启动后台任务；递增 ACTIVE_TASK_FILE"| BgBash
+
+    classDef hot fill:#fff3cd,stroke:#d39e00,color:#111
+    classDef queue fill:#e3f2fd,stroke:#1976d2,color:#111
+    classDef worker fill:#f3e5f5,stroke:#7b1fa2,color:#111
+    class Running,IdleCheck hot
+    class InputFIFO,NotifyFIFO,NotifyBuf queue
+    class SubAgent,BgBash worker
 ```
 
 ### 1.2 FD 分配（固定）
@@ -101,12 +129,15 @@ $len1\r\ndata1\r\n   — 字段1
 | ERROR | message | LLM/内部 |
 | RETRY | (无) | LLM SSE (retry 信号) |
 | CONTEXT_UPDATE | kind, trigger | compact |
-| AGENT_RESULT | session_id, status, in, out, thinking, text | sub-agent 完成（NOTIFY_FIFO） |
-| NOTIFY_PENDING | (无) | notify reader → 主循环（触发 notify turn） |
+| AGENT_RESULT | session_id, status, in, out, thinking, text | notify reader → NOTIFY_BUF → drain；SubAgent 完成结果 |
+| ASYNC_TASK_RESULT | task_id, exit_code, output | notify reader → NOTIFY_BUF → drain；bg-bash 完成结果 |
+| NOTIFY_PENDING | (无) | notify reader → INPUT_FIFO；idle 时触发 notify turn |
 | USER_INPUT | seq, content | 用户输入 |
 | SESSION_END | code | 退出 |
 | IMAGE_DESCRIBE | images, description | 图片描述 |
 | USER_MESSAGE | content | 用户消息回显 |
+
+> 注意：SubAgent 写入 `NOTIFY_FIFO` 的原始 `AGENT_RESULT` 字段顺序是 `session_id, status, thinking, text, in, out, cr, cc, reqs`；notify reader 写入 `NOTIFY_BUF` 并转发给 display/conversation 时规范化为 `session_id, status, in, out, thinking, text`。
 
 ---
 
@@ -326,11 +357,14 @@ curl output → http_stream.awk (解析 HTTP headers/chunked) → sse_convert (p
 
 ### 5.1 三层循环架构
 
-```
-agent_main_loop()       — 最外层：读 INPUT_FIFO，分发 USER_INPUT / AGENT_RESULT
-  └─ agent_run_loop()   — 包装层：调用 agent_loop + 更新终端标题 + 交互提示符
-      └─ agent_loop()   — 中间层：用户输入处理 + 图片展开 + 事件记录 + SIGINT
-          └─ agent_loop_stream() — 最内层：LLM 调用 + 工具执行 + compact
+```mermaid
+graph TB
+    Main["agent_main_loop()<br/>最外层：读 INPUT_FIFO<br/>分发 USER_INPUT / NOTIFY_PENDING / SESSION_END"]
+    Run["agent_run_loop()<br/>包装层：调用 agent_loop<br/>更新终端标题 + 交互提示符"]
+    Loop["agent_loop()<br/>中间层：用户输入处理 + 图片展开<br/>事件记录 + SIGINT + display 转发"]
+    Stream["agent_loop_stream()<br/>最内层：drain notify + compact<br/>LLM 调用 + 工具执行"]
+
+    Main --> Run --> Loop --> Stream
 ```
 
 ### 5.2 agent_main_loop()
@@ -349,24 +383,28 @@ agent_main_loop() {
         while util_read_msg <&6; do
             case "${REPLY_MESSAGE[0]}" in
                 AGENT_RESULT)
-                    # 解析字段
+                    # NOTIFY_FIFO 原始字段：sid status thinking text in out cr cc reqs
                     _sid="${REPLY_MESSAGE[1]}" _status="${REPLY_MESSAGE[2]}"
                     _thinking="${REPLY_MESSAGE[3]}" _text="${REPLY_MESSAGE[4]}"
-                    _in="${REPLY_MESSAGE[5]}" _out="${REPLY_MESSAGE[6]}" ...
+                    _in="${REPLY_MESSAGE[5]:-0}" _out="${REPLY_MESSAGE[6]:-0}" ...
 
-                    # 记录事件（usage, sub_agent_result, sub_agent_end）
+                    # 记录事件（usage, sub_agent_result, sub_agent_end）并更新 stats
                     store_event_append ...
+                    store_stats_update ...
 
-                    # AGENT_RESULT RESP 追加到 NOTIFY_BUF
-                    util_write_msg "AGENT_RESULT" ... >> "$NOTIFY_BUF"
-
-                    # 递减 ACTIVE_TASK_FILE 计数器（大于 0 才减）
-                    _cnt=$(cat "$ACTIVE_TASK_FILE"); (( _cnt > 0 )) && _cnt--
-
-                    # idle 时（无 AGENT_RUNNING_FLAG）触发 notify turn
-                    if [[ ! -f "$AGENT_RUNNING_FLAG" ]]; then
-                        util_write_msg "NOTIFY_PENDING" >&5
-                    fi
+                    # NOTIFY_BUF 规范化字段：sid status in out thinking text
+                    util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
+                    _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
+                    (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
+                    [[ ! -f "$AGENT_RUNNING_FLAG" ]] && util_write_msg "NOTIFY_PENDING" >&5
+                    ;;
+                ASYNC_TASK_RESULT)
+                    # 字段：task_id exit_code output
+                    store_event_append '{"type":"async_task_result",...}'
+                    util_write_msg "${REPLY_MESSAGE[@]}" >> "$NOTIFY_BUF"
+                    _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
+                    (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
+                    [[ ! -f "$AGENT_RUNNING_FLAG" ]] && util_write_msg "NOTIFY_PENDING" >&5
                     ;;
             esac
         done
@@ -380,7 +418,7 @@ agent_main_loop() {
             USER_INPUT)
                 saw_user_input=true
                 agent_run_loop "${REPLY_MESSAGE[2]:-${REPLY_MESSAGE[1]:-}}"
-                # 非交互模式：无活跃子 agent 且无待读结果 → 退出
+                # 非交互模式：无活跃后台任务且无待读结果 → 退出
                 if [[ "$INTERACTIVE" != true ]]; then
                     local _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
                     (( _cnt <= 0 )) && [[ ! -s "$NOTIFY_BUF" ]] && util_write_msg "SESSION_END" >&5
@@ -407,7 +445,7 @@ agent_main_loop() {
 **关键设计变化（vs 旧版）**：
 - **双 FIFO**：INPUT_FIFO（用户输入 + NOTIFY_PENDING）+ NOTIFY_FIFO（SubAgent / bg-bash 结果）
 - **notify reader 子 shell**：后台阻塞读 NOTIFY_FIFO，解析 AGENT_RESULT / ASYNC_TASK_RESULT，写入 NOTIFY_BUF
-- **ACTIVE_TASK_FILE**：文件计数器（同时跟踪 SubAgent 和 bg-bash），在 `tool_sub_agent` / async bash 中子进程创建前递增，在 notify reader 中递减
+- **ACTIVE_TASK_FILE**：文件计数器（同时跟踪 SubAgent 和 bg-bash），在 `tool_sub_agent` / `Bash background=true` 中子进程创建前递增，在 notify reader 中递减
 - **AGENT_RUNNING_FLAG**：标记 agent_loop_stream 是否运行中。运行中时 notify reader 不发 NOTIFY_PENDING（靠 `agent_drain_notify_buf` 在下一轮迭代消费）
 - **退出判断**：`_cnt <= 0 && NOTIFY_BUF 空 → SESSION_END`
 - **时序区别**（关键）：
@@ -430,8 +468,8 @@ agent_loop() {
     #    - 记录 image_describe 事件
     #    - 将描述追加到 user_input 后面
     
-    # 3. 写入 conversation
-    store_conv_add_user "$user_input"
+    # 3. 写入 conversation（notify turn 不写空 user_input）
+    [[ "$turn_kind" != notify ]] && store_conv_add_user "$user_input"
     store_stats_update current_turn_count=+1
     
     # 4. SIGINT trap：关闭 FD 7 + 杀 curl
@@ -442,9 +480,8 @@ agent_loop() {
     
     # 6. 读取 agent_loop_stream 的 RESP 消息
     while util_read_msg <&7; do
-        # 记录 SubAgent 计数
-        [[ TOOL_CALL && SubAgent ]] && active_task_count++
         # 序列化为 stream event，记录到 events.jsonl
+        # 注意：后台任务计数在 tool_sub_agent / Bash background=true 中递增，不在这里递增
         _se=$(util_msg_to_stream) && store_event_append "$_se"
         # 转发给 display（非 stream-json 模式）
         util_is_stream_json || ( util_write_msg ... ) >&4
@@ -470,7 +507,7 @@ agent_loop_stream() {
         # ① agent_loop 运行中标记（notify reader 见此标记不发 NOTIFY_PENDING）
         : > "$AGENT_RUNNING_FLAG"
         
-        # ② 消费 NOTIFY_BUF（SubAgent 结果），在 LLM 调用前处理
+        # ② 消费 NOTIFY_BUF（SubAgent / bg-bash 结果），在 LLM 调用前处理
         agent_drain_notify_buf || true
         
         # ③ Compact before LLM call
@@ -518,7 +555,7 @@ agent_loop_stream() {
         if stop == tool_use|tool_calls → continue loop
         else:
             rm -f "$AGENT_RUNNING_FLAG"       # 移除运行标记
-            agent_drain_notify_buf && continue  # 有 SubAgent 结果 → 继续处理
+            agent_drain_notify_buf && continue  # 有 SubAgent / bg-bash 结果 → 继续处理
             util_write_msg "STOP" "$stop"
             break
     done
@@ -531,9 +568,9 @@ agent_loop_stream() {
 
 **新增设计（vs 旧版）**：
 - 每轮迭代开头创建 `AGENT_RUNNING_FLAG`，结束时移除
-- 每轮迭代开头和 end_turn 后都调用 `agent_drain_notify_buf` 消费 SubAgent 结果
-- end_turn 后如果有 SubAgent 结果 → `continue` 继续处理（不打断流式输出）
-- **`agent_drain_notify_buf` 消费时**：RESP 解析 → AGENT_RESULT 转发 FD 4（display_sub_agent_result 原始格式）→ 从字段构建纯文本注入 conversation
+- 每轮迭代开头和 end_turn 后都调用 `agent_drain_notify_buf` 消费 SubAgent / bg-bash 结果
+- end_turn 后如果有后台结果 → `continue` 继续处理（不打断流式输出）
+- **`agent_drain_notify_buf` 消费时**：RESP 解析 → AGENT_RESULT / ASYNC_TASK_RESULT 写 stdout → agent_loop 转发 FD4 → 从字段构建纯文本注入 conversation
 
 **RETRY 处理细节**：
 当收到 RETRY 消息时，重置所有累积变量：`text="" thinking="" tool_calls="" tool_conv_results="" _ctx_tokens=""`。这是为了丢弃 retry 前的部分响应。
@@ -1012,20 +1049,34 @@ tool_bash_mode_allows() {
 
 ### 9.1 目录结构
 
-```
-~/.bash-agent/projects/<project-key>/<session-id>/
-  conversation.jsonl  — 对话历史（每行一个 JSON 消息）
-  events.jsonl        — 事件日志
-  stats.json          — 统计数据
-  summary.txt         — 上下文摘要
-  plan.md             — 已确认计划
-  plan.draft          — 计划草稿
-  images/             — 粘贴的图片
-  input.fifo          — 用户输入管道（运行时）
-  notify.fifo         — SubAgent 结果通知管道（运行时）
-  notify.buf          — SubAgent 结果缓冲（NOTIFY_BUF，RESP 格式）
-  active_task.count    — 活跃 SubAgent 计数器
-  agent_running.flag  — agent_loop_stream 运行中标记
+```mermaid
+graph TB
+    Root["~/.bash-agent/projects/&lt;project-key&gt;/&lt;session-id&gt;/"]
+    Conv["conversation.jsonl<br/>对话历史，每行一个 JSON 消息"]
+    Events["events.jsonl<br/>事件日志"]
+    Stats["stats.json<br/>统计数据"]
+    Summary["summary.txt<br/>上下文摘要"]
+    Plan["plan.md<br/>已确认计划"]
+    Draft["plan.draft<br/>计划草稿"]
+    Images["images/<br/>粘贴的图片"]
+    Input["input.fifo<br/>用户输入 + NOTIFY_PENDING，运行时"]
+    NotifyFifo["notify.fifo<br/>SubAgent / bg-bash 结果通知，运行时"]
+    NotifyBuf["notify.buf<br/>后台结果缓冲，RESP 格式"]
+    Active["active_task.count<br/>活跃 SubAgent / bg-bash 计数器"]
+    Running["agent_running.flag<br/>agent_loop_stream 运行中标记"]
+
+    Root --> Conv
+    Root --> Events
+    Root --> Stats
+    Root --> Summary
+    Root --> Plan
+    Root --> Draft
+    Root --> Images
+    Root --> Input
+    Root --> NotifyFifo
+    Root --> NotifyBuf
+    Root --> Active
+    Root --> Running
 ```
 
 ### 9.2 project_key 计算
@@ -1209,6 +1260,7 @@ display_stream() { while util_read_msg; do display_message; done }
 | TOOL_CALL | 黄色 `\033[33m[tool] summary\033[0m`；调用 `tool_call_summary` |
 | TOOL_RESULT | Edit→全量输出+换行；Read/Write→第一行+换行；其他→全量+换行 |
 | AGENT_RESULT | 紫色/红色状态行；thinking 截断 120 字符；text 截断 120 字符 |
+| ASYNC_TASK_RESULT | 青色/红色 `[bg-bash task_id] exit_code=N`；output 截断 120 字符 |
 | IMAGE_DESCRIBE | 青色 `📸 images: description` |
 | USER_MESSAGE | 绿色 `> text`（截断 80 字符） |
 | STOP | interrupted → 青色 "Interrupted."；其他 → 确保换行 |
@@ -1249,21 +1301,28 @@ fi
 
 ---
 
-## 11. SubAgent 机制
+## 11. SubAgent / bg-bash 后台结果机制
 
-### 11.1 双 FIFO 架构
+### 11.1 双 FIFO + notify buffer 架构
 
-```
-INPUT_FIFO:  用户输入 + NOTIFY_PENDING（主循环读）
-NOTIFY_FIFO: SubAgent 结果（notify reader 读）
+```mermaid
+graph LR
+    User["stdin_reader"] -->|"USER_INPUT"| Input["INPUT_FIFO<br/>主循环读"]
+    NotifyReader["notify reader"] -->|"NOTIFY_PENDING<br/>仅 idle 时"| Input
+    Input --> Main["agent_main_loop"]
 
-NOTIFY_BUF:  SubAgent 结果缓冲文件（RESP 格式）
-ACTIVE_TASK_FILE: 活跃计数器（文件）
-AGENT_RUNNING_FLAG: agent_loop_stream 运行标记（文件）
+    Sub["SubAgent 子 shell"] -->|"AGENT_RESULT"| NotifyFifo["NOTIFY_FIFO<br/>notify reader 阻塞读"]
+    Bg["bg-bash 子 shell"] -->|"ASYNC_TASK_RESULT"| NotifyFifo
+    NotifyFifo --> NotifyReader
+    NotifyReader -->|"结果 RESP"| Buf["NOTIFY_BUF<br/>后台结果缓冲"]
+    NotifyReader -->|"递减"| Active["ACTIVE_TASK_FILE<br/>活跃任务计数"]
+    Stream["agent_loop_stream"] -->|"LLM 边界 drain"| Buf
+    Buf -->|"display + conversation 注入"| Stream
 ```
 
 ### 11.2 启动流程
 
+**SubAgent**：
 1. `sub_session_id = "sub_$(util_new_session_id)"`
 2. `fork="${3:-false}"`，归一化为 `true` 或 `false`
 3. 记录 `sub_agent_start` 事件（`>/dev/null`）
@@ -1278,6 +1337,14 @@ AGENT_RUNNING_FLAG: agent_loop_stream 运行标记（文件）
    - `agent_loop "$prompt"`
    - `store_sub_send_result`
 
+**bg-bash (`Bash background=true`)**：
+1. `task_id = "task_$(util_new_session_id)"`
+2. **子 shell 创建前**递增 `ACTIVE_TASK_FILE` 计数器
+3. `mktemp` 捕获 stdout/stderr
+4. 后台子 shell 执行 `bash -lc "$cmd" > "$tmpout" 2>&1`
+5. 使用 `sanitize_utf8.awk` 清理输出
+6. 写入父进程 `NOTIFY_FIFO`：`ASYNC_TASK_RESULT task_id exit_code output`
+
 ### 11.3 结果传递
 
 ```bash
@@ -1285,8 +1352,10 @@ store_sub_send_result() {
     # 使用 send_sub_result.awk 从子会话的 stats.json 和 conversation.jsonl 提取:
     # - thinking (最后一条 assistant 的 thinking)
     # - text (最后一条 assistant 的 text)
-    # - usage 统计 (in/out/cr/cc)
+    # - usage 统计 (in/out/cr/cc/reqs)
     # 写入父进程的 NOTIFY_FIFO（不是 INPUT_FIFO）
+    # 原始字段：AGENT_RESULT session_id status thinking text in out cr cc reqs
+    # notify reader 写入 NOTIFY_BUF 时规范化为：AGENT_RESULT session_id status in out thinking text
 }
 ```
 
@@ -1344,7 +1413,7 @@ Bash 是基准实现，C/Go/Rust 是 Port 版本，用各自语言的并发原�
 | 通道 | Bash | C | Go | Rust |
 |------|------|---|----|------|
 | 用户输入 | `INPUT_FIFO` (named pipe) | `input_queue` (MsgQueue) | `rl.Input()` channel | `msg_rx` (mpsc) |
-| SubAgent 结果 | `NOTIFY_FIFO` + `NOTIFY_BUF` | `sub_result_queue` (MsgQueue) | `subResultCh` channel | `sub_result_rx` (mpsc) |
+| 后台结果（SubAgent / bg-bash） | `NOTIFY_FIFO` + `NOTIFY_BUF` | `sub_result_queue` (MsgQueue) | `subResultCh` channel | `sub_result_rx` (mpsc) |
 | Display 输出 | `FD 4` → display_stream 子进程 | `display_queue` (MsgQueue) | display event channel | display worker thread channel |
 | Agent 运行标记 | `AGENT_RUNNING_FLAG` (文件) | `agent->running` (原子变量) | `agent.running` (atomic) | `self.running` (AtomicBool) |
 | 活跃任务计数 | `ACTIVE_TASK_FILE` (文件) | `agent->active_task_count` (原子变量) | `pendingTasks` (mutex) | `active_task_count` (i64) |
@@ -1352,145 +1421,193 @@ Bash 是基准实现，C/Go/Rust 是 Port 版本，用各自语言的并发原�
 ### Bash 版 — 双 FIFO + 文件标记
 
 ```mermaid
-graph TB
-    subgraph Bash["Bash (FIFO + 文件)"]
+graph LR
+    subgraph In["输入"]
         direction TB
-        BL["stdin_reader 子进程"]
-        BInput["INPUT_FIFO (FD 3/5)"]
-        BMain["main loop<br/>agent_run_loop"]
-        BAgent["agent_loop_stream<br/>(LLM call + tool exec)"]
-        BDrain["agent_drain_notify_buf()<br/>NOTIFY_BUF (FD 9)"]
-        BNR["notify reader 子 shell"]
-        BNRFifo["NOTIFY_FIFO (FD 6)"]
-        BDisp["display_stream 子进程<br/>(FD 4)"]
-        BFlag["AGENT_RUNNING_FLAG"]
-        BActive["ACTIVE_TASK_FILE"]
+        BL["stdin_reader"]
+        BInput["INPUT_FIFO<br/>FD3/FD5"]
+        BL -->|"USER_INPUT"| BInput
     end
-    BSub["Sub-Agent 子 shell"]
 
-    BL -->|"USER_INPUT"| BInput
+    subgraph Bash["Bash 主流程"]
+        direction TB
+        BMain["agent_main_loop"]
+        BRun["agent_run_loop / agent_loop"]
+        BAgent["agent_loop_stream<br/>LLM call + tool exec"]
+        BDrain["agent_drain_notify_buf()<br/>读 NOTIFY_BUF (FD9)"]
+        BDisp["display_stream<br/>FD4"]
+        BFlag["AGENT_RUNNING_FLAG"]
+        BMain --> BRun --> BAgent
+        BAgent -->|"LLM 前 + end_turn 后"| BDrain
+        BAgent --> BDisp
+        BAgent -->|"每轮创建 / 退出删除"| BFlag
+    end
+
+    subgraph Notify["后台结果通道"]
+        direction TB
+        BNRFifo["NOTIFY_FIFO<br/>FD6 双端打开"]
+        BNR["notify reader"]
+        BBuf["NOTIFY_BUF"]
+        BActive["ACTIVE_TASK_FILE"]
+        BNRFifo --> BNR --> BBuf
+        BNR -->|"递减"| BActive
+        BNR -->|"检查"| BFlag
+    end
+
+    subgraph Bg["后台任务"]
+        direction TB
+        BSub["SubAgent 子 shell"]
+        BBash["bg-bash 子 shell"]
+        BSub -->|"AGENT_RESULT"| BNRFifo
+        BBash -->|"ASYNC_TASK_RESULT"| BNRFifo
+    end
+
     BInput --> BMain
-    BMain --> BAgent
-    BAgent -->|"每轮 + end_turn 后"| BDrain
-    BAgent --> BDisp
-    BAgent -->|"运行中写标记"| BFlag
-    BSub -->|"AGENT_RESULT"| BNRFifo
-    BNRFifo --> BNR
-    BNR -->|"写入"| BDrain
-    BNR -->|"递减"| BActive
-    BNR -->|"idle 时检查"| BFlag
-    BNR -.->|"NOTIFY_PENDING"| BInput
+    BNR -.->|"idle: NOTIFY_PENDING"| BInput
+    BBuf --> BDrain
+    BDrain -->|"display + conversation"| BAgent
 ```
 
 **关键机制**：
 - `AGENT_RUNNING_FLAG`：agent_loop_stream 运行中创建，退出时删除（含 error 路径）
 - notify reader 检查 flag：存在 → 不发 NOTIFY_PENDING（靠 drain 消费）；不存在 → 发 NOTIFY_PENDING
-- `ACTIVE_TASK_FILE`：tool_sub_agent 中递增（先加后创建），notify reader 中递减
+- `ACTIVE_TASK_FILE`：`tool_sub_agent` / `Bash background=true` 中递增（先加后创建），notify reader 中递减
 
 ### C 版本 — pthread + MsgQueue（三队列分离）
 
 ```mermaid
-graph TB
-    subgraph C["C (pthread + MsgQueue)"]
+graph LR
+    subgraph CIn["输入"]
         direction TB
         CL["readline 线程"]
         CInput["input_queue"]
-        CMain["main loop<br/>agent_run_loop"]
-        CAgent["agent_loop_stream<br/>(LLM call + tool exec)"]
-        CDrain["agent_drain_sub_results()<br/>mq_try_pop"]
-        CResultQ["sub_result_queue"]
+        CL -->|"USER_INPUT"| CInput
+    end
+
+    subgraph CMainFlow["C 主流程"]
+        direction TB
+        CMain["main loop"]
+        CRun["agent_run_loop"]
+        CAgent["agent_loop_stream<br/>LLM call + tool exec"]
+        CDrain["agent_drain_sub_results()<br/>mq_try_pop(sub_result_queue)"]
         CDispQ["display_queue"]
         CDisp["display 线程"]
-        CRunning["agent->running"]
-        CActive["active_task_count"]
+        CRunning["agent-&gt;running"]
+        CMain --> CRun --> CAgent
+        CAgent -->|"LLM 前 + end_turn 后"| CDrain
+        CAgent --> CDispQ --> CDisp
+        CAgent -->|"运行中置 1"| CRunning
     end
-    CSub["Sub-Agent 线程"]
 
-    CL -->|"USER_INPUT"| CInput
+    subgraph CBg["后台任务"]
+        direction TB
+        CSub["SubAgent pthread"]
+        CBash["bg-bash pthread"]
+        CResultQ["sub_result_queue"]
+        CSub -->|"MSG_AGENT_RESULT"| CResultQ
+        CBash -->|"MSG_ASYNC_TASK_RESULT"| CResultQ
+    end
+
     CInput --> CMain
-    CMain --> CAgent
-    CAgent -->|"每轮 + end_turn 后"| CDrain
-    CAgent --> CDispQ
-    CDispQ --> CDisp
-    CAgent -->|"运行中置 1"| CRunning
-    CSub -->|"AGENT_RESULT"| CResultQ
     CResultQ --> CDrain
-    CResultQ -->|"main loop idle 时<br/>mq_pop 阻塞等待"| CMain
+    CResultQ -->|"idle: active_task_count > 0<br/>mq_pop 阻塞等待"| CMain
 ```
 
 **关键机制**：
 - 三队列完全分离：`input_queue` / `sub_result_queue` / `display_queue`
-- main loop 在 agent_run_loop 返回后，`while active_task_count > 0` 阻塞等待 `sub_result_queue`
+- `sub_result_queue` 同时承载 `MSG_AGENT_RESULT` 与 `MSG_ASYNC_TASK_RESULT`
+- main loop 在 `agent_run_loop` 返回后，`while active_task_count > 0` 阻塞等待 `sub_result_queue`
 - `agent->running` 原子变量供 readline 线程判断 Ctrl+C 是否应中断
 
 ### Go 版本 — goroutine + channel
 
 ```mermaid
-graph TB
-    subgraph Go["Go (goroutine + channel)"]
+graph LR
+    subgraph GIn["输入"]
         direction TB
         GL["readline goroutine"]
-        GInput["inputCh (rl.Input)"]
-        GMain["RunLoop<br/>(LLM call + tool exec)"]
-        GDrain["drainSubAgentResults()<br/>非阻塞 select"]
-        GResultQ["subResultCh"]
+        GInput["inputCh / rl.Input()"]
+        GL -->|"USER_INPUT"| GInput
+    end
+
+    subgraph GMainFlow["Go 主流程"]
+        direction TB
+        GLoop["runInteractive / RunLoop"]
+        GDrain["drainSubAgentResults()<br/>非阻塞 select(subResultCh)"]
         GDispQ["displayCh"]
         GDisp["display goroutine"]
         GRunning["agent.running"]
         GPending["pendingTasks"]
+        GLoop -->|"LLM 前 + end_turn/error 后"| GDrain
+        GLoop --> GDispQ --> GDisp
+        GLoop -->|"运行中置 true"| GRunning
+        GLoop -->|"递增/递减"| GPending
     end
-    GSub["Sub-Agent goroutine"]
 
-    GL -->|"USER_INPUT"| GInput
-    GInput --> GMain
-    GMain -->|"每轮 + end_turn/error 后"| GDrain
-    GMain --> GDispQ
-    GDispQ --> GDisp
-    GMain -->|"运行中置 true"| GRunning
-    GSub -->|"AGENT_RESULT"| GResultQ
+    subgraph GBg["后台任务"]
+        direction TB
+        GSub["SubAgent goroutine"]
+        GBash["bg-bash goroutine"]
+        GResultQ["subResultCh"]
+        GSub -->|"Kind=sub_agent"| GResultQ
+        GBash -->|"Kind=async_task"| GResultQ
+    end
+
+    GInput --> GLoop
     GResultQ --> GDrain
-    GResultQ -->|"RunLoop idle 时<br/>select 阻塞等待"| GMain
+    GResultQ -->|"pendingTasks > 0<br/>select 阻塞等待"| GLoop
 ```
 
 **关键机制**：
 - `RunLoop` 内部每轮 LLM call 前 `drainSubAgentResults()`
-- end_turn / error 退出前检查 `pendingSubAgents`，有则 `select { case r := <-subResultCh }`
+- `subResultCh` 同时承载 `SubAgentResult{Kind:"sub_agent"}` 与 `SubAgentResult{Kind:"async_task"}`
+- end_turn / error 退出前检查 `pendingTasks`，有则 `select { case r := <-subResultCh }`
 - `runInteractive` 主循环 `for input := range rl.Input()`
 
 ### Rust 版本 — std::thread + mpsc::channel
 
 ```mermaid
-graph TB
-    subgraph Rust["Rust (thread + mpsc)"]
+graph LR
+    subgraph RIn["输入"]
         direction TB
         RL["readline 线程"]
-        RInput["msg_tx → msg_rx"]
+        RInput["msg_tx → msg_rx<br/>UserInput"]
+        RL --> RInput
+    end
+
+    subgraph RMainFlow["Rust 主流程"]
+        direction TB
         RMain["main_loop"]
-        RAgent["agent_loop<br/>(LLM call + tool exec)"]
-        RDrain["drain_sub_results()<br/>try_recv"]
-        RResultQ["sub_result_tx → sub_result_rx"]
+        RAgent["agent_loop<br/>LLM call + tool exec"]
+        RDrain["drain_sub_results()<br/>try_recv(sub_result_rx)"]
         RDispQ["DisplayEvent channel"]
         RDisp["display worker 线程"]
         RRunning["self.running"]
         RActive["active_task_count"]
+        RMain --> RAgent
+        RAgent -->|"LLM 前 + end_turn 后"| RDrain
+        RAgent --> RDispQ --> RDisp
+        RAgent -->|"运行中 store(true)"| RRunning
+        RAgent -->|"递增/递减"| RActive
     end
-    RSub["Sub-Agent 线程"]
 
-    RL -->|"UserInput"| RInput
+    subgraph RBg["后台任务"]
+        direction TB
+        RSub["SubAgent 线程"]
+        RBash["bg-bash 线程"]
+        RResultQ["sub_result_tx → sub_result_rx"]
+        RSub -->|"MainLoopMessage::AgentResult"| RResultQ
+        RBash -->|"MainLoopMessage::AsyncResult"| RResultQ
+    end
+
     RInput --> RMain
-    RMain --> RAgent
-    RAgent -->|"每轮 + end_turn 后"| RDrain
-    RAgent --> RDispQ
-    RDispQ --> RDisp
-    RAgent -->|"运行中 store(true)"| RRunning
-    RSub -->|"AgentResult"| RResultQ
     RResultQ --> RDrain
-    RResultQ -->|"main_loop idle 时<br/>recv 阻塞等待"| RMain
+    RResultQ -->|"idle: active_task_count > 0<br/>recv 阻塞等待"| RMain
 ```
 
 **关键机制**：
-- `msg_rx` 只接收 UserInput（readline 线程发）；`sub_result_rx` 只接收 AgentResult（SubAgent 线程发）——双通道分离，对齐 Bash 的 INPUT_FIFO + NOTIFY_FIFO
-- main_loop 在 agent_loop 返回后，`while active_task_count > 0` 阻塞等待 `sub_result_rx`
+- `msg_rx` 只接收 `UserInput`（readline 线程发）；`sub_result_rx` 接收 `AgentResult` / `AsyncResult`（SubAgent / bg-bash 线程发）——双通道分离，对齐 Bash 的 INPUT_FIFO + NOTIFY_FIFO
+- main_loop 在 `agent_loop` 返回后，`while active_task_count > 0` 阻塞等待 `sub_result_rx`
 - display worker 独立线程，通过 `DisplayEvent` channel 序列化输出（含 title OSC 序列）
 
 ### 通用约束（四版本共享）

--- a/docs/BASH_ARCHITECTURE.md
+++ b/docs/BASH_ARCHITECTURE.md
@@ -33,14 +33,13 @@ graph LR
 
     subgraph Stream["agent_loop_stream 子进程"]
         direction TB
-        Running["AGENT_RUNNING_FLAG<br/>进入每轮 LLM 前创建；结束/error 删除"]
         Drain["agent_drain_notify_buf<br/>LLM 调用前 + end_turn 后"]
         Compact["agent_compact_context auto"]
         LLM["llm_call<br/>FD8 读取 SSE 解析结果"]
         Tools["tool dispatch<br/>SubAgent / Bash background=true"]
         FD7["stdout RESP → FD7"]
-        Running --> Drain --> Compact --> LLM --> Tools --> FD7
-        Drain -->|"AGENT_RESULT / ASYNC_TASK_RESULT<br/>写 stdout"| FD7
+        Drain --> Compact --> LLM --> Tools --> FD7
+        Drain -->|"AGENT_RESULT / ASYNC_TASK_RESULT / USER_NOTIFY<br/>写 stdout"| FD7
     end
 
     subgraph Notify["notify 通道"]
@@ -50,15 +49,11 @@ graph LR
         NotifyBuf["NOTIFY_BUF<br/>RESP 结果缓冲"]
         Store["events.jsonl / stats.json<br/>记录事件；SubAgent 统计"]
         Active["ACTIVE_TASK_FILE<br/>SubAgent + bg-bash 活跃计数"]
-        IdleCheck{"AGENT_RUNNING_FLAG 存在?"}
-        Hold["不唤醒<br/>等待 agent_drain_notify_buf"]
         NotifyFIFO --> NotifyReader
         NotifyReader -->|"写结果 RESP"| NotifyBuf
         NotifyReader --> Store
-        NotifyReader -->|"递减"| Active
-        NotifyReader --> IdleCheck
-        IdleCheck -->|"否：idle，写 NOTIFY_PENDING"| InputFIFO
-        IdleCheck -->|"是：运行中"| Hold
+        NotifyReader -->|"非 USER_NOTIFY 递减"| Active
+        NotifyReader -->|"统一写 NOTIFY_PENDING"| InputFIFO
     end
 
     subgraph Workers["后台任务"]
@@ -103,6 +98,7 @@ graph LR
 | 7 | 读 | agent_loop_stream → agent_loop 管道 | agent_loop |
 | 8 | 读 | llm_call → agent_loop_stream 管道 | agent_loop_stream |
 | 9 | 读 | NOTIFY_BUF 临时文件读取 | agent_drain_notify_buf |
+| 9 | 写 | NOTIFY_FIFO 写入端（Ctrl+O inject） | interactive_mode stdin_reader |
 
 ### 1.3 RESP 消息协议
 
@@ -131,6 +127,7 @@ $len1\r\ndata1\r\n   — 字段1
 | CONTEXT_UPDATE | kind, trigger | compact |
 | AGENT_RESULT | session_id, status, in, out, thinking, text | notify reader → NOTIFY_BUF → drain；SubAgent 完成结果 |
 | ASYNC_TASK_RESULT | task_id, exit_code, output | notify reader → NOTIFY_BUF → drain；bg-bash 完成结果 |
+| USER_NOTIFY | text | notify reader → NOTIFY_BUF → drain；用户 Ctrl+O 中间介入 |
 | NOTIFY_PENDING | (无) | notify reader → INPUT_FIFO；idle 时触发 notify turn |
 | USER_INPUT | seq, content | 用户输入 |
 | SESSION_END | code | 退出 |
@@ -393,21 +390,25 @@ agent_main_loop() {
                     store_stats_update ...
 
                     # NOTIFY_BUF 规范化字段：sid status in out thinking text
-                    util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
-                    _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
-                    (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
-                    [[ ! -f "$AGENT_RUNNING_FLAG" ]] && util_write_msg "NOTIFY_PENDING" >&5
-                    ;;
-                ASYNC_TASK_RESULT)
-                    # 字段：task_id exit_code output
-                    store_event_append '{"type":"async_task_result",...}'
-                    util_write_msg "${REPLY_MESSAGE[@]}" >> "$NOTIFY_BUF"
-                    _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
-                    (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
-                    [[ ! -f "$AGENT_RUNNING_FLAG" ]] && util_write_msg "NOTIFY_PENDING" >&5
-                    ;;
-            esac
-        done
+                      util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
+                      ;;
+                  ASYNC_TASK_RESULT)
+                      # 字段：task_id exit_code output
+                      store_event_append '{"type":"async_task_result",...}'
+                      util_write_msg "${REPLY_MESSAGE[@]}" >> "$NOTIFY_BUF"
+                      ;;
+                  USER_NOTIFY)
+                      util_write_msg "USER_NOTIFY" "${REPLY_MESSAGE[1]}" >> "$NOTIFY_BUF"
+                      ;;
+                  *) continue ;;
+              esac
+              # 非 USER_NOTIFY 递减活跃计数
+              if [[ "${REPLY_MESSAGE[0]}" != "USER_NOTIFY" ]]; then
+                  _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
+                  (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
+              fi
+              util_write_msg "NOTIFY_PENDING" >&5
+          done
     ) &
     local _notify_pid=$!
 
@@ -438,7 +439,7 @@ agent_main_loop() {
     exec 4>&-
     wait "$display_pid" 2>/dev/null || true
     cleanup_all_pipes
-    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$AGENT_RUNNING_FLAG"
+    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF"
 }
 ```
 
@@ -446,7 +447,7 @@ agent_main_loop() {
 - **双 FIFO**：INPUT_FIFO（用户输入 + NOTIFY_PENDING）+ NOTIFY_FIFO（SubAgent / bg-bash 结果）
 - **notify reader 子 shell**：后台阻塞读 NOTIFY_FIFO，解析 AGENT_RESULT / ASYNC_TASK_RESULT，写入 NOTIFY_BUF
 - **ACTIVE_TASK_FILE**：文件计数器（同时跟踪 SubAgent 和 bg-bash），在 `tool_sub_agent` / `Bash background=true` 中子进程创建前递增，在 notify reader 中递减
-- **AGENT_RUNNING_FLAG**：标记 agent_loop_stream 是否运行中。运行中时 notify reader 不发 NOTIFY_PENDING（靠 `agent_drain_notify_buf` 在下一轮迭代消费）
+- **NOTIFY_PENDING**：notify reader 统一发送 wakeup 信号。main loop 收到后检查 `NOTIFY_BUF` 是否非空（stale wakeup 忽略）
 - **退出判断**：`_cnt <= 0 && NOTIFY_BUF 空 → SESSION_END`
 - **时序区别**（关键）：
   - **INPUT_FIFO**：用户输入排队等待，必须等当前 turn 完全结束后 main loop 才能处理 → 启动新 turn
@@ -499,13 +500,12 @@ agent_loop() {
 ```bash
 agent_loop_stream() {
     local user_input="$1" turn=0
-    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
+    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes' INT
     
     while (( turn < MAX_TURNS )); do
         (( turn++ ))
         
         # ① agent_loop 运行中标记（notify reader 见此标记不发 NOTIFY_PENDING）
-        : > "$AGENT_RUNNING_FLAG"
         
         # ② 消费 NOTIFY_BUF（SubAgent / bg-bash 结果），在 LLM 调用前处理
         agent_drain_notify_buf || true
@@ -554,7 +554,6 @@ agent_loop_stream() {
         # ⑨ 继续/退出
         if stop == tool_use|tool_calls → continue loop
         else:
-            rm -f "$AGENT_RUNNING_FLAG"       # 移除运行标记
             agent_drain_notify_buf && continue  # 有 SubAgent / bg-bash 结果 → 继续处理
             util_write_msg "STOP" "$stop"
             break
@@ -562,12 +561,11 @@ agent_loop_stream() {
     
     # Max turns reached
     (( turn >= MAX_TURNS )) && util_write_msg "ERROR" "Max turns ($MAX_TURNS) reached"
-    rm -f "$AGENT_RUNNING_FLAG"
 }
 ```
 
 **新增设计（vs 旧版）**：
-- 每轮迭代开头创建 `AGENT_RUNNING_FLAG`，结束时移除
+- notify reader 统一发送 NOTIFY_PENDING，main loop 通过 `[[ -s "$NOTIFY_BUF" ]]` 过滤 stale wakeup
 - 每轮迭代开头和 end_turn 后都调用 `agent_drain_notify_buf` 消费 SubAgent / bg-bash 结果
 - end_turn 后如果有后台结果 → `continue` 继续处理（不打断流式输出）
 - **`agent_drain_notify_buf` 消费时**：RESP 解析 → AGENT_RESULT / ASYNC_TASK_RESULT 写 stdout → agent_loop 转发 FD4 → 从字段构建纯文本注入 conversation
@@ -1262,6 +1260,7 @@ display_stream() { while util_read_msg; do display_message; done }
 | AGENT_RESULT | 紫色/红色状态行；thinking 截断 120 字符；text 截断 120 字符 |
 | ASYNC_TASK_RESULT | 青色/红色 `[bg-bash task_id] exit_code=N`；output 截断 120 字符 |
 | IMAGE_DESCRIBE | 青色 `📸 images: description` |
+| USER_NOTIFY | 黄色 `[user inject] text` |
 | USER_MESSAGE | 绿色 `> text`（截断 80 字符） |
 | STOP | interrupted → 青色 "Interrupted."；其他 → 确保换行 |
 | CONTEXT_UPDATE | 青色 "Context compacted (trigger)." |
@@ -1374,7 +1373,7 @@ store_sub_send_result() {
 
 **公共**（两种消息类型）：
 3. 递减 `ACTIVE_TASK_FILE`（大于 0 才减）
-4. 如果 `AGENT_RUNNING_FLAG` 不存在（idle）→ 发 `NOTIFY_PENDING` 到 `INPUT_FIFO`
+4. 统一发 `NOTIFY_PENDING` 到 `INPUT_FIFO`（main loop 通过 `[[ -s "$NOTIFY_BUF" ]]` 过滤 stale wakeup）
 
 ### 11.5 agent_drain_notify_buf()
 
@@ -1413,9 +1412,9 @@ Bash 是基准实现，C/Go/Rust 是 Port 版本，用各自语言的并发原�
 | 通道 | Bash | C | Go | Rust |
 |------|------|---|----|------|
 | 用户输入 | `INPUT_FIFO` (named pipe) | `input_queue` (MsgQueue) | `rl.Input()` channel | `msg_rx` (mpsc) |
-| 后台结果（SubAgent / bg-bash） | `NOTIFY_FIFO` + `NOTIFY_BUF` | `sub_result_queue` (MsgQueue) | `subResultCh` channel | `sub_result_rx` (mpsc) |
+| 后台结果（SubAgent / bg-bash / Ctrl+O inject） | `NOTIFY_FIFO` + `NOTIFY_BUF` | `sub_result_queue` (MsgQueue) | `subResultCh` channel | `sub_result_rx` (mpsc) |
 | Display 输出 | `FD 4` → display_stream 子进程 | `display_queue` (MsgQueue) | display event channel | display worker thread channel |
-| Agent 运行标记 | `AGENT_RUNNING_FLAG` (文件) | `agent->running` (原子变量) | `agent.running` (atomic) | `self.running` (AtomicBool) |
+| Agent 运行标记 | *(无)* | `agent->running` (原子变量) | `agent.running` (atomic) | `self.running` (AtomicBool) |
 | 活跃任务计数 | `ACTIVE_TASK_FILE` (文件) | `agent->active_task_count` (原子变量) | `pendingTasks` (mutex) | `active_task_count` (i64) |
 
 ### Bash 版 — 双 FIFO + 文件标记
@@ -1436,7 +1435,7 @@ graph LR
         BAgent["agent_loop_stream<br/>LLM call + tool exec"]
         BDrain["agent_drain_notify_buf()<br/>读 NOTIFY_BUF (FD9)"]
         BDisp["display_stream<br/>FD4"]
-        BFlag["AGENT_RUNNING_FLAG"]
+        BFlag["NOTIFY_PENDING → stale wakeup 过滤"]
         BMain --> BRun --> BAgent
         BAgent -->|"LLM 前 + end_turn 后"| BDrain
         BAgent --> BDisp
@@ -1469,7 +1468,7 @@ graph LR
 ```
 
 **关键机制**：
-- `AGENT_RUNNING_FLAG`：agent_loop_stream 运行中创建，退出时删除（含 error 路径）
+- `NOTIFY_PENDING`：notify reader 统一发送，main loop 通过 `[[ -s "$NOTIFY_BUF" ]]` 过滤 stale wakeup
 - notify reader 检查 flag：存在 → 不发 NOTIFY_PENDING（靠 drain 消费）；不存在 → 发 NOTIFY_PENDING
 - `ACTIVE_TASK_FILE`：`tool_sub_agent` / `Bash background=true` 中递增（先加后创建），notify reader 中递减
 
@@ -1631,6 +1630,7 @@ interactive_mode() {
     # 2. 回放最近 10 轮事件 (event_replay.awk)
     # 3. 启动 stdin_reader 子进程:
     #    - bind Ctrl+V 到图片粘贴
+    #    - bind Ctrl+O 到 inject handler
     #    - readline 循环: read -e -r -p '> '
     #    - USER_INPUT → INPUT_FIFO (FD 5)
     #    - exit/quit → SESSION_END

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,7 +125,7 @@ graph TB
         Drain["agent_drain_notify_buf<br/>每轮 LLM call 前 + end_turn 后"]
         NotifyReader["notify reader<br/>阻塞读 NOTIFY_FIFO"]
         NotifyBuf["NOTIFY_BUF<br/>结果缓冲"]
-        Running["AGENT_RUNNING_FLAG"]
+        Wakeup["NOTIFY_PENDING<br/>统一 wakeup"]
     end
 
     Stdin["stdin_reader<br/>read -p &gt; &lt; /dev/tty"] -->|"USER_INPUT / SESSION_END<br/>INPUT_FIFO"| Main
@@ -162,7 +162,7 @@ graph TB
 | FIFO fd 5 | stdin_reader → agent_main_loop | 用户输入传递（INPUT_FIFO 写入端） | write 后非阻塞，read 阻塞 |
 | FIFO fd 3 | agent_main_loop | INPUT_FIFO 读取端 | read 阻塞 |
 | FIFO | agent_loop_stream → SubAgent | 启动子 agent | 写入后非阻塞 |
-| NOTIFY_FIFO | SubAgent / bg-bash → notify reader | `AGENT_RESULT` / `ASYNC_TASK_RESULT` 回传 | read 阻塞 |
+| NOTIFY_FIFO | SubAgent / bg-bash / Ctrl+O inject → notify reader | `AGENT_RESULT` / `ASYNC_TASK_RESULT` / `USER_NOTIFY` 回传 | read 阻塞 |
 | NOTIFY_BUF | notify reader → agent_drain_notify_buf | 后台结果缓冲；可在 LLM 调用边界 drain | 原子 append + mv |
 | stdin | 用户 → stdin_reader | 交互模式输入（后台进程） | read 阻塞 |
 
@@ -221,7 +221,7 @@ graph TB
 | 通道 | 类型 | 方向 | 用途 | 同步机制 |
 |------|------|------|------|---------|
 | `inputCh` / `msg_rx` / `input_queue` | channel / queue | input → main_loop | 用户输入排队；必须等当前 turn 结束后启动新 turn | 阻塞收取 |
-| `subResultCh` / `sub_result_rx` / `sub_result_queue` | channel / queue | SubAgent/bg-bash → agent_loop/main_loop | `AGENT_RESULT` / `ASYNC_TASK_RESULT` 回传；可在 LLM 调用边界 drain | 非阻塞 drain + idle 阻塞等待 |
+| `subResultCh` / `sub_result_rx` / `sub_result_queue` | channel / queue | SubAgent/bg-bash/Ctrl+O inject → agent_loop/main_loop | `AGENT_RESULT` / `ASYNC_TASK_RESULT` / `USER_NOTIFY` 回传；可在 LLM 调用边界 drain | 非阻塞 drain + idle 阻塞等待 |
 | display channel / display queue | channel / queue | agent_loop → display worker | 渲染事件 | 阻塞收取 |
 | HTTP stream | `io.Reader` / `Read` | API → agent_loop | SSE 流式读取 | read 阻塞 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,27 +35,25 @@
 
 ## 运行时分层
 
-```text
-stdin / args / env
-        |
-        v
-src/agent.sh
-├─ 配置与 CLI
-├─ session/context 管理
-├─ prompt 组装
-├─ agent loop
-├─ tool runtime
-├─ API 请求
-└─ stream-json / human 输出
-        |
-        v
-src/awk/*
-├─ JSON helper library
-├─ JSON helper CLI entrypoints
-├─ SSE parser
-├─ 格式转换
-├─ RESP-like 协议输出 / 文本抽取
-└─ tool 专用变换
+```mermaid
+graph TB
+    Input["stdin / args / env"] --> Agent["src/agent.sh"]
+
+    Agent --> CLI["配置与 CLI"]
+    Agent --> Session["session/context 管理"]
+    Agent --> Prompt["prompt 组装"]
+    Agent --> Loop["agent loop"]
+    Agent --> Tools["tool runtime"]
+    Agent --> API["API 请求"]
+    Agent --> Output["stream-json / human 输出"]
+
+    Agent --> AWK["src/awk/*"]
+    AWK --> JSONLib["JSON helper library"]
+    AWK --> JSONCli["JSON helper CLI entrypoints"]
+    AWK --> SSE["SSE parser"]
+    AWK --> Format["格式转换"]
+    AWK --> RESP["RESP-like 协议输出 / 文本抽取"]
+    AWK --> ToolTransform["tool 专用变换"]
 ```
 
 ### `bash` 负责什么
@@ -96,7 +94,7 @@ Go、Rust、C 版本保持和 Bash 一致的职责分层，用各自语言的并
 - **Rust**：`std::thread` + `mpsc::channel`（`msg_rx` / `sub_result_rx` / display worker thread）
 - **C**：`pthread` + 消息队列（`input_queue` / `sub_result_queue` / `display_queue`）
 
-三者的 agent_loop 退出后，main_loop 层都有 `while (active_sub_count > 0)` 阻塞等待 SubAgent 结果，确保 idle 状态下 SubAgent 结果仍能触发新 agent_loop。
+三者的 agent_loop 退出后，main_loop 层都有 `while (active_task_count > 0)` / `pendingTasks > 0` 阻塞等待 SubAgent / bg-bash 结果，确保 idle 状态下后台结果仍能触发新 agent_loop。
 
 交互状态只在 display 层处理，原始事件和会话状态只在 stream 层处理，interactive history 统一使用 `~/.bash-agent/history`。
 
@@ -116,47 +114,41 @@ Go、Rust、C 版本保持和 Bash 一致的职责分层，用各自语言的并
 
 ### bash 版本的通道
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                           主进程                                     │
-│  ┌──────────────┐    RESP-like     ┌──────────────────┐            │
-│  │   agent_loop  │ ←──── fd 7/8 ───│ agent_loop_stream│            │
-│  │   (外层)      │                  │     (内层)        │            │
-│  └──────┬───────┘                  └────────┬─────────┘            │
-│         │                                    │                      │
-│         │                                    │ RESP-like            │
-│         │                                    │ (fd)                 │
-│         │                                    ↓                      │
-│         │                           ┌─────────────────┐            │
-│         │                           │  awk SSE 解析    │            │
-│         │                           └────────┬────────┘            │
-│         │                                    │ HTTP stream          │
-│         │                                    ↓                      │
-│         │                              ┌──────────┐                │
-│         │                              │ API 服务  │                │
-│         │                              └──────────┘                │
-│         │                                                          │
-│         │ RESP via fd 4 pipe                                       │
-│         ↓                                                          │
-│  ┌──────────────┐                                                  │
-│  │ display_stream│ ←── fd 4 ──── agent_loop                        │
-│  │ (子进程)      │     display_message → display_human_text        │
-│  └──────────────┘     display_ensure_newline / display_term_title   │
-│         │ stderr                                                    │
-│         ↓                                                          │
-│     [终端]                                                         │
-│                                                                    │
-│  ┌──────────────┐                                                  │
-│  │ stdin_reader  │ ── FIFO ──── agent_main_loop                     │
-│  │ (后台进程)    │     read -p "> " < /dev/tty                      │
-│  └──────────────┘     → USER_INPUT / SESSION_END                    │
-│                                                                    │
-│  ┌──────────────┐                                                  │
-│  │ 子 agent      │ ←── FIFO (启动) ─── agent_loop_stream           │
-│  │ (子进程)      │ ── FIFO (结果) ──→ agent_main_loop               │
-│  │ FD 3-9 关闭，不与主进程争管道                                     │
-│  └──────────────┘                                                  │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    subgraph Bash["Bash 主进程"]
+        direction TB
+        Main["agent_main_loop"]
+        Loop["agent_loop<br/>外层"]
+        Stream["agent_loop_stream<br/>内层：LLM call + tool exec"]
+        Display["display_stream<br/>子进程"]
+        Drain["agent_drain_notify_buf<br/>每轮 LLM call 前 + end_turn 后"]
+        NotifyReader["notify reader<br/>阻塞读 NOTIFY_FIFO"]
+        NotifyBuf["NOTIFY_BUF<br/>结果缓冲"]
+        Running["AGENT_RUNNING_FLAG"]
+    end
+
+    Stdin["stdin_reader<br/>read -p &gt; &lt; /dev/tty"] -->|"USER_INPUT / SESSION_END<br/>INPUT_FIFO"| Main
+    Main -->|"USER_INPUT / NOTIFY_PENDING"| Loop
+    Loop -->|"fd 7 RESP"| Stream
+    Stream -->|"stdout RESP"| Loop
+    Loop -->|"fd 4 RESP"| Display
+    Display -->|"stderr"| Terminal["终端"]
+
+    Stream -->|"llm_call"| Awk["awk SSE 解析"]
+    Awk -->|"HTTP stream"| API["API 服务"]
+    Awk -->|"RESP-like"| Stream
+
+    Stream -->|"创建 / 清理"| Running
+    Stream -->|"SubAgent / bg-bash 启动"| Worker["SubAgent 子进程 / bg-bash 子 shell"]
+    Worker -->|"AGENT_RESULT / ASYNC_TASK_RESULT<br/>NOTIFY_FIFO"| NotifyReader
+    NotifyReader -->|"追加 RESP"| NotifyBuf
+    NotifyReader -->|"idle 时：NOTIFY_PENDING<br/>INPUT_FIFO"| Main
+    Stream -->|"运行中：drain"| Drain
+    Loop -->|"end_turn 后：drain"| Drain
+    Drain -->|"原子 mv + 解析 RESP"| NotifyBuf
+    Drain -->|"写 stdout → agent_loop 转发 FD4"| Display
+    Drain -->|"store_conv_add_user"| Conv["conversation.jsonl"]
 ```
 
 **通道说明**：
@@ -169,8 +161,9 @@ Go、Rust、C 版本保持和 Bash 一致的职责分层，用各自语言的并
 | RESP fd 4 | agent_loop → display_stream | 渲染消息传递给子进程显示 | write_message / read_message |
 | FIFO fd 5 | stdin_reader → agent_main_loop | 用户输入传递（INPUT_FIFO 写入端） | write 后非阻塞，read 阻塞 |
 | FIFO fd 3 | agent_main_loop | INPUT_FIFO 读取端 | read 阻塞 |
-| FIFO | 主 → 子 | 启动子 agent | 写入后非阻塞 |
-| FIFO | 子 → 主 | 子 agent 结果回传 | read 阻塞 |
+| FIFO | agent_loop_stream → SubAgent | 启动子 agent | 写入后非阻塞 |
+| NOTIFY_FIFO | SubAgent / bg-bash → notify reader | `AGENT_RESULT` / `ASYNC_TASK_RESULT` 回传 | read 阻塞 |
+| NOTIFY_BUF | notify reader → agent_drain_notify_buf | 后台结果缓冲；可在 LLM 调用边界 drain | 原子 append + mv |
 | stdin | 用户 → stdin_reader | 交互模式输入（后台进程） | read 阻塞 |
 
 ### 文件描述符分层约定
@@ -187,54 +180,62 @@ FD 按所在进程层级分配，全局可见的 FD 用连续小数字（3-6）�
 | 8  | 子进程 | llm_call 管道读取端 | agent_loop_stream |
 | 9  | 子进程 | curl 管道读取端 | llm_stream_curl |
 
-### Go/Rust 版本的通道
+### Go/Rust/C 版本的通道
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                           主 goroutine/task                          │
-│  ┌──────────────┐        msgChan        ┌──────────────────┐       │
-│  │   agent_loop  │ ←────────────────────│ agent_loop_stream│       │
-│  │   (外层)      │                       │     (内层)        │       │
-│  └──────┬───────┘                       └────────┬─────────┘       │
-│         │                                        │                 │
-│         │                                        │ HTTP stream     │
-│         │                                        ↓                 │
-│         │                                  ┌──────────┐            │
-│         │                                  │ API 服务  │            │
-│         │                                  └──────────┘            │
-│         │                                                          │
-│         │ msgChan (AGENT_RESULT)                                   │
-│         ↓                                                          │
-│  ┌──────────────┐                                                  │
-│  │ 子 agent      │ ←── goroutine/task 启动                         │
-│  │ (异步执行)    │                                                  │
-│  └──────────────┘                                                  │
-│                                                                    │
-│  ┌──────────────┐                                                  │
-│  │ interactive   │ ←── done channel (同步等待)                      │
-│  │ mode          │                                                  │
-│  └──────────────┘                                                  │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    subgraph Port["Go / Rust / C 通道模型"]
+        direction TB
+        Input["readline / stdin goroutine-thread"]
+        Main["main_loop / RunLoop"]
+        Agent["agent_loop<br/>LLM call + tool exec"]
+        Drain["drain_sub_results()<br/>每轮 LLM call 前 + end_turn 后"]
+        ResultQ["subResultCh / sub_result_rx / sub_result_queue"]
+        DisplayQ["display channel / display queue"]
+        Display["display worker"]
+        Running["running flag"]
+        Pending["pendingTasks / active_task_count"]
+    end
+
+    Input -->|"USER_INPUT"| Main
+    Main --> Agent
+    Agent -->|"运行中置 true"| Running
+    Agent -->|"LLM HTTP stream"| API["API 服务"]
+    API --> Agent
+    Agent -->|"display event"| DisplayQ
+    DisplayQ --> Display
+    Display --> Terminal["终端"]
+
+    Agent -->|"SubAgent / bg-bash 启动"| Worker["SubAgent goroutine-thread / bg-bash goroutine-thread"]
+    Worker -->|"AGENT_RESULT / ASYNC_TASK_RESULT"| ResultQ
+    ResultQ --> Drain
+    ResultQ -->|"idle 时 main_loop 阻塞等待"| Main
+    Agent -->|"运行中：非阻塞 drain"| Drain
+    Drain -->|"display event"| DisplayQ
+    Drain -->|"store_conv_add_user"| Conv["conversation.jsonl"]
+    Worker --> Pending
 ```
 
 **通道说明**：
 
 | 通道 | 类型 | 方向 | 用途 | 同步机制 |
 |------|------|------|------|---------|
-| msgChan | `chan MainLoopMessage` | stream → loop | 内层消息传递给外层 | channel 阻塞 |
-| msgChan | `chan MainLoopMessage` | 子 → 主 | 子 agent 结果回传 | channel 阻塞 |
-| done | `chan struct{}` | mainLoop → interactive | 交互模式同步 | channel 阻塞 |
-| HTTP stream | `io.Reader` | API → stream | SSE 流式读取 | read 阻塞 |
+| `inputCh` / `msg_rx` / `input_queue` | channel / queue | input → main_loop | 用户输入排队；必须等当前 turn 结束后启动新 turn | 阻塞收取 |
+| `subResultCh` / `sub_result_rx` / `sub_result_queue` | channel / queue | SubAgent/bg-bash → agent_loop/main_loop | `AGENT_RESULT` / `ASYNC_TASK_RESULT` 回传；可在 LLM 调用边界 drain | 非阻塞 drain + idle 阻塞等待 |
+| display channel / display queue | channel / queue | agent_loop → display worker | 渲染事件 | 阻塞收取 |
+| HTTP stream | `io.Reader` / `Read` | API → agent_loop | SSE 流式读取 | read 阻塞 |
 
 ### 关键差异
 
-| 方面 | bash | Go/Rust |
-|------|------|---------|
-| API 解析层 | 独立 awk 进程 | 内嵌在 agent_loop_stream |
-| stream → loop 通道 | RESP-like fd 7/8 | msgChan |
-| 子 agent 结果回传 | FIFO | msgChan |
-| 交互模式同步 | read 阻塞 | done channel |
-| 子 agent 计数回收 | FIFO 消息触发 | msgChan 消息触发 |
+| 方面 | bash | Go/Rust/C |
+|------|------|-----------|
+| API 解析层 | 独立 awk 进程 | 内嵌在 agent_loop |
+| stream → loop 通道 | RESP-like fd 7/8 | 函数内事件/消息对象 |
+| 用户输入 | `INPUT_FIFO`，当前 turn 结束后消费 | input channel/queue，当前 turn 结束后消费 |
+| 后台结果回传 | `NOTIFY_FIFO` → `NOTIFY_BUF` | `subResultCh` / `sub_result_rx` / `sub_result_queue` |
+| 后台结果消费 | `agent_drain_notify_buf` 在 LLM 调用边界消费 | `drain_sub_results` 在 LLM 调用边界消费 |
+| idle 唤醒 | notify reader 写 `NOTIFY_PENDING` 到 `INPUT_FIFO` | main_loop 阻塞等待后台结果 |
+| 后台任务计数回收 | `ACTIVE_TASK_FILE` | `pendingTasks` / `active_task_count` |
 
 ### 消息格式
 
@@ -243,17 +244,24 @@ FD 按所在进程层级分配，全局可见的 FD 用连续小数字（3-6）�
 *N\r\n$len\r\ndata\r\n...
 ```
 
-**Go/Rust MainLoopMessage**：
+**Go/Rust 后台结果消息**：
 ```go
-type MainLoopMessage struct {
-    Type      string // "USER_INPUT" or "AGENT_RESULT"
-    Input     string
-    SessionID string
-    Status    string // "ok" or "failed"
-    Result    string
-    InTokens  int
-    OutTokens int
-    Done      chan<- struct{} // 交互模式同步
+type SubAgentResult struct {
+    Kind      string // "sub_agent" 或 "async_task"
+    SessionID string // SubAgent
+    Status    string // "ok" 或 "failed"
+    Thinking  string
+    Text      string
+
+    InputTokens  int
+    OutputTokens int
+    CacheRead    int
+    CacheWrite   int
+    Requests     int
+
+    TaskID   string // bg-bash
+    ExitCode int
+    Output   string
 }
 ```
 
@@ -263,14 +271,15 @@ type MainLoopMessage struct {
 
 session 数据按当前项目目录归档：
 
-```text
-~/.bash-agent/projects/<project_key>/<session_id>/
-    conversation.jsonl
-    events.jsonl
-    summary.txt
-    plan.md
-    plan.draft
-    stats.json
+```mermaid
+graph TB
+    Root["~/.bash-agent/projects/&lt;project_key&gt;/&lt;session_id&gt;/"]
+    Root --> Conv["conversation.jsonl"]
+    Root --> Events["events.jsonl"]
+    Root --> Summary["summary.txt"]
+    Root --> Plan["plan.md"]
+    Root --> Draft["plan.draft"]
+    Root --> Stats["stats.json"]
 ```
 
 职责分工：
@@ -298,13 +307,17 @@ compact 使用**缓存对齐摘要（Cache-Aligned Summarization）**和基于�
 
 compact 在 `agent_loop_stream()` 的 **每次 LLM 调用前** 执行：
 
-```text
-while turn < MAX_TURNS:
-    ① compact_context_window auto     ← 使用上一轮 USAGE 记录的 ctx_tokens
-    ② llm_call()
-    ③ 流式处理：TEXT / THINKING / TOOL_CALL / USAGE / STOP
-    ④ 持久化 assistant + tool_results
-    ⑤ stats_set current_context_tokens = _ctx_tokens   ← 供下一轮 compact 使用
+```mermaid
+flowchart TB
+    Start{"turn < MAX_TURNS?"}
+    Compact["① compact_context_window auto<br/>读取上一轮 USAGE 记录的 ctx_tokens"]
+    Call["② llm_call()"]
+    Stream["③ 流式处理<br/>TEXT / THINKING / TOOL_CALL / USAGE / STOP"]
+    Persist["④ 持久化 assistant + tool_results"]
+    Stats["⑤ stats_set current_context_tokens = _ctx_tokens<br/>供下一轮 compact 使用"]
+
+    Start -->|"是"| Compact --> Call --> Stream --> Persist --> Stats --> Start
+    Start -->|"否"| End["结束"]
 ```
 
 数据流时序：
@@ -369,10 +382,20 @@ Safety valve 也改用 `compact_turn_keep()` 实现 turn 对齐（替换原简�
 
 summary 调用（`run_summary_call`）采用与正常请求**完全相同的前缀结构**，实现前缀缓存命中：
 
-```
-正常请求：  [System prompt + Tools + Summary] + [全部消息]
-summary请求：[System prompt + Tools + Summary] + [dropped 消息 H] + [summary 指令]
-            ←────── 缓存命中，按 P_cache 计费 ──────→  ← P_input →
+```mermaid
+flowchart TB
+    Prefix["共享前缀<br/>System prompt + Tools + Summary"]
+    NormalTail["正常请求尾部<br/>全部消息"]
+    SummaryTail1["summary 请求缓存命中段<br/>dropped 消息 H"]
+    SummaryTail2["summary 请求新增段<br/>summary 指令"]
+
+    Prefix --> NormalTail
+    Prefix --> SummaryTail1 --> SummaryTail2
+
+    classDef cached fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    classDef input fill:#fff3e0,stroke:#ef6c00,color:#e65100
+    class Prefix,SummaryTail1 cached
+    class SummaryTail2 input
 ```
 
 由于 dropped 消息是 CONV_FILE 开头的行，它们与之前请求中的前缀完全一致。summary 请求只追加了一条 user 消息作为总结指令，不影响前缀匹配。这就是 **Cache-Aligned Summarization**：摘要 agent 的前缀与主 agent 对齐，确保前缀缓存命中。
@@ -450,13 +473,11 @@ system prompt 首尾都是语言约束，中间内容无论多长、是否变化
 
 ### 4. Skills
 
-skills 当前优先读取：
+skills 当前按以下优先级读取：
 
-```text
-./.claude/skills/<name>/SKILL.md
-./skills/<name>/SKILL.md
-~/.claude/skills/<name>/SKILL.md
-```
+1. `<当前项目>/.claude/skills/<name>/SKILL.md`
+2. `<当前项目>/skills/<name>/SKILL.md`
+3. `<用户 Home>/.claude/skills/<name>/SKILL.md`
 
 策略分两层：
 

--- a/go/agent.go
+++ b/go/agent.go
@@ -35,7 +35,7 @@ type Agent struct {
 	displayWG        sync.WaitGroup
 	toolDefs         string // JSON 格式工具定义
 	ctxTokens        int    // 当前上下文 token 数
-	pendingTasks int    // 等待中的子 agent 数量
+	pendingTasks     int    // 等待中的子 agent 数量
 	subResultCh      chan SubAgentResult
 	subMu            sync.Mutex
 	runMu            sync.Mutex
@@ -56,9 +56,9 @@ type SubAgentResult struct {
 	CacheWrite   int
 	Requests     int
 	// async_task 字段
-	TaskID    string
-	ExitCode  int
-	Output    string
+	TaskID   string
+	ExitCode int
+	Output   string
 }
 
 // imageNextName returns the next sequential image filename.
@@ -722,8 +722,13 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 	a.running.Store(true)
 	defer a.running.Store(false)
 
-	// 记录 user_input 事件（使用原始文本，包含 [Image #N] 占位符）
-	if turnKind == "user_input" {
+	// notify turn 只负责消费 pending sub_result；stale wakeup 直接忽略
+	if turnKind == "notify" {
+		if !a.drainSubAgentResults(ctx) {
+			return nil
+		}
+	} else if turnKind == "user_input" {
+		// 记录 user_input 事件（使用原始文本，包含 [Image #N] 占位符）
 		a.emitJSON(map[string]interface{}{"type": "user_input", "content": userInput})
 	}
 
@@ -760,8 +765,10 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		userInput = expandedInput
 	}
 
-	// 添加用户消息
-	_ = a.store.AddUserMessage(userInput)
+	// 添加用户消息；notify turn 的消息已由 drainSubAgentResults 注入
+	if turnKind != "notify" {
+		_ = a.store.AddUserMessage(userInput)
+	}
 
 	// 用户输入时递增 turn（与 bash 版一致：store_stats_update current_turn_count=+1）
 	_ = a.store.IncrementTurn()
@@ -989,6 +996,11 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 			continue
 		}
 
+		// end_turn 后先消费已到达的 notify/user inject；有内容则继续下一轮
+		if a.drainSubAgentResults(ctx) {
+			continue
+		}
+
 		// end_turn 但有等待中的子 agent → 等待结果并继续
 		a.subMu.Lock()
 		hasPending := a.pendingTasks > 0
@@ -1014,15 +1026,17 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 }
 
 // drainSubAgentResults 消费所有已到达但未处理的 SubAgent 结果（对齐 bash agent_drain_notify_buf）
-func (a *Agent) drainSubAgentResults(ctx context.Context) {
+func (a *Agent) drainSubAgentResults(ctx context.Context) bool {
+	drained := false
 	for {
 		select {
 		case r := <-a.subResultCh:
 			a.handleSubAgentResult(r)
+			drained = true
 		case <-ctx.Done():
-			return
+			return drained
 		default:
-			return
+			return drained
 		}
 	}
 }
@@ -1184,6 +1198,11 @@ func (a *Agent) runSubAgent(ctx context.Context, sessionID, prompt, fork string)
 
 // handleSubAgentResult 处理子 agent 结果
 func (a *Agent) handleSubAgentResult(r SubAgentResult) {
+	// user_notify 分支（Ctrl+O 中间介入）
+	if r.Kind == "user_notify" {
+		a.handleUserNotify(r.Text)
+		return
+	}
 	// async_task 分支
 	if r.Kind == "async_task" {
 		a.handleAsyncTaskResult(r)
@@ -1257,10 +1276,10 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 func (a *Agent) handleAsyncTaskResult(r SubAgentResult) {
 	// 1. 记录 async_task_result 事件
 	a.emitJSON(map[string]interface{}{
-		"type":       "async_task_result",
-		"task_id":    r.TaskID,
-		"exit_code":  r.ExitCode,
-		"output":     r.Output,
+		"type":      "async_task_result",
+		"task_id":   r.TaskID,
+		"exit_code": r.ExitCode,
+		"output":    r.Output,
 	})
 
 	// 3. 递减活跃计数（async task 无 token 消耗，跳过 stats）
@@ -1287,4 +1306,21 @@ func (a *Agent) handleAsyncTaskResult(r SubAgentResult) {
 	injectMsg := fmt.Sprintf("[bg-bash %s] exit_code=%d\nOutput: %s",
 		r.TaskID, r.ExitCode, r.Output)
 	_ = a.store.AddUserMessage(injectMsg)
+}
+
+// handleUserNotify 处理用户 Ctrl+O 中间介入的输入
+func (a *Agent) handleUserNotify(text string) {
+	// 显示（统一走 Display 接口）
+	a.EmitDisplay(Event{
+		Type:   EventUserNotify,
+		Fields: []string{"USER_NOTIFY", text},
+	})
+
+	// Ctrl+O 是用户自然输入；conversation 中保存原文，显示层才加 [user inject]
+	_ = a.store.AddUserMessage(text)
+}
+
+// EnqueueUserNotify 将用户 Ctrl+O 输入写入 notify/sub_result 通道。
+func (a *Agent) EnqueueUserNotify(text string) {
+	a.subResultCh <- SubAgentResult{Kind: "user_notify", Text: text}
 }

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -274,11 +274,20 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 	rl := NewReadline(home)
 	rl.SetImagePasteCallback(a.ImagePasteCallback)
 	rl.SetInterruptCallback(a.Interrupt)
+	rl.SetInjectCallback(func(text string) {
+		a.EnqueueUserNotify(text)
+		rl.SendNotifyWakeup()
+	})
 	rl.Start()
 
 	// 主循环：从 readline goroutine 接收输入，交给 agent 处理
 	for input := range rl.Input() {
-		if err := a.RunLoop(ctx, input, "user_input"); err != nil {
+		turnKind := "user_input"
+		if input == notifyWakeupInput {
+			input = ""
+			turnKind = "notify"
+		}
+		if err := a.RunLoop(ctx, input, turnKind); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 		a.FlushDisplay()

--- a/go/cmd/goagent/readline.go
+++ b/go/cmd/goagent/readline.go
@@ -14,6 +14,8 @@ import (
 // with the agent main goroutine via channels.
 //
 // Display output uses linenoiseWrite which handles Hide/OPOST/Show internally.
+const notifyWakeupInput = "\x00notify"
+
 type Readline struct {
 	inputCh     chan string
 	histPath    string
@@ -43,6 +45,17 @@ func (r *Readline) Start() {
 // SetImagePasteCallback registers a function to be called when Ctrl+V is pressed.
 func (r *Readline) SetImagePasteCallback(fn func() string) {
 	linenoise.SetImagePasteCallback(fn)
+}
+
+// SetInjectCallback registers a function to be called when Ctrl+O is pressed.
+// The function receives the current edit buffer text.
+func (r *Readline) SetInjectCallback(fn func(string)) {
+	linenoise.SetInjectCallback(fn)
+}
+
+// SendNotifyWakeup wakes the main loop to process pending notify messages.
+func (r *Readline) SendNotifyWakeup() {
+	r.inputCh <- notifyWakeupInput
 }
 
 // Input returns the channel on which user input lines are delivered.

--- a/go/display.go
+++ b/go/display.go
@@ -272,5 +272,13 @@ func (d *TermDisplay) ShowEvent(ev Event) {
 			d.EnsureNewline()
 			d.writef("\033[33m> %s\033[0m\n", content)
 		}
+
+	case EventUserNotify:
+		text := ""
+		if len(ev.Fields) > 1 {
+			text = ev.Fields[1]
+		}
+		d.EnsureNewline()
+		d.writef("\033[33m[user inject] %s\033[0m\n", text)
 	}
 }

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -63,6 +63,7 @@ static struct edit_feed_result linenoise_edit_feed_safe(struct linenoiseState *l
 
 // C wrapper that calls the Go export below.
 extern void goImagePasteCallback(char **out, size_t *outlen);
+extern int goInjectCallback(char *buf, size_t len);
 
 static void linenoise_write(const char *s, size_t len) {
 	linenoiseWrite(s, len);
@@ -119,6 +120,26 @@ func goImagePasteCallback(cout **C.char, coutlen *C.size_t) {
 func SetImagePasteCallback(fn func() string) {
 	imagePasteFn = fn
 	C.linenoiseSetImagePasteCallback(C.linenoiseImagePasteCallback(C.goImagePasteCallback))
+}
+
+// injectFn is set by SetInjectCallback.
+var injectFn func(string)
+
+//export goInjectCallback
+func goInjectCallback(cbuf *C.char, clen C.size_t) C.int {
+	if injectFn == nil || clen == 0 {
+		return 1
+	}
+	injectFn(C.GoStringN(cbuf, C.int(clen)))
+	return 0
+}
+
+// SetInjectCallback registers a function to be called when
+// Ctrl+O is pressed in linenoise. The function receives
+// the current edit buffer text.
+func SetInjectCallback(fn func(string)) {
+	injectFn = fn
+	C.linenoiseSetInjectCallback(C.linenoiseInjectCallback(C.goInjectCallback))
 }
 
 // Line reads a line of input using linenoise's blocking API.

--- a/go/types.go
+++ b/go/types.go
@@ -106,6 +106,7 @@ const (
 	EventSubAgentResult                  // SUB_AGENT_RESULT (replay 用)
 	EventDisplayFlush                    // display queue 同步屏障
 	EventImageDescribe                   // IMAGE_DESCRIBE
+	EventUserNotify                      // USER_NOTIFY (Ctrl+O 中间介入)
 )
 
 // Usage 记录 token 使用量

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -253,6 +253,10 @@ enum MainLoopMessage {
         exit_code: i32,
         output: String,
     },
+    UserNotify {
+        text: String,
+    },
+    NotifyPending,
 }
 
 struct Agent {
@@ -361,6 +365,9 @@ enum DisplayEvent {
     ImageDescribe {
         images: String,
         description: String,
+    },
+    UserNotify {
+        text: String,
     },
     Title(String), // 终端标题（OSC 序列），通过 display worker 序列化避免与 text 交织
 }
@@ -502,6 +509,12 @@ fn render_display_event(
             if !description.is_empty() {
                 lw(&format!("\x1b[36m📸 {}: {}\x1b[0m\n", images, description));
             }
+            ds.last_char = "\n".to_string();
+            ds.prev_was_thinking = false;
+        }
+        DisplayEvent::UserNotify { text } => {
+            ensure_newline(ds, &lw);
+            lw(&format!("\x1b[33m[user inject] {}\x1b[0m\n", text));
             ds.last_char = "\n".to_string();
             ds.prev_was_thinking = false;
         }
@@ -913,12 +926,17 @@ impl Agent {
         ffi::set_image_dir(self.paths.session_dir.join("images"));
         ffi::register_paste_callback();
 
+        // 注册 inject callback（Ctrl+O），将文本发送到 channel
+        let (inject_tx, inject_rx) = mpsc::channel::<String>();
+        ffi::register_inject_callback(inject_tx);
+
         // 使用 Agent 结构体中的共享 interrupted / running，供 Ctrl+C 中断 agent
         let interrupted_flag = self.interrupted.clone();
         let running_flag = self.running.clone();
 
         // 启动 readline 线程，将用户输入发送到消息队列
         let msg_tx_arc = self.msg_tx.clone();
+        let sub_result_tx = self.sub_result_tx.clone();
         let history_path_clone = history_path.to_string_lossy().to_string();
         let readline_handle = std::thread::spawn(move || {
             ffi::set_multiline(true);
@@ -964,6 +982,16 @@ impl Agent {
                         let result = unsafe { ffi::edit_feed_raw(ls_ptr) };
                         let more_ptr = ffi::edit_more_ptr();
                         if result == more_ptr {
+                            // Check inject channel (Ctrl+O while editing)
+                            if let Ok(text) = inject_rx.try_recv() {
+                                if !text.is_empty() {
+                                    let _ = sub_result_tx.send(MainLoopMessage::UserNotify { text });
+                                    let tx_guard = msg_tx_arc.lock().unwrap();
+                                    if let Some(tx) = tx_guard.as_ref() {
+                                        let _ = tx.send(MainLoopMessage::NotifyPending);
+                                    }
+                                }
+                            }
                             continue; // 还在编辑
                         }
                         if result.is_null() {
@@ -1062,6 +1090,12 @@ impl Agent {
                 }
             };
             match msg {
+                MainLoopMessage::NotifyPending => {
+                    self.running.store(true, Ordering::SeqCst);
+                    let _ = self.agent_loop_with_kind(String::new(), "notify");
+                    self.running.store(false, Ordering::SeqCst);
+                    self.flush_display();
+                }
                 MainLoopMessage::UserInput { input } => {
                     if self.cfg.interactive {
                         // 清除当前行（包括提示符）
@@ -1111,12 +1145,18 @@ impl Agent {
                                 // 将其放回队列末尾，等当前子 agent 完成后再处理。
                                 // TODO: 暂时忽略，后续可改为队列缓存。
                             }
+                            Ok(MainLoopMessage::NotifyPending) => {}
                             Ok(MainLoopMessage::AsyncResult { task_id, exit_code, output }) => {
                                 let _ = self.emit_and_append_event(json!({"type":"async_task_result","task_id":&task_id,"exit_code":exit_code,"output":&output}));
                                 if self.active_task_count > 0 { self.active_task_count -= 1; }
                                 let ctx = format!("[bg-bash {}] exit_code={}\nOutput: {}", task_id, exit_code, output);
                                 let _ = self.queue_display_event(DisplayEvent::AsyncTaskResult { task_id, exit_code, output });
                                 let _ = self.agent_loop_with_kind(ctx, "async_task_result");
+                                self.flush_display();
+                            }
+                            Ok(MainLoopMessage::UserNotify { text }) => {
+                                let _ = self.queue_display_event(DisplayEvent::UserNotify { text: text.clone() });
+                                let _ = self.agent_loop_with_kind(text, "user_notify");
                                 self.flush_display();
                             }
                             Err(std::sync::mpsc::RecvError) => {
@@ -1261,6 +1301,11 @@ impl Agent {
                 let _ = self.conv.add_user(&ctx);
                 drained = true;
             }
+            MainLoopMessage::UserNotify { text } => {
+                let _ = self.queue_display_event(DisplayEvent::UserNotify { text: text.clone() });
+                let _ = self.conv.add_user(&text);
+                drained = true;
+            }
             _ => {}
             }
         }
@@ -1292,8 +1337,11 @@ impl Agent {
         crate::tools::drain_fd(self.cancel_read_fd);
 
         let result = (|| -> Result<()> {
-            // 记录 user_input 事件（使用原始文本，包含 [Image #N] 占位符）
-            if turn_kind == "user_input" {
+            // notify turn 只消费 pending sub_result；stale wakeup 直接返回
+            if turn_kind == "notify" {
+                if !self.drain_sub_results() { return Ok(()); }
+            } else if turn_kind == "user_input" {
+                // 记录 user_input 事件（使用原始文本，包含 [Image #N] 占位符）
                 self.append_event(json!({"type":"user_input","content":user_input}))?;
             }
 
@@ -1338,7 +1386,9 @@ impl Agent {
                 user_input
             };
 
-            self.conv.add_user(&user_input)?;
+            if turn_kind != "notify" {
+                self.conv.add_user(&user_input)?;
+            }
             // Increment turn count
             self.increment_turn_count();
 
@@ -1661,6 +1711,7 @@ impl Agent {
             DisplayEvent::SubAgentResult { .. } => {}
             DisplayEvent::AsyncTaskResult { .. } => {}
             DisplayEvent::ImageDescribe { .. } => {}
+            DisplayEvent::UserNotify { .. } => {}
             DisplayEvent::Title(_) => {}
         }
         if let Some(tx) = &self.display_tx {

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -3,11 +3,16 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
+use std::sync::mpsc;
 
 /// Global image directory path, set once during agent initialization.
 /// Used by the image paste callback to know where to save clipboard images.
 static IMAGE_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Global inject callback data: channel sender.
+/// Set by register_inject_callback before linenoise is used.
+static INJECT_TX: Mutex<Option<mpsc::Sender<String>>> = Mutex::new(None);
 
 /// Set the global image directory path for the paste callback.
 /// Should be called once during agent initialization.
@@ -47,6 +52,7 @@ unsafe extern "C" {
     fn linenoiseHistoryLoad(filename: *const c_char) -> libc::c_int;
     fn linenoiseSetMultiLine(ml: libc::c_int);
     fn linenoiseSetImagePasteCallback(cb: Option<unsafe extern "C" fn(*mut *mut libc::c_char, *mut libc::size_t)>);
+    fn linenoiseSetInjectCallback(cb: Option<unsafe extern "C" fn(*mut libc::c_char, libc::size_t) -> libc::c_int>);
     fn linenoiseWrite(s: *const c_char, len: libc::size_t);
     fn linenoiseRegisterState(ls: *mut LinenoiseState);
     fn linenoiseSetActive(active: libc::c_int);
@@ -249,6 +255,36 @@ pub fn register_paste_callback() {
     unsafe {
         linenoiseSetImagePasteCallback(Some(image_paste_callback_impl));
     }
+}
+
+/// Register the inject callback with linenoise.
+/// Called when Ctrl+O is pressed.
+/// The callback sends the edit buffer text to the provided channel.
+/// The readline thread always queues it as pending notify and wakes the main loop.
+pub fn register_inject_callback(tx: mpsc::Sender<String>) {
+    *INJECT_TX.lock().unwrap() = Some(tx);
+    unsafe {
+        linenoiseSetInjectCallback(Some(inject_callback_impl));
+    }
+}
+
+/// Extern "C" function called by linenoise when the user presses Ctrl+O.
+#[unsafe(no_mangle)]
+pub extern "C" fn inject_callback_impl(buf: *mut libc::c_char, len: libc::size_t) -> libc::c_int {
+    if buf.is_null() || len == 0 {
+        return 1;
+    }
+    let text = unsafe {
+        let slice = std::slice::from_raw_parts(buf as *const u8, len as usize);
+        String::from_utf8_lossy(slice).into_owned()
+    };
+    if text.is_empty() {
+        return 1;
+    }
+    if let Some(tx) = INJECT_TX.lock().unwrap().as_ref() {
+        let _ = tx.send(text);
+    }
+    0
 }
 
 /// Extern "C" function called by linenoise when the user presses Ctrl+V.

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -422,7 +422,6 @@ store_session_init() {
     NOTIFY_FIFO="${session_dir}/notify.fifo"
     NOTIFY_BUF="${session_dir}/notify.buf"
     ACTIVE_TASK_FILE="${session_dir}/active_task.count"
-    AGENT_RUNNING_FLAG="${session_dir}/agent_running.flag"
     [[ -p "$NOTIFY_FIFO" ]] || { rm -f "$NOTIFY_FIFO"; mkfifo "$NOTIFY_FIFO"; }
     printf '0\n' > "$ACTIVE_TASK_FILE"
 }
@@ -1173,6 +1172,10 @@ display_message() {
             printf '\033[%sm[bg-bash %s] exit_code=%s\033[0m\n' "$([[ "${REPLY_MESSAGE[2]}" == "0" ]] && echo 36 || echo 31)" "${REPLY_MESSAGE[1]}" "${REPLY_MESSAGE[2]}"
             [[ -n "${REPLY_MESSAGE[3]:0:120}" ]] && printf '%s\n' "${REPLY_MESSAGE[3]:0:120}"
             DISPLAY_LAST_CHAR=$'\n' ;;
+        USER_NOTIFY)
+            display_ensure_newline
+            printf '\033[33m[user inject] %s\033[0m\n' "${REPLY_MESSAGE[1]}"
+            DISPLAY_LAST_CHAR=$'\n' ;;
         IMAGE_DESCRIBE)
             [[ -n "${REPLY_MESSAGE[2]}" ]] && { display_human_text "$(printf '\033[36m📸 %s: %s\033[0m\n' "${REPLY_MESSAGE[1]}" "${REPLY_MESSAGE[2]}")"; DISPLAY_LAST_CHAR=$'\n'; }
             ;;
@@ -1337,18 +1340,21 @@ agent_main_loop() {
                     store_event_append "{\"type\":\"sub_agent_end\",\"session_id\":\"$(util_json_escape "$_sid")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"status\":\"$_status\"}"
                     store_stats_update total_input_tokens=+$_in total_output_tokens=+$_out total_cache_read_tokens=+$_cr total_cache_creation_tokens=+$_cc sub_agent_request_count=+1 agent_request_count=+$_reqs
                     util_write_msg "AGENT_RESULT" "$_sid" "$_status" "$_in" "$_out" "$_thinking" "$_text" >> "$NOTIFY_BUF"
-                    local _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
-                    (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
-                    [[ ! -f "$AGENT_RUNNING_FLAG" ]] && util_write_msg "NOTIFY_PENDING" >&5
                     ;;
                 ASYNC_TASK_RESULT)
                     store_event_append "{\"type\":\"async_task_result\",\"task_id\":\"$(util_json_escape "${REPLY_MESSAGE[1]}")\",\"exit_code\":${REPLY_MESSAGE[2]},\"output\":\"$(util_json_escape "${REPLY_MESSAGE[3]}")\"}"
                     util_write_msg "${REPLY_MESSAGE[@]}" >> "$NOTIFY_BUF"
-                    local _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
-                    (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
-                    [[ ! -f "$AGENT_RUNNING_FLAG" ]] && util_write_msg "NOTIFY_PENDING" >&5
                     ;;
+                USER_NOTIFY)
+                    util_write_msg "USER_NOTIFY" "${REPLY_MESSAGE[1]}" >> "$NOTIFY_BUF"
+                    ;;
+                *) continue ;;
             esac
+            if [[ "${REPLY_MESSAGE[0]}" != "USER_NOTIFY" ]]; then
+                local _cnt=$(cat "$ACTIVE_TASK_FILE" 2>/dev/null || echo 0)
+                (( _cnt > 0 )) && printf '%d\n' $(( _cnt - 1 )) > "$ACTIVE_TASK_FILE"
+            fi
+            util_write_msg "NOTIFY_PENDING" >&5
         done
     ) &
     local _notify_pid=$!
@@ -1381,7 +1387,7 @@ agent_main_loop() {
     exec 4>&-
     wait "$display_pid" 2>/dev/null || true
     cleanup_all_pipes
-    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF" "$AGENT_RUNNING_FLAG"
+    rm -f "$INPUT_FIFO" "$NOTIFY_FIFO" "$NOTIFY_BUF"
 }
 
 agent_drain_notify_buf() {
@@ -1399,6 +1405,9 @@ agent_drain_notify_buf() {
             util_write_msg "ASYNC_TASK_RESULT" "${REPLY_MESSAGE[@]:1}"
             _conv+="[bg-bash ${REPLY_MESSAGE[1]}] exit_code=${REPLY_MESSAGE[2]}"$'\n'
             [[ -n "${REPLY_MESSAGE[3]}" ]] && _conv+="Output: ${REPLY_MESSAGE[3]}"$'\n'
+        elif [[ "${REPLY_MESSAGE[0]}" == "USER_NOTIFY" ]]; then
+            util_write_msg "USER_NOTIFY" "${REPLY_MESSAGE[1]}"
+            _conv+="${REPLY_MESSAGE[1]}"$'\n'
         fi
     done
     exec 9<&-
@@ -1410,11 +1419,9 @@ agent_drain_notify_buf() {
 agent_loop_stream() {
     local user_input="$1" turn=0
     # Trap SIGINT: close pipe FD to unblock read
-    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes; rm -f "$AGENT_RUNNING_FLAG"' INT
+    trap 'INTERRUPT_REQUESTED=true; cleanup_all_pipes' INT
     while (( turn < MAX_TURNS )); do
         (( turn++ )) || true
-        # agent_loop 运行中标记（notify reader 见此标记不发 NOTIFY_PENDING，靠 drain 消费）
-        : > "$AGENT_RUNNING_FLAG"
         agent_drain_notify_buf || true
         # Compact before each LLM call: uses ctx_tokens from previous call's USAGE
         agent_compact_context auto && util_write_msg "CONTEXT_UPDATE" "compact" "auto"
@@ -1458,7 +1465,6 @@ agent_loop_stream() {
         # Fatal stop reasons exit immediately
         case "$stop" in
             error|max_tokens|length)
-                rm -f "$AGENT_RUNNING_FLAG"
                 [[ "$stop" != "error" ]] && { util_write_msg "ERROR" "Response truncated (max_tokens reached)"; }
                 return 1
                 ;;
@@ -1475,7 +1481,6 @@ agent_loop_stream() {
             fi
             # tool_use/tool_calls → loop continues; otherwise exit unless a sub-agent result arrived meanwhile
             if [[ "$stop" != "tool_use" && "$stop" != "tool_calls" ]]; then
-                rm -f "$AGENT_RUNNING_FLAG"
                 agent_drain_notify_buf && continue
                 util_write_msg "STOP" "$stop"
                 break
@@ -1488,7 +1493,6 @@ agent_loop_stream() {
     if (( turn >= MAX_TURNS )); then
         util_write_msg "ERROR" "Max turns ($MAX_TURNS) reached"
     fi
-    rm -f "$AGENT_RUNNING_FLAG"
 }
 
 agent_loop() {
@@ -1694,6 +1698,13 @@ validate_config() {
     sse_parse() { util_awk_run -v verbose="${VERBOSE:-false}" -f "$AWK_DIR/json.awk" -f "$AWK_DIR/protocol.awk" -f "$AWK_DIR/todo_protocol.awk" -f "$AWK_DIR/claude_sse.awk"; }
 }
 
+# Ctrl+O: inject input through NOTIFY_FIFO.
+agent_user_inject_readline() {
+    [[ -n "${READLINE_LINE:-}" ]] || return
+    util_write_msg "USER_NOTIFY" "$READLINE_LINE" >&9 2>/dev/null
+    READLINE_LINE="" READLINE_POINT=0
+}
+
 interactive_mode() {
     local history_file="${BASH_AGENT_HOME:-${HOME}}/.bash-agent/history" line
     mkdir -p "$(dirname "$history_file")" 2>/dev/null || true
@@ -1711,8 +1722,10 @@ interactive_mode() {
     display_term_title "idle"
     {
         exec 5> "$INPUT_FIFO"
+        exec 9<> "$NOTIFY_FIFO"
         set -o emacs 2>/dev/null || true
         bind -x '"\C-v": agent_image_insert_placeholder_readline' 2>/dev/null || true
+        bind -x '"\C-o": agent_user_inject_readline' 2>/dev/null || true
         while true; do
             stty echo 2>/dev/null || true
             if ! IFS= read -e -r -p $'\033[32m>\033[0m ' line < /dev/tty; then

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -129,6 +129,7 @@ static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;
 static linenoiseFreeHintsCallback *freeHintsCallback = NULL;
 static linenoiseImagePasteCallback imagePasteCallback = NULL;
+static linenoiseInjectCallback injectCallback = NULL;
 static char *linenoiseReadLine(FILE *fp, int *err);
 static char *linenoiseNoTTY(void);
 static void refreshLineWithCompletion(struct linenoiseState *ls, linenoiseCompletions *lc, int flags);
@@ -498,6 +499,7 @@ enum KEY_ACTION{
 	CTRL_L = 12,        /* Ctrl+l */
 	ENTER = 13,         /* Enter */
 	CTRL_N = 14,        /* Ctrl-n */
+	CTRL_O = 15,        /* Ctrl+o (inject input) */
 	CTRL_P = 16,        /* Ctrl-p */
 	CTRL_T = 20,        /* Ctrl-t */
 	CTRL_U = 21,        /* Ctrl+u */
@@ -825,6 +827,10 @@ void linenoiseSetHintsCallback(linenoiseHintsCallback *fn) {
 
 void linenoiseSetImagePasteCallback(linenoiseImagePasteCallback cb) {
     imagePasteCallback = cb;
+}
+
+void linenoiseSetInjectCallback(linenoiseInjectCallback cb) {
+    injectCallback = cb;
 }
 
 /* Register a function to free the hints returned by the hints callback
@@ -2010,6 +2016,7 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
          * Use two calls to handle slow terminals returning the two
          * chars at different times. */
         if (read(l->ifd,seq,1) == -1) break;
+
         if (read(l->ifd,seq+1,1) == -1) break;
 
         /* ESC [ sequences. */
@@ -2124,6 +2131,13 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
                 linenoiseEditInsert(l, out, outlen);
                 free(out);
             }
+        }
+        break;
+    case CTRL_O: /* ctrl+o, inject input */
+        if (injectCallback && l->len > 0 && injectCallback(l->buf, l->len) == 0) {
+            l->buf[0] = '\0';
+            l->pos = l->len = 0;
+            refreshLine(l);
         }
         break;
     }

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -107,6 +107,12 @@ void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 typedef void (*linenoiseImagePasteCallback)(char **out, size_t *outlen);
 void linenoiseSetImagePasteCallback(linenoiseImagePasteCallback cb);
 
+/* Inject callback — called when Ctrl+O is pressed.
+ * cb() receives the current edit buffer content and length.
+ * Return 0 to consume (clear buffer), non-zero to keep editing. */
+typedef int (*linenoiseInjectCallback)(char *buf, size_t len);
+void linenoiseSetInjectCallback(linenoiseInjectCallback cb);
+
 /* History API. */
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);


### PR DESCRIPTION
## 背景

agent 运行中（LLM streaming / tool 执行）或空闲时，用户需要能随时输入追加指令，不中断当前 turn。之前的输入只能等当前 turn 结束后才能处理。

## 核心设计

用户输入（Ctrl+O）**永远走 notify/sub_result channel**，作为 pending injection 在安全边界注入，不中断当前 LLM turn。

- **Ctrl+O**（0x0F）是单字节控制字符，所有终端一致（与 Ctrl+V 相同），不依赖终端特定的转义序列
- **conversation 单写者**：notify reader/异步来源只写 pending 队列，主 loop 在安全边界统一 flush
- **stale wakeup 过滤**：notify reader 统一发送 NOTIFY_PENDING，main loop 收到后检查 pending 队列是否非空，空则忽略

## Bash 实现

- 删除 `AGENT_RUNNING_FLAG`：不再需要文件 flag 控制 notify reader 是否发 wakeup
- notify reader 的 `case` 后统一发送 `NOTIFY_PENDING`；active count 递减合并到 case 后
- `agent_drain_notify_buf` 新增 `USER_NOTIFY` 处理：conversation 用原文，不加 `[user inject]` 前缀
- `agent_loop_stream` 每轮 LLM call 前 + end_turn 后 drain pending
- `agent_user_inject_readline`：`bind -x '"\C-o"'`，写 `USER_NOTIFY` 到 NOTIFY_FIFO（fd9）
- `exec 9<> "$NOTIFY_FIFO"`（O_RDWR 不阻塞，不用 `2>/dev/null` 避免吞掉 `read -e -p` 的 stderr 提示符）

## Go / Rust / C 对齐

核心行为全部对齐 Bash：
- Ctrl+O 永远走 notify/sub-result pending
- stale wakeup 空 pending 忽略
- LLM call 前和 end_turn 后 flush pending
- `USER_NOTIFY` 写 conversation 用原文

| | Bash | Go | Rust | C |
|---|---|---|---|---|
| 触发 | `bind \C-o` | linenoise callback | linenoise callback | linenoise callback |
| pending channel | NOTIFY_FIFO→BUF | subResultCh (buf=8) | sub_result_tx (unbounded) | sub_result_queue |
| stale wakeup | `\|[[ -s NOTIFY_BUF ]]` | drainSubAgent→false | drain→false | drain≤0 return |

## linenoise

- 枚举新增 `CTRL_O = 15`
- `case CTRL_O:` 调用 `injectCallback`，返回 0 则清空 edit buffer
- 删除了之前不通用的 ESC+CR 检测

## 验证

- 四版本编译通过（build-bash / build-go / build-rust / build-c）
- Bash pty race test 5/5（提示符显示 + 输入 + Ctrl+O buffer 清空）
- Go e2e 181 passed / Rust e2e 181 passed / C e2e 181 passed
- 文档已更新：`AGENT_RUNNING_FLAG` 引用全部清除，注释统一为 Ctrl+O