### PR TITLE
修复 SubAgent 与后台 Bash 进程隔离，统一 C/Go/Rust 执行模型

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -10,6 +10,9 @@
 #include <sys/utsname.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <time.h>
 #include <curl/curl.h>
 
@@ -253,6 +256,10 @@ Agent *agent_create(const char *provider, const char *model,
     a->cwd = util_strdup(cwd);
     a->home = util_strdup(home);
     a->interactive = interactive;
+    a->out = stdout;
+    a->err = stderr;
+    a->owns_out = 0;
+    a->owns_err = 0;
     a->input_queue = input_queue;
     a->display_queue = display_queue;
     a->sub_result_queue = malloc(sizeof(MsgQueue));
@@ -337,6 +344,8 @@ void agent_destroy(Agent *agent) {
         free(agent->skill_names);
     }
     store_session_paths_free(&agent->paths);
+    if (agent->owns_out && agent->out) fclose(agent->out);
+    if (agent->owns_err && agent->err) fclose(agent->err);
     if (agent->sub_result_queue) {
         mq_destroy(agent->sub_result_queue);
         free(agent->sub_result_queue);
@@ -933,7 +942,8 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
         if (agent->verbose && body) {
             int body_len = (int)strlen(body);
             int preview_len = body_len > 200 ? 200 : body_len;
-            fprintf(stderr, "[verbose] Request body (%dKB): %.*s%s\n",
+            FILE *err = agent->err ? agent->err : stderr;
+            fprintf(err, "[verbose] Request body (%dKB): %.*s%s\n",
                     body_len / 1024, preview_len, body, body_len > 200 ? "..." : "");
         }
 
@@ -1121,14 +1131,27 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                         args->task_id = util_strdup(task_id);
                         args->sub_result_queue = agent->sub_result_queue;
                         pthread_t thread;
-                        pthread_create(&thread, NULL, async_bash_thread_fn, args);
-                        pthread_detach(thread);
-                        /* 立即返回 */
-                        StrBuf result;
-                        sb_init(&result);
-                        sb_appendf(&result, "Async task started: task_id=%s", task_id);
-                        tr.output = result.data;
-                        tr.exit_code = 0;
+                        int prc = pthread_create(&thread, NULL, async_bash_thread_fn, args);
+                        if (prc != 0) {
+                            agent->active_task_count--;
+                            free(args->cmd);
+                            free(args->task_id);
+                            free(args);
+                            StrBuf result;
+                            sb_init(&result);
+                            sb_append(&result, "Error: failed to start async bash thread");
+                            tr.output = result.data;
+                            tr.exit_code = 1;
+                        } else {
+                            pthread_detach(thread);
+                            /* 立即返回 */
+                            StrBuf result;
+                            sb_init(&result);
+                            sb_appendf(&result, "Async task started: task_id=%s", task_id);
+                            tr.output = result.data;
+                            tr.exit_code = 0;
+                        }
+                        free(cmd);
                     } else {
                         free(cmd);
                         tr = tool_dispatch(tc->name, tc->input_json.data,
@@ -1824,13 +1847,49 @@ static void *async_bash_thread_fn(void *arg) {
         free(args->cmd); free(args->task_id); free(args);
         return NULL;
     }
-    close(fd);
 
-    /* 执行命令，输出写入临时文件 */
-    char cmd_buf[8192];
-    snprintf(cmd_buf, sizeof(cmd_buf), "bash -lc '%s' > '%s' 2>&1", args->cmd, tmp_template);
-    int rc = system(cmd_buf);
-    int exit_code = WEXITSTATUS(rc);
+    /* 执行命令，输出写入临时文件：fork/exec，避免 system() quoting/stdin 风险 */
+    int exit_code = 0;
+    pid_t pid = fork();
+    if (pid < 0) {
+        exit_code = 127;
+        const char *msg = "Failed to fork async bash\n";
+        ssize_t unused = write(fd, msg, strlen(msg));
+        (void)unused;
+    } else if (pid == 0) {
+        setpgid(0, 0);
+
+        int devnull = open("/dev/null", O_RDONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDIN_FILENO);
+            close(devnull);
+        }
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        close(fd);
+        execl("/bin/bash", "bash", "-lc", args->cmd, (char *)NULL);
+        _exit(127);
+    } else {
+        setpgid(pid, pid);
+        close(fd);
+        fd = -1;
+        int status = 0;
+        while (waitpid(pid, &status, 0) < 0) {
+            if (errno == EINTR) continue;
+            status = -1;
+            break;
+        }
+        if (status == -1) {
+            exit_code = 127;
+        } else if (WIFEXITED(status)) {
+            exit_code = WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            exit_code = 128 + WTERMSIG(status);
+        } else {
+            exit_code = 1;
+        }
+    }
+    if (fd >= 0) close(fd);
 
     /* 读取全部输出 */
     char *output = NULL;
@@ -1844,6 +1903,9 @@ static void *async_bash_thread_fn(void *arg) {
         output[n] = '\0';
         fclose(f);
         remove(tmp_template);
+        char *sanitized = util_sanitize_utf8(output);
+        free(output);
+        output = sanitized;
     }
 
     /* 构造 MSG_ASYNC_TASK_RESULT 并 push 到 sub_result_queue */
@@ -1898,8 +1960,25 @@ static void *sub_agent_thread_fn(void *arg) {
         store_session_paths_free(&sub_paths);
     }
 
-    /* 重定向 stdout/stderr 到 /dev/null */
-    /* (在子线程中不做这个，因为工具执行用的是 popen) */
+    /* 子 agent 输出隔离：不要在线程里 dup2，全进程 fd 共享，会影响主 agent。 */
+    sub->out = fopen("/dev/null", "w");
+    if (sub->out) sub->owns_out = 1;
+    else sub->out = stdout;
+    sub->err = fopen("/dev/null", "w");
+    if (sub->err) sub->owns_err = 1;
+    else sub->err = stderr;
+    sub->output_format = 0;
+    sub->verbose = 0;
+    sub->max_turns = 10;
+    sub->max_tokens = args->parent->max_tokens;
+    sub->max_context_tokens = args->parent->max_context_tokens;
+    sub->tool_timeout_secs = args->parent->tool_timeout_secs;
+    sub->tool_result_max_bytes = args->parent->tool_result_max_bytes;
+    sub->dp_cfg = dp_config_init(sub->max_context_tokens);
+    free(sub->thinking);
+    sub->thinking = util_strdup(args->parent->thinking);
+    free(sub->effort);
+    sub->effort = util_strdup(args->parent->effort);
 
     /* 执行 agent_loop */
     int rc = agent_loop(sub, args->prompt, "user_input");
@@ -2025,7 +2104,16 @@ char *agent_handle_sub_agent(Agent *agent, const char *prompt,
     args->sub_result_queue = agent->sub_result_queue;
 
     pthread_t thread;
-    pthread_create(&thread, NULL, sub_agent_thread_fn, args);
+    int prc = pthread_create(&thread, NULL, sub_agent_thread_fn, args);
+    if (prc != 0) {
+        agent->active_task_count--;
+        FREE_PTR(args->prompt);
+        FREE_PTR(args->description);
+        FREE_PTR(args->sub_session_id);
+        free(args);
+        free(sub_session_id);
+        return util_strdup("Error: failed to start sub-agent thread");
+    }
     pthread_detach(thread);
 
     StrBuf result;
@@ -3060,7 +3148,8 @@ int agent_compact_context(Agent *agent, const char *trigger) {
     /* 对齐 bash 版 llm_summary_call: text 为空时报错退出，不 trim 不写 usage
      * bash: [[ -n "$text" ]] || util_die "Failed to generate context summary..." */
     if (rc != 0 || accum.text.len == 0) {
-        fprintf(stderr, "[compact] Failed to generate summary: rc=%d text_len=%zu stop=%s error=%s\n",
+        FILE *err = agent->err ? agent->err : stderr;
+        fprintf(err, "[compact] Failed to generate summary: rc=%d text_len=%zu stop=%s error=%s\n",
                 rc, accum.text.len,
                 accum.stop_reason ? accum.stop_reason : "none",
                 accum.error ? accum.error : "none");
@@ -3218,9 +3307,10 @@ void agent_update_title_status(Agent *agent, const char *status) {
     int idle = (status && strcmp(status, "idle") == 0 && agent->active_task_count <= 0);
     const char *prefix = idle ? "" : "\xe2\x8f\xb3 ";
     int progress = idle ? 0 : 3;
-    fprintf(stderr, "\x1b]0;%s%s T:%s R:%s I:%s(%s) O:%s C:%s\x07\x1b]9;4;%d\x07",
+    FILE *err = agent->err ? agent->err : stderr;
+    fprintf(err, "\x1b]0;%s%s T:%s R:%s I:%s(%s) O:%s C:%s\x07\x1b]9;4;%d\x07",
             prefix, agent->model, tc_s, ar_s, total_i_s, pct_s, ao_s, ct_s, progress);
-    fflush(stderr);
+    fflush(err);
 
     free(stats_content);
 }

--- a/c/agent.h
+++ b/c/agent.h
@@ -8,6 +8,7 @@
 #include "protocol.h"
 #include "json.h"
 #include "util.h"
+#include <stdio.h>
 
 /* DP Compact 配置结构体 */
 typedef struct {
@@ -50,6 +51,10 @@ typedef struct {
     int output_format;      /* 0=human, 1=stream-json */
     int verbose;
     int interactive;
+    FILE *out;              /* agent 专属 stdout，子 agent 指向 /dev/null */
+    FILE *err;              /* agent 专属 stderr/title，子 agent 指向 /dev/null */
+    int owns_out;
+    int owns_err;
     char *thinking;
     char *effort;
 

--- a/c/tools.c
+++ b/c/tools.c
@@ -580,8 +580,15 @@ static ToolResult tool_bash(const char *input_json, int timeout_secs) {
     }
 
     if (pid == 0) {
-        /* 子进程 */
+        /* 子进程：独立进程组，stdin 不继承主终端，stdout/stderr 走 pipe */
+        setpgid(0, 0);
         close(pipefd[0]);
+
+        int devnull = open("/dev/null", O_RDONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDIN_FILENO);
+            close(devnull);
+        }
         dup2(pipefd[1], STDOUT_FILENO);
         dup2(pipefd[1], STDERR_FILENO);
         close(pipefd[1]);
@@ -590,6 +597,7 @@ static ToolResult tool_bash(const char *input_json, int timeout_secs) {
     }
 
     /* 父进程 */
+    setpgid(pid, pid);
     close(pipefd[1]);
 
     /* 设置 pipe 为非阻塞 */
@@ -618,7 +626,7 @@ static ToolResult tool_bash(const char *input_json, int timeout_secs) {
 
         /* 检查超时 */
         if (effective_timeout > 0 && time(NULL) >= deadline) {
-            kill(pid, SIGKILL);
+            if (kill(-pid, SIGKILL) < 0) kill(pid, SIGKILL);
             timed_out = 1;
             break;
         }
@@ -627,7 +635,10 @@ static ToolResult tool_bash(const char *input_json, int timeout_secs) {
     close(pipefd[0]);
 
     int status = 0;
-    waitpid(pid, &status, 0);
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR) continue;
+        break;
+    }
 
     if (timed_out) {
         char tmsg[128];

--- a/go/agent.go
+++ b/go/agent.go
@@ -1094,6 +1094,8 @@ func (a *Agent) LaunchAsyncBash(ctx context.Context, cmd string, timeoutSecs int
 	// 启动 goroutine（对齐 Bash 版：无 timeout，无截断）
 	go func() {
 		execCmd := exec.Command("bash", "-lc", cmd)
+		execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		execCmd.Stdin = nil
 		var stdout, stderr bytes.Buffer
 		execCmd.Stdout = &stdout
 		execCmd.Stderr = &stderr
@@ -1127,48 +1129,49 @@ func (a *Agent) LaunchAsyncBash(ctx context.Context, cmd string, timeoutSecs int
 	return fmt.Sprintf("Async task started: task_id=%s", taskID), nil
 }
 
-func (a *Agent) runSubAgent(ctx context.Context, sessionID, prompt, fork string) SubAgentResult {
-	result := SubAgentResult{
+func (a *Agent) runSubAgent(ctx context.Context, sessionID, prompt, fork string) (result SubAgentResult) {
+	result = SubAgentResult{
 		SessionID: sessionID,
 		Status:    "failed",
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			result.Status = "failed"
+			result.Text = fmt.Sprintf("sub-agent panic: %v", r)
+		}
+	}()
 
-	// 构建子 agent 命令
-	self, err := os.Executable()
+	homeDir := os.Getenv("BASH_AGENT_HOME")
+	if homeDir == "" {
+		homeDir = os.Getenv("HOME")
+	}
+	cwd, err := os.Getwd()
 	if err != nil {
+		result.Text = err.Error()
 		return result
 	}
 
-	args := []string{
-		"-p", a.cfg.Provider,
-		"--base-url", a.cfg.BaseURL,
-		"-m", a.cfg.Model,
-		"--api-key", a.cfg.APIKey,
-		"--session", sessionID,
-		"--max-turns", "10",
-		prompt,
+	childCfg := a.cfg
+	childCfg.MaxTurns = 10
+	// 子 agent 必须静默：不输出 stream-json，不写终端正文，不抢 title。
+	childCfg.OutputFormat = "human"
+	childCfg.Interactive = false
+
+	childStore := NewFileStore(homeDir, cwd)
+	if err := childStore.Init(sessionID); err != nil {
+		result.Text = err.Error()
+		return result
 	}
 
-	// 设置 BASH_AGENT_HOME
-	homeDir := os.Getenv("BASH_AGENT_HOME")
-	if homeDir == "" {
-		homeDir = os.Getenv("HOME") + "/.bash-agent"
-	}
-	env := os.Environ()
-	env = append(env, "BASH_AGENT_HOME="+homeDir)
+	childDisplay := NewTermDisplay()
+	childDisplay.SetSilent(true)
+	childLLM := NewHTTPTransport(childCfg)
+	childTools := NewToolDispatcher(childCfg)
+	child := NewAgent(childCfg, childStore, childLLM, childTools, childDisplay)
+	child.SetToolDefs(a.toolDefs)
+	defer child.CloseDisplay()
 
-	cmd := exec.CommandContext(ctx, self, args...)
-	cmd.Env = env
-
-	// 子 agent 完全静默：stdin/stdout/stderr 全部指向 /dev/null
-	// （与 bash 版 exec </dev/null >/dev/null 2>&1 一致）
-	devNull, _ := os.Open(os.DevNull)
-	cmd.Stdin = devNull
-	cmd.Stdout = devNull
-	cmd.Stderr = devNull
-
-	err = cmd.Run()
-	if err != nil {
+	if err := child.RunLoop(ctx, prompt, "user_input"); err != nil {
 		result.Status = "failed"
 		result.Text = err.Error()
 	} else {
@@ -1177,21 +1180,19 @@ func (a *Agent) runSubAgent(ctx context.Context, sessionID, prompt, fork string)
 
 	// 从子 agent 的 conversation.jsonl 提取最后一条 assistant 消息的 thinking 和 text
 	// （与 bash 版 send_sub_result.awk 逻辑一致）
-	if thinking, text, err := a.store.GetSubAgentResult(sessionID); err == nil {
+	if thinking, text, err := childStore.GetSubAgentResult(sessionID); err == nil {
 		result.Thinking = thinking
 		if result.Status == "ok" {
 			result.Text = text
 		}
 	}
 
-	// 解析子 agent 的 stats 获取 token 信息
-	if stats, err := a.store.GetSubAgentStats(sessionID); err == nil {
-		result.InputTokens = stats.InputTokens
-		result.OutputTokens = stats.OutputTokens
-		result.CacheRead = stats.CacheRead
-		result.CacheWrite = stats.CacheWrite
-		result.Requests = stats.TotalRequests
-	}
+	stats := childStore.GetStats()
+	result.InputTokens = stats.InputTokens
+	result.OutputTokens = stats.OutputTokens
+	result.CacheRead = stats.CacheRead
+	result.CacheWrite = stats.CacheWrite
+	result.Requests = stats.TotalRequests
 
 	return result
 }

--- a/go/tools.go
+++ b/go/tools.go
@@ -41,12 +41,12 @@ type AsyncBashLauncher func(ctx context.Context, cmd string, timeoutSecs int) (s
 
 // ToolDispatcher 工具调度器
 type ToolDispatcher struct {
-	cfg              Config
-	launcher         SubAgentLauncher
+	cfg                    Config
+	launcher               SubAgentLauncher
 	backgroundBashLauncher AsyncBashLauncher
-	planConfirmFn    func() (string, error)
-	planClearFn      func() (string, error)
-	skillLoader      func(name string) (string, error)
+	planConfirmFn          func() (string, error)
+	planClearFn            func() (string, error)
+	skillLoader            func(name string) (string, error)
 }
 
 // NewToolDispatcher 创建工具调度器
@@ -549,6 +549,7 @@ func (td *ToolDispatcher) toolBash(ctx context.Context, cmd, timeoutStr, backgro
 
 	execCmd := exec.CommandContext(cmdCtx, "bash", "-lc", cmd)
 	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	execCmd.Stdin = nil
 	var stdout, stderr bytes.Buffer
 	execCmd.Stdout = &stdout
 	execCmd.Stderr = &stderr

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -26,7 +26,9 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::io::IntoRawFd;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
@@ -1482,7 +1484,14 @@ impl Agent {
                                 let tx = self.sub_result_tx.clone();
                                 let tid = task_id.clone();
                                 thread::spawn(move || {
-                                    let output = std::process::Command::new("bash").arg("-lc").arg(&command).output();
+                                    let output = Command::new("bash")
+                                        .arg("-lc")
+                                        .arg(&command)
+                                        .stdin(Stdio::null())
+                                        .stdout(Stdio::piped())
+                                        .stderr(Stdio::piped())
+                                        .process_group(0)
+                                        .output();
                                     let (exit_code, stdout) = match output {
                                         Ok(o) => (o.status.code().unwrap_or(-1), String::from_utf8_lossy(&o.stdout).to_string() + &String::from_utf8_lossy(&o.stderr)),
                                         Err(e) => (127, e.to_string()),

--- a/rust/src/tools.rs
+++ b/rust/src/tools.rs
@@ -8,6 +8,7 @@ use crate::config::Config;
     use nix::unistd::pipe;
     use std::fs;
     use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
+    use std::os::unix::process::CommandExt;
     use std::path::Path;
     use std::process::{Command, Stdio};
     use std::sync::atomic::AtomicBool;
@@ -292,8 +293,10 @@ use crate::config::Config;
             let mut child = Command::new("bash")
                 .arg("-lc")
                 .arg(command)
+                .stdin(Stdio::null())
                 .stdout(unsafe { Stdio::from_raw_fd(stdout_w.into_raw_fd()) })
                 .stderr(unsafe { Stdio::from_raw_fd(stderr_w.into_raw_fd()) })
+                .process_group(0)
                 .spawn()?;
 
             let stdout_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
@@ -338,16 +341,14 @@ use crate::config::Config;
                 }
                 Ok(WaitResult::Cancel) => {
                     timed_out = true; // 标记为截断
+                    let _ = unsafe { libc::kill(-(child.id() as libc::pid_t), libc::SIGKILL) };
+                    let _ = child.try_wait();
                     // drain cancel pipe 防止后续 tool 调用立即收到 Cancel
                     drain_fd(self.cancel_fd);
                 }
                 Ok(WaitResult::Timeout) => {
                     timed_out = true;
-                    // SIGTERM 子进程
-                    let _ = Command::new("kill")
-                        .arg("--")
-                        .arg(format!("-{}", child.id()))
-                        .output();
+                    let _ = unsafe { libc::kill(-(child.id() as libc::pid_t), libc::SIGKILL) };
                     let _ = child.try_wait();
                 }
                 Err(e) => {


### PR DESCRIPTION
## 背景

本次修复主要解决 SubAgent 与 `Bash(background=true)` 在高级 runtime（C/Go/Rust）中的进程隔离和行为一致性问题。

此前存在几个风险：

- C 版 Bash 子进程可能继承主终端 `stdin`，与主 agent 的 readline 抢输入，导致交互卡住。
- C 版后台 Bash 使用 `system("bash -lc '%s' ...")` 执行命令，存在 shell quoting 错误和额外 shell 层风险。
- C/Go/Rust 三个高级 runtime 的后台 Bash 行为不完全一致：
  - 是否继承 stdin 不一致
  - 是否设置独立进程组不一致
  - timeout/cancel 时是否 kill 整个进程组不一致
  - 子任务输出隔离策略不一致
- C 版 SubAgent 子线程可能污染主终端输出，且配置继承不完整。

## 改动内容

### C 版

#### Bash 工具进程隔离

- Bash 子进程启动后设置独立进程组。
- 子进程 `stdin` 显式重定向到 `/dev/null`，避免继承主终端。
- `stdout/stderr` 保持通过 pipe 回传给父进程。
- timeout 时优先 kill 整个进程组，避免子孙进程残留。
- `waitpid` 增加 `EINTR` 处理。

#### 后台 Bash 重构

- 移除 `system("bash -lc '%s' ...")`。
- 改为 `fork/exec /bin/bash -lc <cmd>`。
- 命令通过 argv 传递，不再手拼 shell quoting。
- 子进程 `stdin` 接 `/dev/null`。
- `stdout/stderr` 写入临时文件。
- 子进程设置独立进程组。
- 后台任务输出增加 UTF-8 sanitize。
- 结果仍通过 `MSG_ASYNC_TASK_RESULT` 注入父 agent，保持协议语义不变。
- 增加后台线程创建失败处理：
  - 回滚 `active_task_count`
  - 释放资源
  - 返回明确错误

#### SubAgent 输出隔离与配置继承

- 为 `Agent` 增加专属 `out/err` 句柄。
- 子 Agent 的 `out/err` 指向 `/dev/null`，避免污染主终端。
- `agent_update_title_status`、verbose request body、compact 错误输出改为写入 agent 专属 `err`。
- 子 Agent 继承父 Agent 的关键配置：
  - `max_tokens`
  - `max_context_tokens`
  - `tool_timeout_secs`
  - `tool_result_max_bytes`
  - `thinking`
  - `effort`
  - `dp_cfg`
- 子 Agent 固定为非交互、静默输出、`max_turns=10`。
- `pthread_create` 失败时正确回滚和释放资源。

### Go 版

- SubAgent 不再通过 `os.Executable()` 拉起独立进程。
- 改为 goroutine 内创建独立 child agent。
- child agent 使用独立 store/session/display/transport/tools。
- child display 设置 silent，避免污染主终端。
- child agent 继承父配置并限制：
  - `MaxTurns=10`
  - `Interactive=false`
  - `OutputFormat=human`
- 增加 panic recover，转为失败结果返回父 agent。
- SubAgent 结果从 child store 读取，stats 从 child store 汇总。
- 同步 Bash 执行隔离：
  - 普通 Bash 显式不继承 stdin
  - 后台 Bash 设置独立进程组
  - 后台 Bash 显式不继承 stdin
  - 结果仍通过 `subResultCh` 注入父 agent

### Rust 版

- 普通 Bash：
  - 设置 `stdin(Stdio::null())`
  - 设置独立进程组
  - cancel/timeout 时 kill 进程组
- 后台 Bash：
  - 设置 `stdin(Stdio::null())`
  - 设置独立进程组
  - `stdout/stderr` 继续捕获后通过 channel 注入父 agent

## 行为保持

- Bash 版未修改。
- `background=true` 的协议语义保持不变：
  - 工具调用立即返回 `task_id`
  - 后台任务完成后异步注入父 agent conversation
  - 结果仍记录为 `async_task_result`
- SubAgent 仍通过父 agent 统一处理结果、事件、统计和 conversation 注入。
- 未修改 system prompt / tools.json。

## 验证

已完成以下验证：

```bash
make -B build-c
AGENT=./dist/cagent bash tests/test.sh
make test-go-e2e
make test-rust-e2e
git diff --check
```

结果：

- C e2e：`182 passed, 0 failed`
- Go e2e：`182 passed, 0 failed`
- Rust e2e：`182 passed, 0 failed`
- `git diff --check` 通过
- C build 通过，仅保留既有 warning：`display_only_push` unused

## 提交

```text
bc4f0aa fix background bash process isolation