### PR TITLE
fix: 修复 C/Go/Rust 跨运行时架构一致性（缓存顺序、HTTP 重试、tool_read 行号等 6 项）

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -773,14 +773,17 @@ static int agent_drain_sub_results(Agent *agent) {
 int agent_wait_for_sub_agents(Agent *agent) {
     while (agent->active_task_count > 0) {
         void *sub_data = NULL;
-        if (mq_pop(agent->sub_result_queue, &sub_data) != 0) return -1;
+        /* mq_pop 失败表示队列已关闭/空 → break 而非 return -1
+         * processed==0 表示收到无法处理的消息 → continue 而非 return -1
+         * 避免因非任务消息（如 user_notify）或队列边界条件提前退出 */
+        if (mq_pop(agent->sub_result_queue, &sub_data) != 0) break;
         InputMessage *sub_msg = (InputMessage *)sub_data;
         int processed = agent_process_sub_result(agent, sub_msg, 1);
         input_message_free(sub_msg);
         free(sub_msg);
-        if (!processed) return -1;
+        if (!processed) continue;
     }
-    return 0;
+    return agent->active_task_count > 0 ? -1 : 0;
 }
 
 int agent_run_loop(Agent *agent, const char *user_input, const char *turn_kind) {
@@ -1302,6 +1305,8 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                     break;
                 } else if (strcmp(accum->tools[i].name, "PlanClear") == 0) {
                     agent_compact_context(agent, "plan_clear");
+                    /* compact 后执行清空（对齐 bash 版 tool_plan_clear 顺序） */
+                    store_plan_clear(&agent->paths);
                     break;
                 }
             }

--- a/c/tools.c
+++ b/c/tools.c
@@ -95,7 +95,7 @@ static ToolResult tool_read(const char *input_json, int max_bytes) {
         return r;
     }
 
-    /* 按行分割，添加行号 */
+    /* 按行分割（不加行号 — 对齐 Bash sed -n / Rust 原始文本输出） */
     StrBuf buf;
     sb_init(&buf);
     int line_num = 1;
@@ -107,7 +107,7 @@ static ToolResult tool_read(const char *input_json, int max_bytes) {
         if (line_num >= start_line && line_num <= end_line) {
             const char *eol = strchr(p, '\n');
             if (!eol) eol = p + strlen(p);
-            sb_appendf(&buf, "%6d  %.*s\n", line_num, (int)(eol - p), p);
+            sb_appendf(&buf, "%.*s\n", (int)(eol - p), p);
         }
         /* 跳到下一行 */
         const char *eol = strchr(p, '\n');
@@ -829,10 +829,10 @@ static ToolResult tool_plan_confirm(const SessionPaths *paths) {
 }
 
 static ToolResult tool_plan_clear(const SessionPaths *paths) {
+    (void)paths;
+    /* 不在这里清空 plan.md — 由 agent_loop 在 compact 之后执行
+     * 对齐 bash 版: agent_compact_context(plan_clear) → store_plan_clear */
     ToolResult r = {NULL, 0};
-    if (paths) {
-        store_plan_clear(paths);
-    }
     r.output = util_strdup("Plan cleared.");
     return r;
 }

--- a/c/transport.c
+++ b/c/transport.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <time.h>
+#include <unistd.h>
 #include <curl/curl.h>
 
 /* ============================================================
@@ -311,182 +313,242 @@ static void fill_openai_usage_event(SseEvent *evt, JsonVal usage) {
     }
 }
 
+/* 处理非 SSE 响应：如果 line_buf 中有残留 JSON，作为完整响应解析 */
+static void process_residual_json(StreamCtx *sctx, const char *provider,
+                                  sse_callback_fn callback, void *ctx) {
+    if (!sctx->line_buf.data || sctx->line_buf.len == 0) return;
+    char *residual = sctx->line_buf.data;
+    while (*residual == ' ' || *residual == '\t' || *residual == '\r' || *residual == '\n') residual++;
+    if (*residual != '{') return;
+
+    size_t pos = 0;
+    JsonParse jp = json_parse(residual, &pos);
+    if (jp.error) return;
+
+    char *err_msg = json_get_string(jp.val, "error");
+    if (err_msg) {
+        emit_simple_event(callback, ctx, SSE_ERROR, err_msg);
+        free(err_msg);
+    } else if (strcmp(provider, "claude") == 0) {
+        JsonVal content = json_get(jp.val, "content");
+        if (content.type == JSON_ARRAY) {
+            int clen = json_array_len(content);
+            for (int i = 0; i < clen; i++) {
+                JsonVal block = json_array_get(content, i);
+                char *btype = json_get_string(block, "type");
+                if (btype && strcmp(btype, "text") == 0) {
+                    char *txt = json_get_string(block, "text");
+                    if (txt) { emit_simple_event(callback, ctx, SSE_TEXT, txt); free(txt); }
+                } else if (btype && strcmp(btype, "thinking") == 0) {
+                    char *txt = json_get_string(block, "thinking");
+                    if (txt) { emit_simple_event(callback, ctx, SSE_THINKING, txt); free(txt); }
+                } else if (btype && strcmp(btype, "tool_use") == 0) {
+                    char *id = json_get_string(block, "id");
+                    char *name = json_get_string(block, "name");
+                    SseEvent evt;
+                    memset(&evt, 0, sizeof(evt));
+                    evt.type = SSE_TOOL_CALL;
+                    evt.tool_id = id;
+                    evt.tool_name = name;
+                    evt.tool_input = "{}";
+                    callback(ctx, &evt);
+                    free(id); free(name);
+                }
+                free(btype);
+            }
+        }
+        char *stop_reason = json_get_string(jp.val, "stop_reason");
+        if (stop_reason) {
+            emit_simple_event(callback, ctx, SSE_STOP, stop_reason);
+            free(stop_reason);
+        }
+        JsonVal usage = json_get(jp.val, "usage");
+        if (usage.type != JSON_NULL) {
+            SseEvent evt;
+            memset(&evt, 0, sizeof(evt));
+            evt.type = SSE_USAGE;
+            evt.in_tokens = json_get_int(usage, "input_tokens");
+            evt.out_tokens = json_get_int(usage, "output_tokens");
+            evt.cache_read_tokens = json_get_int(usage, "cache_read_input_tokens");
+            evt.cache_creation_tokens = json_get_int(usage, "cache_creation_input_tokens");
+            callback(ctx, &evt);
+        }
+    } else {
+        JsonVal choices = json_get(jp.val, "choices");
+        if (choices.type == JSON_ARRAY) {
+            JsonVal choice = json_array_get(choices, 0);
+            JsonVal msg = json_get(choice, "message");
+            char *content = json_get_string(msg, "content");
+            if (content) {
+                emit_simple_event(callback, ctx, SSE_TEXT, content);
+                free(content);
+            }
+            char *reasoning = json_get_string(msg, "reasoning_content");
+            if (!reasoning) reasoning = json_get_string(msg, "reasoning");
+            if (reasoning) {
+                emit_simple_event(callback, ctx, SSE_THINKING, reasoning);
+                free(reasoning);
+            }
+            JsonVal tool_calls = json_get(msg, "tool_calls");
+            if (tool_calls.type == JSON_ARRAY) {
+                int tc_len = json_array_len(tool_calls);
+                for (int i = 0; i < tc_len; i++) {
+                    JsonVal tc = json_array_get(tool_calls, i);
+                    JsonVal fn = json_get(tc, "function");
+                    char *id = json_get_string(tc, "id");
+                    char *name = json_get_string(fn, "name");
+                    char *arguments = json_get_string(fn, "arguments");
+                    SseEvent evt;
+                    memset(&evt, 0, sizeof(evt));
+                    evt.type = SSE_TOOL_CALL;
+                    evt.tool_id = id;
+                    evt.tool_name = name;
+                    evt.tool_input = arguments ? arguments : (char *)"{}";
+                    callback(ctx, &evt);
+                    free(id);
+                    free(name);
+                    free(arguments);
+                }
+            }
+            char *finish = json_get_string(choice, "finish_reason");
+            if (finish) {
+                if (strcmp(finish, "tool_calls") == 0) emit_simple_event(callback, ctx, SSE_STOP, "tool_use");
+                else if (strcmp(finish, "stop") == 0) emit_simple_event(callback, ctx, SSE_STOP, "end_turn");
+                else emit_simple_event(callback, ctx, SSE_STOP, finish);
+                free(finish);
+            }
+        }
+        JsonVal usage = json_get(jp.val, "usage");
+        if (usage.type != JSON_NULL) {
+            SseEvent evt;
+            memset(&evt, 0, sizeof(evt));
+            evt.type = SSE_USAGE;
+            fill_openai_usage_event(&evt, usage);
+            callback(ctx, &evt);
+        }
+    }
+}
+
 int http_post_sse(const char *url, const char **headers, int header_count,
                   const char *body, size_t body_len,
                   const char *provider,
                   sse_callback_fn callback, void *ctx,
                   volatile int *cancelled) {
-    CURL *curl = curl_easy_init();
-    if (!curl) return -1;
+    /* 对齐 Bash curl --retry 2 --retry-delay 1 --retry-max-time 20
+     * 和 Rust StreamClient: 最多重试 2 次，延迟 1s，总窗口 20s */
+    const int max_retries = 2;
+    const long retry_max_time_ms = 20000;
+
+    struct timespec start_ts;
+    clock_gettime(CLOCK_MONOTONIC, &start_ts);
 
     struct curl_slist *hdrs = NULL;
     for (int i = 0; i < header_count; i++) {
         hdrs = curl_slist_append(hdrs, headers[i]);
     }
 
-    curl_easy_setopt(curl, CURLOPT_URL, url);
-    curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)body_len);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
-    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-
-    StreamCtx sctx;
-    sctx.callback = callback;
-    sctx.ctx = ctx;
-    sb_init(&sctx.line_buf);
-    sctx.cancelled = cancelled;
-    sctx.provider = (char *)provider;
-    sctx.openai_tools = NULL;
-    sctx.openai_tool_count = 0;
-    sctx.openai_tool_cap = 0;
-
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_cb);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &sctx);
-
-    CURLcode rc = curl_easy_perform(curl);
-
+    CURLcode rc = CURLE_OK;
     long http_code = 0;
-    if (rc == CURLE_OK) {
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    }
 
-    /* 处理非 SSE 响应：如果 line_buf 中有残留 JSON，作为完整响应解析 */
-    if (rc == CURLE_OK && sctx.line_buf.data && sctx.line_buf.len > 0) {
-        char *residual = sctx.line_buf.data;
-        /* 去掉前导空白 */
-        while (*residual == ' ' || *residual == '\t' || *residual == '\r' || *residual == '\n') residual++;
-        if (*residual == '{') {
-            /* 非 SSE 的完整 JSON 响应 — 按格式解析 */
-            size_t pos = 0;
-            JsonParse jp = json_parse(residual, &pos);
-            if (!jp.error) {
-                char *err_msg = json_get_string(jp.val, "error");
-                if (err_msg) {
-                    emit_simple_event(callback, ctx, SSE_ERROR, err_msg);
-                    free(err_msg);
-                } else if (strcmp(provider, "claude") == 0) {
-                    /* Claude 非流式响应 */
-                    JsonVal content = json_get(jp.val, "content");
-                    if (content.type == JSON_ARRAY) {
-                        int clen = json_array_len(content);
-                        for (int i = 0; i < clen; i++) {
-                            JsonVal block = json_array_get(content, i);
-                            char *btype = json_get_string(block, "type");
-                            if (btype && strcmp(btype, "text") == 0) {
-                                char *txt = json_get_string(block, "text");
-                                if (txt) { emit_simple_event(callback, ctx, SSE_TEXT, txt); free(txt); }
-                            } else if (btype && strcmp(btype, "thinking") == 0) {
-                                char *txt = json_get_string(block, "thinking");
-                                if (txt) { emit_simple_event(callback, ctx, SSE_THINKING, txt); free(txt); }
-                            } else if (btype && strcmp(btype, "tool_use") == 0) {
-                                char *id = json_get_string(block, "id");
-                                char *name = json_get_string(block, "name");
-                                SseEvent evt;
-                                memset(&evt, 0, sizeof(evt));
-                                evt.type = SSE_TOOL_CALL;
-                                evt.tool_id = id;
-                                evt.tool_name = name;
-                                evt.tool_input = "{}"; /* 非 SSE 模式简化处理 */
-                                callback(ctx, &evt);
-                                free(id); free(name);
-                            }
-                            free(btype);
-                        }
-                    }
-                    /* stop_reason */
-                    char *stop_reason = json_get_string(jp.val, "stop_reason");
-                    if (stop_reason) {
-                        emit_simple_event(callback, ctx, SSE_STOP, stop_reason);
-                        free(stop_reason);
-                    }
-                    /* usage */
-                    JsonVal usage = json_get(jp.val, "usage");
-                    if (usage.type != JSON_NULL) {
-                        SseEvent evt;
-                        memset(&evt, 0, sizeof(evt));
-                        evt.type = SSE_USAGE;
-                        evt.in_tokens = json_get_int(usage, "input_tokens");
-                        evt.out_tokens = json_get_int(usage, "output_tokens");
-                        evt.cache_read_tokens = json_get_int(usage, "cache_read_input_tokens");
-                        evt.cache_creation_tokens = json_get_int(usage, "cache_creation_input_tokens");
-                        callback(ctx, &evt);
-                    }
-                } else {
-                    /* OpenAI 非流式响应 */
-                    JsonVal choices = json_get(jp.val, "choices");
-                    if (choices.type == JSON_ARRAY) {
-                        JsonVal choice = json_array_get(choices, 0);
-                        JsonVal msg = json_get(choice, "message");
-                        char *content = json_get_string(msg, "content");
-                        if (content) {
-                            emit_simple_event(callback, ctx, SSE_TEXT, content);
-                            free(content);
-                        }
-                        char *reasoning = json_get_string(msg, "reasoning_content");
-                        if (!reasoning) reasoning = json_get_string(msg, "reasoning");
-                        if (reasoning) {
-                            emit_simple_event(callback, ctx, SSE_THINKING, reasoning);
-                            free(reasoning);
-                        }
-                        JsonVal tool_calls = json_get(msg, "tool_calls");
-                        if (tool_calls.type == JSON_ARRAY) {
-                            int tc_len = json_array_len(tool_calls);
-                            for (int i = 0; i < tc_len; i++) {
-                                JsonVal tc = json_array_get(tool_calls, i);
-                                JsonVal fn = json_get(tc, "function");
-                                char *id = json_get_string(tc, "id");
-                                char *name = json_get_string(fn, "name");
-                                char *arguments = json_get_string(fn, "arguments");
-                                SseEvent evt;
-                                memset(&evt, 0, sizeof(evt));
-                                evt.type = SSE_TOOL_CALL;
-                                evt.tool_id = id;
-                                evt.tool_name = name;
-                                evt.tool_input = arguments ? arguments : (char *)"{}";
-                                callback(ctx, &evt);
-                                free(id);
-                                free(name);
-                                free(arguments);
-                            }
-                        }
-                        char *finish = json_get_string(choice, "finish_reason");
-                        if (finish) {
-                            if (strcmp(finish, "tool_calls") == 0) emit_simple_event(callback, ctx, SSE_STOP, "tool_use");
-                            else if (strcmp(finish, "stop") == 0) emit_simple_event(callback, ctx, SSE_STOP, "end_turn");
-                            else emit_simple_event(callback, ctx, SSE_STOP, finish);
-                            free(finish);
-                        }
-                    }
-                    JsonVal usage = json_get(jp.val, "usage");
-                    if (usage.type != JSON_NULL) {
-                        SseEvent evt;
-                        memset(&evt, 0, sizeof(evt));
-                        evt.type = SSE_USAGE;
-                        fill_openai_usage_event(&evt, usage);
-                        callback(ctx, &evt);
-                    }
-                }
-            }
+    for (int attempt = 0; attempt <= max_retries; attempt++) {
+        CURL *curl = curl_easy_init();
+        if (!curl) { curl_slist_free_all(hdrs); return -1; }
+
+        StreamCtx sctx;
+        sctx.callback = callback;
+        sctx.ctx = ctx;
+        sb_init(&sctx.line_buf);
+        sctx.cancelled = cancelled;
+        sctx.provider = (char *)provider;
+        sctx.openai_tools = NULL;
+        sctx.openai_tool_count = 0;
+        sctx.openai_tool_cap = 0;
+
+        curl_easy_setopt(curl, CURLOPT_URL, url);
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)body_len);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
+        curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_cb);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &sctx);
+
+        rc = curl_easy_perform(curl);
+
+        http_code = 0;
+        if (rc == CURLE_OK) {
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
         }
+
+        /* 判断是否需要重试 */
+        int should_retry = 0;
+        if (rc != CURLE_OK) {
+            if (!(rc == CURLE_WRITE_ERROR && cancelled && *cancelled))
+                should_retry = 1;
+        } else if (http_code >= 500) {
+            should_retry = 1;
+        }
+
+        if (!should_retry) {
+            /* 成功或不可重试错误 → 处理残留 JSON */
+            if (rc == CURLE_OK) {
+                process_residual_json(&sctx, provider, callback, ctx);
+            }
+            sb_free(&sctx.line_buf);
+            streamctx_free_openai_tools(&sctx);
+            curl_easy_cleanup(curl);
+            curl_slist_free_all(hdrs);
+
+            if (rc == CURLE_WRITE_ERROR && cancelled && *cancelled) {
+                emit_simple_event(callback, ctx, SSE_STOP, "interrupted");
+                return 0;
+            }
+            if (rc != CURLE_OK) return -1;
+            if (http_code >= 400) return (int)http_code;
+            return 0;
+        }
+
+        /* 需要重试 → 清理本次尝试的状态 */
+        sb_free(&sctx.line_buf);
+        streamctx_free_openai_tools(&sctx);
+        curl_easy_cleanup(curl);
+
+        /* cancelled 不重试 */
+        if (rc == CURLE_WRITE_ERROR && cancelled && *cancelled) {
+            emit_simple_event(callback, ctx, SSE_STOP, "interrupted");
+            curl_slist_free_all(hdrs);
+            return 0;
+        }
+
+        /* 检查重试限制 */
+        struct timespec now_ts;
+        clock_gettime(CLOCK_MONOTONIC, &now_ts);
+        long elapsed_ms = (now_ts.tv_sec - start_ts.tv_sec) * 1000L +
+                          (now_ts.tv_nsec - start_ts.tv_nsec) / 1000000L;
+        if (attempt >= max_retries || elapsed_ms >= retry_max_time_ms) {
+            /* 重试耗尽 */
+            curl_slist_free_all(hdrs);
+            if (rc != CURLE_OK) return -1;
+            if (http_code >= 400) return (int)http_code;
+            return 0;
+        }
+
+        /* 发送 SSE_RETRY 重置累积器（对齐 bash awk RETRY 事件） */
+        {
+            SseEvent retry_evt;
+            memset(&retry_evt, 0, sizeof(retry_evt));
+            retry_evt.type = SSE_RETRY;
+            callback(ctx, &retry_evt);
+        }
+
+        sleep(1);
     }
 
-    sb_free(&sctx.line_buf);
-    streamctx_free_openai_tools(&sctx);
+    /* 不应到达 */
     curl_slist_free_all(hdrs);
-    curl_easy_cleanup(curl);
-
-    /* 如果是被 cancelled 中断的，发送 STOP interrupted 让 agent_loop 正常结束 */
-    if (rc == CURLE_WRITE_ERROR && cancelled && *cancelled) {
-        emit_simple_event(callback, ctx, SSE_STOP, "interrupted");
-        return 0;  /* 不是错误——是被中断的正常退出 */
-    }
-
-    if (rc != CURLE_OK) return -1;
-    if (http_code >= 400) return (int)http_code;  /* HTTP 错误码作为负返回值的替代 */
-    return 0;
+    return -1;
 }
 
 /* ============================================================

--- a/go/agent.go
+++ b/go/agent.go
@@ -626,7 +626,9 @@ func (a *Agent) CompactContext(ctx context.Context, trigger string) (bool, error
 		if trigger != "plan_clear" && trigger != "plan_confirm" {
 			return false, nil
 		}
-		if keepLines >= totalLines {
+		/* plan_clear/plan_confirm 绕过守卫继续执行（对齐 Bash/C/Rust）
+		 * 仅在 keepLines <= 0 时放弃 */
+		if keepLines <= 0 {
 			return false, nil
 		}
 	}

--- a/go/tools.go
+++ b/go/tools.go
@@ -235,10 +235,11 @@ func (td *ToolDispatcher) toolRead(p, offsetStr, limitStr string) (string, error
 		end = start + limit
 	}
 
-	// 带行号输出
+	// 不加行号 — 对齐 Bash sed -n / Rust 原始文本输出
 	var buf strings.Builder
 	for i := start; i < end; i++ {
-		buf.WriteString(fmt.Sprintf("%6d\t%s\n", i+1, lines[i]))
+		buf.WriteString(lines[i])
+		buf.WriteByte('\n')
 	}
 	return buf.String(), nil
 }

--- a/go/transport.go
+++ b/go/transport.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 )
 
 // ═══════════════════════════════════════════
@@ -45,17 +46,50 @@ func (t *HTTPTransport) Call(ctx context.Context, messages, systemPrompt, toolDe
 		fmt.Fprintf(osStderr, "[verbose] Request body (%dKB): %s\n", len(body)/1024, preview)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", t.buildURL(), bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header = t.buildHeaders()
+	// 对齐 Bash curl --retry 2 --retry-delay 1 --retry-max-time 20
+	// 和 Rust StreamClient: 最多重试 2 次，延迟 1s，总窗口 20s
+	const maxRetries = 2
+	const retryDelay = 1 * time.Second
+	const retryMaxTime = 20 * time.Second
 
-	resp, err := t.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http request: %w", err)
+	start := time.Now()
+	var resp *http.Response
+	var httpErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, "POST", t.buildURL(), bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header = t.buildHeaders()
+
+		resp, httpErr = t.client.Do(req)
+		if httpErr == nil && resp.StatusCode < 500 {
+			break // 成功（2xx）或客户端错误（4xx）
+		}
+
+		// 传输错误或 5xx → 可重试
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if attempt < maxRetries && time.Since(start) < retryMaxTime {
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		// 重试耗尽
+		if httpErr != nil {
+			return nil, fmt.Errorf("http request: %w", httpErr)
+		}
+		// 5xx 重试耗尽 → 返回错误事件
+		ch := make(chan Event, 2)
+		ch <- Event{Type: EventError, Fields: []string{"ERROR", fmt.Sprintf("HTTP %d (server error, retries exhausted)", resp.StatusCode)}}
+		ch <- Event{Type: EventStop, Fields: []string{"STOP", "error"}}
+		close(ch)
+		return ch, nil
 	}
 
+	// 4xx 错误处理（不重试）
 	if resp.StatusCode >= 400 {
 		respBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
@@ -66,7 +100,7 @@ func (t *HTTPTransport) Call(ctx context.Context, messages, systemPrompt, toolDe
 		return ch, nil
 	}
 
-	// 启动 SSE 解析 goroutine
+	// 成功 → 启动 SSE 解析 goroutine
 	ch := make(chan Event, 64)
 	go t.parseSSEStream(resp, ch)
 	return ch, nil

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -1619,9 +1619,9 @@ impl Agent {
                         // Note: granular tool_result events already written by display_event via emit_and_append_event
                     }
                     // Update context tokens from USAGE (used by next turn's compact check)
-                    if self.last_input_tokens > 0 {
-                        self.update_stats_from_usage();
-                    }
+                    // 对齐 Bash/Go: agent_request_count 和 token totals 无条件更新,
+                    // current_context_tokens 仅在 > 0 时写入
+                    self.update_stats_from_usage();
                     // tool_use/tool_calls → loop continues; anything else → break
                     if stop.as_str() != "tool_use" && stop.as_str() != "tool_calls" {
                         // end_turn 后尝试 drain（对齐 bash agent_drain_notify_buf && continue）


### PR DESCRIPTION
### 背景

以 Bash 版（`src/agent.sh`）为主线，对 C / Go / Rust 三个移植版本进行全量架构一致性审查，发现 6 项跨运行时不一致。本 PR 逐项修复，确保四版本行为完全对齐。

---

### 高危

#### H-1 · C 版 PlanClear 在压缩前已清空 plan.md（C 独有）

**问题**：`tool_plan_clear()` 在工具分发阶段直接调用 `store_plan_clear()` 清空了 `plan.md`，随后主循环才执行 `agent_compact_context("plan_clear")`。此时 summary 请求的 system prompt 已不含旧计划内容，无法命中 KV cache 前缀——每次 PlanClear 都额外产生一次完整冷启动（数十万 token 级别的 cache_creation 费用）。

**修复**：
- `c/tools.c` — `tool_plan_clear()` 不再直接写 `plan.md`，仅返回结果（与 `tool_plan_confirm` 的模式一致）
- `c/agent.c` — 在 `agent_compact_context("plan_clear")` **之后**才执行 `store_plan_clear()`

**对照**：Bash / Go / Rust 均正确（先 compact 再写 plan）。C 的 PlanConfirm 也正确。仅 PlanClear 有此 Bug。

---

#### H-2 · Go 与 C 缺少 HTTP 传输层重试机制

**问题**：Bash 使用 `curl --retry 2 --retry-delay 1 --retry-max-time 20`，Rust 有 `StreamClient` 应用层重试（5xx 和连接错误均重试）。Go 的 `client.Do(req)` 和 C 的 `curl_easy_perform()` 均为单次请求，遇到临时连接故障或 5xx 直接终止。已实现的 `SSE_RETRY` / `EventRetry` 累积器重置代码因无重试路径而成为不可达死代码。

**修复**：
- `go/transport.go` — `Call()` 添加重试循环（最多 2 次重试，延迟 1s，总窗口 20s），5xx 和连接错误均重试，4xx 不重试
- `c/transport.c` — `http_post_sse()` 添加重试循环，重试前通过回调发送 `SSE_RETRY` 事件重置累积器；提取 `process_residual_json()` 辅助函数消除重复代码

**修复后**：四版本均具备等价重试能力，C 的 `SSE_RETRY` 累积器重置逻辑变为可达。

---

### 中危

#### M-1 · C/Go tool_read 行号行为不一致

**问题**：Bash（`sed -n`）和 Rust 不加行号输出原始文本；C 用 `%6d + 两空格` 格式、Go 用 `%6d + Tab` 格式——三个版本输出互不相同。同一 session 切换版本时 LLM 看到的 tool result 内容不一致。

| 版本 | 修复前 | 修复后 |
|------|--------|--------|
| Bash | 原始文本（无行号） | — |
| Rust | 原始文本（无行号） | — |
| C | `%6d  %s`（两空格） | 原始文本（无行号） |
| Go | `%6d\t%s`（Tab） | 原始文本（无行号） |

**修复**：`c/tools.c` 和 `go/tools.go` 移除行号格式化，统一为 Bash / Rust 的原始文本输出。

---

#### M-2 · C 版 agent_wait_for_sub_agents 错误返回处理

**问题**：`mq_pop` 失败（队列关闭/空）或 `processed==0`（收到无法处理的消息）时函数直接 `return -1`，调用者忽略返回值后继续进入 `agent_destroy`，可能释放仍被 detached 线程使用的 `sub_result_queue`（use-after-free 风险）。

**修复**：`c/agent.c` — `mq_pop` 失败时 `break` 而非 `return -1`；`processed==0` 时 `continue` 而非 `return -1`。函数返回值反映 `active_task_count` 实际状态。

---

### 低危

#### L-1 · Go CompactContext plan_clear/confirm 守卫对齐

**问题**：Bash / C / Rust 在 plan_clear / plan_confirm 时绕过 `keep >= total` 守卫继续执行 compact；Go 独有地在 `keepLines >= totalLines` 时提前返回 `false`。

**修复**：`go/agent.go` — plan 操作时 `keepLines >= totalLines` 不再提前返回，仅 `keepLines <= 0` 时放弃。

---

#### L-2 · Rust update_stats_from_usage 守卫对齐

**问题**：Bash / Go 的 `agent_request_count` 和 token totals 无条件更新；Rust 独有地在 `last_input_tokens == 0` 时跳过全部 stats 更新（包括 `agent_request_count` 递增），导致终端标题请求计数与其他版本不一致。

**修复**：`rust/src/agent.rs` — 移除 `if self.last_input_tokens > 0` 外层守卫，`update_stats_from_usage()` 无条件调用。内部仍保留 `current_context_tokens` 的 `ctx > 0` 守卫（与 Bash / Go 一致）。

---

### 测试结果

| 测试 | 结果 |
|------|------|
| C e2e（`AGENT=./dist/cagent bash tests/test.sh`） | ✅ 182 passed, 0 failed |
| Go e2e（`make test-go-e2e`） | ✅ 182 passed, 0 failed |
| Rust e2e（`make test-rust-e2e`） | ✅ 182 passed, 0 failed |
| Go unit（`make test-go`） | ✅ ok 0.086s |
| tools.json SHA256 四版本一致性 | ✅ `f5d25071...` |

---

### 文件变更

```
 c/agent.c         |  11 +-
 c/tools.c         |  10 +-
 c/transport.c     | 372 +++++++++++++++++++++++++++++++-----------------------
 go/agent.go       |   4 +-
 go/tools.go       |   5 +-
 go/transport.go   |  52 ++++++--
 rust/src/agent.rs |   6 +-
 7 files changed, 282 insertions(+), 178 deletions(-)