### PR TITLE
修复 SubAgent 与后台 Bash 进程隔离，统一 C/Go/Rust 三版本执行模型

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -1969,7 +1969,7 @@ static void *sub_agent_thread_fn(void *arg) {
     else sub->err = stderr;
     sub->output_format = 0;
     sub->verbose = 0;
-    sub->max_turns = 10;
+    sub->max_turns = args->parent->max_turns;
     sub->max_tokens = args->parent->max_tokens;
     sub->max_context_tokens = args->parent->max_context_tokens;
     sub->tool_timeout_secs = args->parent->tool_timeout_secs;

--- a/go/agent.go
+++ b/go/agent.go
@@ -717,65 +717,13 @@ func (a *Agent) emitJSON(obj map[string]interface{}) {
 	}
 }
 
-func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
+func (a *Agent) RunLoop(ctx context.Context, initialUserInput, initialTurnKind string) error {
 	// 设置 running 标志：1 表示 agent 正在处理，readline 据此判断 Ctrl+C 是否应中断
 	a.running.Store(true)
 	defer a.running.Store(false)
 
-	// notify turn 只负责消费 pending sub_result；stale wakeup 直接忽略
-	if turnKind == "notify" {
-		if !a.drainSubAgentResults(ctx) {
-			return nil
-		}
-	} else if turnKind == "user_input" {
-		// 记录 user_input 事件（使用原始文本，包含 [Image #N] 占位符）
-		a.emitJSON(map[string]interface{}{"type": "user_input", "content": userInput})
-	}
-
-	// 展开图片占位符：events 记录原始文本，conversation/LLM 使用展开后的长文本
-	if turnKind == "user_input" && strings.Contains(userInput, "[Image #") {
-		expandedInput := a.expandImagePlaceholders(userInput)
-
-		// 提取 <attached-images> 中的描述内容
-		desc := ""
-		if start := strings.Index(expandedInput, "<attached-images>"); start >= 0 {
-			start += len("<attached-images>")
-			if end := strings.Index(expandedInput[start:], "</attached-images>"); end >= 0 {
-				desc = expandedInput[start : start+end]
-			}
-		}
-
-		// 收集所有 [Image #N] 占位符
-		re := regexp.MustCompile(`\[Image #\d+\]`)
-		matches := re.FindAllString(userInput, -1)
-		if len(matches) > 0 {
-			images := strings.Join(matches, " ")
-
-			// 记录 image_describe 事件
-			a.emitJSON(map[string]interface{}{
-				"type":    "image_describe",
-				"images":  images,
-				"content": desc,
-			})
-
-			// 推送 IMAGE_DESCRIBE 到 display
-			a.EmitDisplay(Event{Type: EventImageDescribe, Fields: []string{"IMAGE_DESCRIBE", images, desc}})
-		}
-
-		userInput = expandedInput
-	}
-
-	// 添加用户消息；notify turn 的消息已由 drainSubAgentResults 注入
-	if turnKind != "notify" {
-		_ = a.store.AddUserMessage(userInput)
-	}
-
-	// 用户输入时递增 turn（与 bash 版一致：store_stats_update current_turn_count=+1）
-	_ = a.store.IncrementTurn()
-	// 对齐 bash版: store_stats_update 末尾调 display_term_title
-	a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, ""))
-
-	// 中断处理：用 context.WithCancel 包装，Ctrl+C 同时取消 context（取消 HTTP 请求）
+	// 中断处理：在整个 RunLoop 期间共享一个 cancellable context
+	// Ctrl+C 同时取消 context（取消 HTTP 请求和工具执行）
 	var interrupted atomic.Bool
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -806,216 +754,297 @@ func (a *Agent) RunLoop(ctx context.Context, userInput, turnKind string) error {
 		}
 	}()
 
-	for turn := 0; turn < a.cfg.MaxTurns; turn++ {
-		// Drain SubAgent results that arrived during previous LLM call（对齐 bash agent_drain_notify_buf）
-		a.drainSubAgentResults(ctx)
+	userInput := initialUserInput
+	turnKind := initialTurnKind
 
-		// Compact
-		if compacted, _ := a.CompactContext(ctx, "auto"); compacted {
-			a.EmitDisplay(Event{Type: EventContextUpdate, Fields: []string{"CONTEXT_UPDATE", "compact", "auto"}})
+	// 外层循环：每个 phase（user_input / sub_agent_result / async_task_result / user_notify）获得独立的 max_turns 预算
+	// 对齐 Bash 版：agent_drain_notify_buf 在 turn loop 内消费（共享预算），
+	// NOTIFY_PENDING 触发的 agent_run_loop "" notify 是嵌套调用（独立预算）
+	for {
+		// === Phase setup ===
+
+		// notify turn 只负责消费 pending sub_result；stale wakeup 直接忽略
+		if turnKind == "notify" {
+			if !a.drainSubAgentResults(ctx) {
+				return nil
+			}
+		} else if turnKind == "user_input" {
+			// 记录 user_input 事件（使用原始文本，包含 [Image #N] 占位符）
+			a.emitJSON(map[string]interface{}{"type": "user_input", "content": userInput})
 		}
 
-		// 获取 messages
-		messages, err := a.store.GetMessages()
-		if err != nil {
-			return fmt.Errorf("get messages: %w", err)
-		}
-		systemPrompt := a.BuildPrompt()
+		// 展开图片占位符：events 记录原始文本，conversation/LLM 使用展开后的长文本
+		if turnKind == "user_input" && strings.Contains(userInput, "[Image #") {
+			expandedInput := a.expandImagePlaceholders(userInput)
 
-		// LLM 调用
-		ch, err := a.llm.Call(ctx, messages, systemPrompt, a.toolDefs, a.cfg.MaxTokens, a.cfg.Thinking)
-		if err != nil {
-			a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", err.Error()}})
-			return err
-		}
-
-		var text, thinking string
-		var toolCalls []ToolCallInfo
-		var toolResults []ToolResultInfo
-		var stopReason string
-		var usage Usage
-		var loopErr string
-
-		for ev := range ch {
-			if interrupted.Load() {
-				stopReason = "interrupted"
-				break
+			// 提取 <attached-images> 中的描述内容
+			desc := ""
+			if start := strings.Index(expandedInput, "<attached-images>"); start >= 0 {
+				start += len("<attached-images>")
+				if end := strings.Index(expandedInput[start:], "</attached-images>"); end >= 0 {
+					desc = expandedInput[start : start+end]
+				}
 			}
 
-			switch ev.Type {
-			case EventText:
-				a.EmitDisplay(ev)
-				if len(ev.Fields) > 1 {
-					text += ev.Fields[1]
-					a.emitJSON(map[string]interface{}{"type": "text", "content": ev.Fields[1]})
-				}
-			case EventThinking:
-				a.EmitDisplay(ev)
-				if len(ev.Fields) > 1 {
-					thinking += ev.Fields[1]
-					a.emitJSON(map[string]interface{}{"type": "thinking", "content": ev.Fields[1]})
-				}
-			case EventToolCall:
-				if len(ev.Fields) >= 4 {
-					tc := ToolCallInfo{
-						Name:  ev.Fields[1],
-						ID:    ev.Fields[2],
-						Input: ev.Fields[3],
-					}
-					toolCalls = append(toolCalls, tc)
+			// 收集所有 [Image #N] 占位符
+			re := regexp.MustCompile(`\[Image #\d+\]`)
+			matches := re.FindAllString(userInput, -1)
+			if len(matches) > 0 {
+				images := strings.Join(matches, " ")
 
-					// 生成 CallSummary 并显示（替代 transport 的原始事件）
-					params := ExtractToolParams(tc.Name, json.RawMessage(tc.Input))
-					callSummary := a.tools.CallSummary(tc.Name, params)
-					a.EmitDisplay(Event{Type: EventToolCall, Fields: []string{"TOOL_CALL", tc.Name, tc.ID, tc.Input, callSummary}})
+				// 记录 image_describe 事件
+				a.emitJSON(map[string]interface{}{
+					"type":    "image_describe",
+					"images":  images,
+					"content": desc,
+				})
 
-					// 执行工具
-					output, toolErr := a.tools.Dispatch(ctx, tc.Name, params)
-					if toolErr != nil {
-						output = "Error: " + toolErr.Error()
-					}
-					output = FormatToolResult(output)
-					convOutput := output
-
-					switch tc.Name {
-					case "Read", "Write":
-						pathParam := params["path"]
-						fs := FileSummary(tc.Name, pathParam, params["offset"], params["limit"])
-						output = fs + "\n" + output
-					case "Edit":
-						convOutput = firstLine(output)
-					}
-
-					// 显示结果
-					a.EmitDisplay(Event{Type: EventToolResult, Fields: []string{"TOOL_RESULT", tc.ID, tc.Name, output}})
-
-					// stream-json + events.jsonl: 分别写 tool_call 和 tool_result（与 bash 版一致）
-					a.emitJSON(map[string]interface{}{
-						"type":  "tool_call",
-						"name":  tc.Name,
-						"id":    tc.ID,
-						"input": json.RawMessage(tc.Input),
-					})
-					a.emitJSON(map[string]interface{}{
-						"type":        "tool_result",
-						"tool_use_id": tc.ID,
-						"name":        tc.Name,
-						"content":     output,
-					})
-
-					toolResults = append(toolResults, ToolResultInfo{ToolID: tc.ID, ToolName: tc.Name, Output: output, ConvOutput: convOutput})
-				}
-			case EventUsage:
-				if u, ok := ev.Payload.(Usage); ok {
-					usage = u
-					a.emitJSON(map[string]interface{}{
-						"type":                        "usage",
-						"input_tokens":                u.InputTokens,
-						"output_tokens":               u.OutputTokens,
-						"cache_read_input_tokens":     u.CacheRead,
-						"cache_creation_input_tokens": u.CacheWrite,
-						"kind":                        "agent",
-					})
-				}
-			case EventStop:
-				a.EmitDisplay(ev)
-				if len(ev.Fields) > 1 {
-					stopReason = ev.Fields[1]
-				}
-				a.emitJSON(map[string]interface{}{"type": "stop", "reason": stopReason})
-			case EventError:
-				a.EmitDisplay(ev)
-				if len(ev.Fields) > 1 {
-					loopErr = ev.Fields[1]
-				}
-				stopReason = "error"
-				a.emitJSON(map[string]interface{}{"type": "error", "message": loopErr})
-				// 与 bash 版对齐：ERROR 立即 break 出事件循环
-				break
-			case EventRetry:
-				// 对齐 Rust: 清空当前累积状态
-				text = ""
-				thinking = ""
-				toolCalls = nil
-				toolResults = nil
-				usage = Usage{}
-				a.emitJSON(map[string]interface{}{"type": "retry"})
-			default:
-				a.EmitDisplay(ev)
+				// 推送 IMAGE_DESCRIBE 到 display
+				a.EmitDisplay(Event{Type: EventImageDescribe, Fields: []string{"IMAGE_DESCRIBE", images, desc}})
 			}
+
+			userInput = expandedInput
 		}
 
-		// 记录 usage
-		ctxTokens := a.RecordUsage(usage, "agent", a.cfg.Model)
-		_ = ctxTokens
+		// 添加用户消息；notify turn 的消息已由 drainSubAgentResults 注入
+		if turnKind != "notify" {
+			_ = a.store.AddUserMessage(userInput)
+		}
 
-		// 更新终端标题（与 bash 版 store_stats_update 后调 display_term_title 一致）
+		// 用户输入时递增 turn（与 bash 版一致：store_stats_update current_turn_count=+1）
+		_ = a.store.IncrementTurn()
+		// 对齐 bash版: store_stats_update 末尾调 display_term_title
 		a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, ""))
 
+		// === Turn loop（独立 max_turns 预算）===
+		phaseFatalErr := error(nil)
+
+	TurnLoop:
+		for turn := 0; turn < a.cfg.MaxTurns; turn++ {
+			// Drain SubAgent results that arrived during previous LLM call（对齐 bash agent_drain_notify_buf）
+			a.drainSubAgentResults(ctx)
+
+			// Compact
+			if compacted, _ := a.CompactContext(ctx, "auto"); compacted {
+				a.EmitDisplay(Event{Type: EventContextUpdate, Fields: []string{"CONTEXT_UPDATE", "compact", "auto"}})
+			}
+
+			// 获取 messages
+			messages, err := a.store.GetMessages()
+			if err != nil {
+				cancel()
+				close(sigDone)
+				signal.Stop(sigCh)
+				a.runMu.Lock()
+				if a.currentInterrupt == &interrupted {
+					a.currentInterrupt = nil
+					a.currentCancel = nil
+				}
+				a.runMu.Unlock()
+				return fmt.Errorf("get messages: %w", err)
+			}
+			systemPrompt := a.BuildPrompt()
+
+			// LLM 调用
+			ch, err := a.llm.Call(ctx, messages, systemPrompt, a.toolDefs, a.cfg.MaxTokens, a.cfg.Thinking)
+			if err != nil {
+				a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", err.Error()}})
+				break
+			}
+
+			var text, thinking string
+			var toolCalls []ToolCallInfo
+			var toolResults []ToolResultInfo
+			var stopReason string
+			var usage Usage
+			var loopErr string
+
+			for ev := range ch {
+				if interrupted.Load() {
+					stopReason = "interrupted"
+					break
+				}
+
+				switch ev.Type {
+				case EventText:
+					a.EmitDisplay(ev)
+					if len(ev.Fields) > 1 {
+						text += ev.Fields[1]
+						a.emitJSON(map[string]interface{}{"type": "text", "content": ev.Fields[1]})
+					}
+				case EventThinking:
+					a.EmitDisplay(ev)
+					if len(ev.Fields) > 1 {
+						thinking += ev.Fields[1]
+						a.emitJSON(map[string]interface{}{"type": "thinking", "content": ev.Fields[1]})
+					}
+				case EventToolCall:
+					if len(ev.Fields) >= 4 {
+						tc := ToolCallInfo{
+							Name:  ev.Fields[1],
+							ID:    ev.Fields[2],
+							Input: ev.Fields[3],
+						}
+						toolCalls = append(toolCalls, tc)
+
+						// 生成 CallSummary 并显示（替代 transport 的原始事件）
+						params := ExtractToolParams(tc.Name, json.RawMessage(tc.Input))
+						callSummary := a.tools.CallSummary(tc.Name, params)
+						a.EmitDisplay(Event{Type: EventToolCall, Fields: []string{"TOOL_CALL", tc.Name, tc.ID, tc.Input, callSummary}})
+
+						// 执行工具
+						output, toolErr := a.tools.Dispatch(ctx, tc.Name, params)
+						if toolErr != nil {
+							output = "Error: " + toolErr.Error()
+						}
+						output = FormatToolResult(output)
+						convOutput := output
+
+						switch tc.Name {
+						case "Read", "Write":
+							pathParam := params["path"]
+							fs := FileSummary(tc.Name, pathParam, params["offset"], params["limit"])
+							output = fs + "\n" + output
+						case "Edit":
+							convOutput = firstLine(output)
+						}
+
+						// 显示结果
+						a.EmitDisplay(Event{Type: EventToolResult, Fields: []string{"TOOL_RESULT", tc.ID, tc.Name, output}})
+
+						// stream-json + events.jsonl: 分别写 tool_call 和 tool_result（与 bash 版一致）
+						a.emitJSON(map[string]interface{}{
+							"type":  "tool_call",
+							"name":  tc.Name,
+							"id":    tc.ID,
+							"input": json.RawMessage(tc.Input),
+						})
+						a.emitJSON(map[string]interface{}{
+							"type":        "tool_result",
+							"tool_use_id": tc.ID,
+							"name":        tc.Name,
+							"content":     output,
+						})
+
+						toolResults = append(toolResults, ToolResultInfo{ToolID: tc.ID, ToolName: tc.Name, Output: output, ConvOutput: convOutput})
+					}
+				case EventUsage:
+					if u, ok := ev.Payload.(Usage); ok {
+						usage = u
+						a.emitJSON(map[string]interface{}{
+							"type":                        "usage",
+							"input_tokens":                u.InputTokens,
+							"output_tokens":               u.OutputTokens,
+							"cache_read_input_tokens":     u.CacheRead,
+							"cache_creation_input_tokens": u.CacheWrite,
+							"kind":                        "agent",
+						})
+					}
+				case EventStop:
+					a.EmitDisplay(ev)
+					if len(ev.Fields) > 1 {
+						stopReason = ev.Fields[1]
+					}
+					a.emitJSON(map[string]interface{}{"type": "stop", "reason": stopReason})
+				case EventError:
+					a.EmitDisplay(ev)
+					if len(ev.Fields) > 1 {
+						loopErr = ev.Fields[1]
+					}
+					stopReason = "error"
+					a.emitJSON(map[string]interface{}{"type": "error", "message": loopErr})
+					// 与 bash 版对齐：ERROR 立即 break 出事件循环
+					break
+				case EventRetry:
+					// 对齐 Rust: 清空当前累积状态
+					text = ""
+					thinking = ""
+					toolCalls = nil
+					toolResults = nil
+					usage = Usage{}
+					a.emitJSON(map[string]interface{}{"type": "retry"})
+				default:
+					a.EmitDisplay(ev)
+				}
+			}
+
+			// 记录 usage
+			ctxTokens := a.RecordUsage(usage, "agent", a.cfg.Model)
+			_ = ctxTokens
+
+			// 更新终端标题（与 bash 版 store_stats_update 后调 display_term_title 一致）
+			a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, ""))
+
+			if interrupted.Load() {
+				a.EmitDisplay(Event{Type: EventStop, Fields: []string{"STOP", "interrupted"}})
+				a.emitJSON(map[string]interface{}{"type": "stop", "reason": "interrupted"})
+				break
+			}
+
+			// 致命停止原因
+			switch stopReason {
+			case "error", "max_tokens", "length":
+				if stopReason != "error" {
+					a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", "Response truncated (max_tokens reached)"}})
+				}
+				if loopErr != "" {
+					phaseFatalErr = fmt.Errorf("LLM error: %s", loopErr)
+				} else {
+					phaseFatalErr = fmt.Errorf("stopped: %s", stopReason)
+				}
+				break TurnLoop
+			}
+
+			// 保存 assistant 消息
+			_ = a.store.AddAssistantMessage(text, thinking, toolCalls)
+			if len(toolResults) > 0 {
+				_ = a.store.AddToolResults(toolResults)
+			}
+
+			// tool_use → 继续循环
+			if stopReason == "tool_use" || stopReason == "tool_calls" {
+				continue
+			}
+
+			// end_turn 后先消费已到达的 notify/user inject；有内容则继续下一轮（共享 turn 预算）
+			if a.drainSubAgentResults(ctx) {
+				continue
+			}
+
+			// end_turn，无 drained 结果 → 退出 turn loop
+			break
+		}
+
 		if interrupted.Load() {
-			a.EmitDisplay(Event{Type: EventStop, Fields: []string{"STOP", "interrupted"}})
-			a.emitJSON(map[string]interface{}{"type": "stop", "reason": "interrupted"})
 			a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, "idle"))
 			return nil
 		}
 
-		// 致命停止原因
-		switch stopReason {
-		case "error", "max_tokens", "length":
-			if stopReason != "error" {
-				a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", "Response truncated (max_tokens reached)"}})
-			}
-			a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, "idle"))
-			// error 退出后仍需消费 pending SubAgent 结果（对齐 C/Rust main_loop 的 active_sub_count 等待）
-			a.subMu.Lock()
-			hasPending := a.pendingTasks > 0
-			a.subMu.Unlock()
-			if hasPending {
-				select {
-				case r := <-a.subResultCh:
-					a.handleSubAgentResult(r)
-					continue
-				case <-ctx.Done():
-					return ctx.Err()
-				}
-			}
-			if loopErr != "" {
-				return fmt.Errorf("LLM error: %s", loopErr)
-			}
-			return fmt.Errorf("stopped: %s", stopReason)
-		}
-
-		// 保存 assistant 消息
-		_ = a.store.AddAssistantMessage(text, thinking, toolCalls)
-		if len(toolResults) > 0 {
-			_ = a.store.AddToolResults(toolResults)
-		}
-
-		// tool_use → 继续循环
-		if stopReason == "tool_use" || stopReason == "tool_calls" {
-			continue
-		}
-
-		// end_turn 后先消费已到达的 notify/user inject；有内容则继续下一轮
-		if a.drainSubAgentResults(ctx) {
-			continue
-		}
-
-		// end_turn 但有等待中的子 agent → 等待结果并继续
+		// === Post-phase：检查是否有等待中的子 agent 结果 ===
 		a.subMu.Lock()
 		hasPending := a.pendingTasks > 0
 		a.subMu.Unlock()
+
 		if hasPending {
 			select {
 			case r := <-a.subResultCh:
-				a.handleSubAgentResult(r)
-				continue
+				// 处理结果（events + stats + display），获取 context 和 turnKind
+				context, tk := a.handleSubAgentResult(r)
+				// 下一轮 phase：context 作为 userInput，由 phase setup 写入 conversation
+				userInput = context
+				turnKind = tk
+				continue // 外层循环 → 新的 turn 预算
 			case <-ctx.Done():
+				a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, "idle"))
 				return ctx.Err()
 			}
 		}
 
-		// 其他 stop reason → 退出
+		// 无 pending 子 agent → 退出
+		if phaseFatalErr != nil {
+			a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, "idle"))
+			return phaseFatalErr
+		}
 		break
 	}
 
@@ -1031,7 +1060,10 @@ func (a *Agent) drainSubAgentResults(ctx context.Context) bool {
 	for {
 		select {
 		case r := <-a.subResultCh:
-			a.handleSubAgentResult(r)
+			context, _ := a.handleSubAgentResult(r)
+			if context != "" {
+				_ = a.store.AddUserMessage(context)
+			}
 			drained = true
 		case <-ctx.Done():
 			return drained
@@ -1141,18 +1173,11 @@ func (a *Agent) runSubAgent(ctx context.Context, sessionID, prompt, fork string)
 		}
 	}()
 
-	homeDir := os.Getenv("BASH_AGENT_HOME")
-	if homeDir == "" {
-		homeDir = os.Getenv("HOME")
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		result.Text = err.Error()
-		return result
-	}
+	homeDir := a.store.GetHomeDir()
+	cwd := a.store.GetCwd()
 
 	childCfg := a.cfg
-	childCfg.MaxTurns = 10
+	childCfg.MaxTurns = a.cfg.MaxTurns
 	// 子 agent 必须静默：不输出 stream-json，不写终端正文，不抢 title。
 	childCfg.OutputFormat = "human"
 	childCfg.Interactive = false
@@ -1198,16 +1223,16 @@ func (a *Agent) runSubAgent(ctx context.Context, sessionID, prompt, fork string)
 }
 
 // handleSubAgentResult 处理子 agent 结果
-func (a *Agent) handleSubAgentResult(r SubAgentResult) {
+// 返回 (context, turnKind)：context 为注入 conversation 的文本，turnKind 为下一轮 RunLoop 的类型
+// 不写入 conversation — 由调用方（drainSubAgentResults 或 RunLoop 外层循环）负责写入
+func (a *Agent) handleSubAgentResult(r SubAgentResult) (string, string) {
 	// user_notify 分支（Ctrl+O 中间介入）
 	if r.Kind == "user_notify" {
-		a.handleUserNotify(r.Text)
-		return
+		return a.handleUserNotify(r.Text), "user_notify"
 	}
 	// async_task 分支
 	if r.Kind == "async_task" {
-		a.handleAsyncTaskResult(r)
-		return
+		return a.handleAsyncTaskResult(r), "async_task_result"
 	}
 	// 记录 usage 事件（带 kind=sub_agent, sub_session_id）
 	usageEvent := map[string]interface{}{
@@ -1268,13 +1293,11 @@ func (a *Agent) handleSubAgentResult(r SubAgentResult) {
 	injectMsg := fmt.Sprintf("[sub-agent %s] %s (in=%d, out=%d)\nThinking: %s\nText: %s",
 		r.SessionID, r.Status, r.InputTokens, r.OutputTokens, r.Thinking, r.Text)
 
-	// 注入为用户消息（不记录 user_input 事件，与 bash 版 agent_loop turn_kind=sub_agent_result 一致）
-	_ = a.store.AddUserMessage(injectMsg)
-
+	return injectMsg, "sub_agent_result"
 }
 
-// handleAsyncTaskResult 处理异步 bash 任务结果
-func (a *Agent) handleAsyncTaskResult(r SubAgentResult) {
+// handleAsyncTaskResult 处理异步 bash 任务结果，返回注入 conversation 的文本
+func (a *Agent) handleAsyncTaskResult(r SubAgentResult) string {
 	// 1. 记录 async_task_result 事件
 	a.emitJSON(map[string]interface{}{
 		"type":      "async_task_result",
@@ -1303,14 +1326,14 @@ func (a *Agent) handleAsyncTaskResult(r SubAgentResult) {
 		},
 	})
 
-	// 5. 注入 conversation
+	// 5. 构造注入消息
 	injectMsg := fmt.Sprintf("[bg-bash %s] exit_code=%d\nOutput: %s",
 		r.TaskID, r.ExitCode, r.Output)
-	_ = a.store.AddUserMessage(injectMsg)
+	return injectMsg
 }
 
-// handleUserNotify 处理用户 Ctrl+O 中间介入的输入
-func (a *Agent) handleUserNotify(text string) {
+// handleUserNotify 处理用户 Ctrl+O 中间介入的输入，返回注入 conversation 的文本
+func (a *Agent) handleUserNotify(text string) string {
 	// 显示（统一走 Display 接口）
 	a.EmitDisplay(Event{
 		Type:   EventUserNotify,
@@ -1318,7 +1341,7 @@ func (a *Agent) handleUserNotify(text string) {
 	})
 
 	// Ctrl+O 是用户自然输入；conversation 中保存原文，显示层才加 [user inject]
-	_ = a.store.AddUserMessage(text)
+	return text
 }
 
 // EnqueueUserNotify 将用户 Ctrl+O 输入写入 notify/sub_result 通道。

--- a/go/agent.go
+++ b/go/agent.go
@@ -832,16 +832,8 @@ func (a *Agent) RunLoop(ctx context.Context, initialUserInput, initialTurnKind s
 			// 获取 messages
 			messages, err := a.store.GetMessages()
 			if err != nil {
-				cancel()
-				close(sigDone)
-				signal.Stop(sigCh)
-				a.runMu.Lock()
-				if a.currentInterrupt == &interrupted {
-					a.currentInterrupt = nil
-					a.currentCancel = nil
-				}
-				a.runMu.Unlock()
-				return fmt.Errorf("get messages: %w", err)
+				phaseFatalErr = fmt.Errorf("get messages: %w", err)
+				break TurnLoop
 			}
 			systemPrompt := a.BuildPrompt()
 
@@ -849,7 +841,8 @@ func (a *Agent) RunLoop(ctx context.Context, initialUserInput, initialTurnKind s
 			ch, err := a.llm.Call(ctx, messages, systemPrompt, a.toolDefs, a.cfg.MaxTokens, a.cfg.Thinking)
 			if err != nil {
 				a.EmitDisplay(Event{Type: EventError, Fields: []string{"ERROR", err.Error()}})
-				break
+				phaseFatalErr = err
+				break TurnLoop
 			}
 
 			var text, thinking string

--- a/go/store.go
+++ b/go/store.go
@@ -132,6 +132,9 @@ func NewFileStore(home, cwd string) *FileStore {
 	return &FileStore{home: home, cwd: cwd}
 }
 
+func (s *FileStore) GetHomeDir() string { return s.home }
+func (s *FileStore) GetCwd() string     { return s.cwd }
+
 // ─── Session lifecycle ───
 
 func (s *FileStore) Init(sessionID string) error {

--- a/go/types.go
+++ b/go/types.go
@@ -136,16 +136,16 @@ type ToolResultInfo struct {
 
 // Stats 会话统计数据
 type Stats struct {
-	TurnCount        int     `json:"current_turn_count"`          // user turn count
-	TotalRequests    int     `json:"agent_request_count"`         // total LLM requests
-	TotalCompact     int     `json:"compact_request_count"`       // number of compactions
-	SubAgentRequests int     `json:"sub_agent_request_count"`     // sub-agent requests
-	InputTokens      int     `json:"total_input_tokens"`          // cumulative input
-	OutputTokens     int     `json:"total_output_tokens"`         // cumulative output
-	CacheRead        int     `json:"total_cache_read_tokens"`     // cumulative cache read
-	CacheWrite       int     `json:"total_cache_creation_tokens"` // cumulative cache write
-	ContextTokens    int     `json:"current_context_tokens"`      // current context size
-	LastUpdated      string  `json:"last_updated"`                // ISO 8601 timestamp
+	TurnCount        int    `json:"current_turn_count"`          // user turn count
+	TotalRequests    int    `json:"agent_request_count"`         // total LLM requests
+	TotalCompact     int    `json:"compact_request_count"`       // number of compactions
+	SubAgentRequests int    `json:"sub_agent_request_count"`     // sub-agent requests
+	InputTokens      int    `json:"total_input_tokens"`          // cumulative input
+	OutputTokens     int    `json:"total_output_tokens"`         // cumulative output
+	CacheRead        int    `json:"total_cache_read_tokens"`     // cumulative cache read
+	CacheWrite       int    `json:"total_cache_creation_tokens"` // cumulative cache write
+	ContextTokens    int    `json:"current_context_tokens"`      // current context size
+	LastUpdated      string `json:"last_updated"`                // ISO 8601 timestamp
 }
 
 // SessionRow session 列表行
@@ -163,6 +163,8 @@ type SessionStore interface {
 	Init(sessionID string) error
 	Fork(parentDir, childDir string) error
 	GetDir() string
+	GetHomeDir() string
+	GetCwd() string
 	ImageDir() string
 	GetLatestDir() (string, error)
 	ResolveContinue() (string, error)

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -818,8 +818,8 @@ impl Agent {
                 sub_result_tx: Arc::new(sub_rtx),
                 active_task_count: 0,
                 sub_agent_request_count: 0,
-                stdout: RefCell::new(Box::new(io::empty())),  // 子 agent 输出全部丢弃（与 Go 的 io.Discard、Bash 的 >/dev/null 对应）
-                stderr: RefCell::new(Box::new(io::empty())),  // 子 agent 错误输出全部丢弃
+                stdout: RefCell::new(Box::new(io::sink())),  // 子 agent 输出全部丢弃（与 Go 的 io.Discard、Bash 的 >/dev/null 对应）
+                stderr: RefCell::new(Box::new(io::sink())),  // 子 agent 错误输出全部丢弃
                 display_tx: None,
                 display_handle: None,
                 cancel_read_fd: -1,


### PR DESCRIPTION
## 背景

C/Go/Rust 三个高级 runtime 在 SubAgent 和 `Bash(background=true)` 的进程隔离、结果处理、配置继承上存在多处不一致。本次以 Bash 版为基准，全面对齐三版本行为。

## 改动内容

### 1. Bash 工具进程隔离（`bc4f0aa`）

**C 同步 Bash**（`c/tools.c`）：
- 子进程 `stdin` 重定向到 `/dev/null`，不再继承主终端（修复 readline 抢输入导致卡住）
- 子进程设置独立进程组（`setpgid`）
- timeout 时 kill 整个进程组（`kill(-pid, SIGKILL)`）
- `waitpid` 处理 `EINTR`

**C 后台 Bash**（`c/agent.c`）：
- 移除 `system("bash -lc '%s' ...")`，改为 `fork/exec`，命令通过 argv 传递，消除 shell quoting 风险
- 子进程 `stdin` 接 `/dev/null`，设置独立进程组
- 输出增加 UTF-8 sanitize
- `pthread_create` 失败时正确回滚计数器和释放资源

**Go**（`go/tools.go`、`go/agent.go`）：
- 同步和后台 Bash 显式 `Stdin = nil`
- 后台 Bash 设置 `Setpgid: true`

**Rust**（`rust/src/tools.rs`、`rust/src/agent.rs`）：
- 同步和后台 Bash 设置 `stdin(Stdio::null())`
- 设置 `process_group(0)`
- cancel/timeout 改用 `libc::kill(-pid, SIGKILL)` 替代 spawn `kill` 命令

### 2. SubAgent 配置继承与结果处理一致性（`5141a54`、`4f35fef`）

**子 agent `max_turns`**：
- C/Go 此前硬编码为 10，修正为继承父 agent 的 `max_turns`（对齐 Bash 版子 shell 继承环境变量）

**子 agent 结果处理模型**：
- Go 此前用平铺 `for` 循环 `continue` 处理子 agent 结果（共享 turn 预算），重构为外层 `for {}` + 内层 `TurnLoop`，每个 phase 获得独立 `max_turns` 预算（对齐 Bash/C/Rust 的嵌套调用模型）

**`handleSubAgentResult` 重构**：
- 不再直接写 conversation，改为返回 `(context, turnKind)` 由调用方写入
- `drainSubAgentResults`（turn loop 内消费，共享预算）和 RunLoop 外层循环（post-end_turn，独立预算）分别处理

**Go `runSubAgent`**：
- 从 `os.Executable()` + `exec.Command` 改为 goroutine 内创建独立 child agent
- home/cwd 从父 agent store 继承，不再用 `os.Getenv`
- 增加 panic recover

**Rust**：
- 子 agent `stdout/stderr` 从 `io::empty()` 修正为 `io::sink()`

**C SubAgent 输出隔离**：
- 为 `Agent` 增加 `out`/`err` 专属句柄，子 agent 指向 `/dev/null`
- verbose、compact 错误、title 状态写 agent 专属 `err`
- `pthread_create` 失败正确回滚

## 验证

- C e2e：`182 passed, 0 failed`
- Go e2e：`182 passed, 0 failed`
- Rust e2e：`182 passed, 0 failed`
- `git diff --check` 通过
- 未修改 system prompt / tools.json
- 未修改 Bash 版

## 提交

- `bc4f0aa` fix background bash process isolation
- `5141a54` fix subagent consistency: inherit max_turns, nested result handling, io::sink
- `4f35fef` fix go RunLoop: fatal error paths use phaseFatalErr instead of direct return