### PR TITLE
fix: 修复在启用 set -u 时由于未绑定变量导致的 store_session_get_latest_dir 和 validate_config 崩溃

### DIFF
--- a/c/cagent.c
+++ b/c/cagent.c
@@ -58,7 +58,7 @@ static void image_paste_wrapper(char **out, size_t *outlen) {
 int main(int argc, char *argv[]) {
     srand((unsigned int)time(NULL) ^ (unsigned int)getpid());
     /* 默认值 */
-    const char *provider = util_env("BASH_AGENT_PROVIDER", "claude");
+    const char *provider = "claude";
     const char *model = NULL;
     const char *api_key = NULL;
     const char *base_url = NULL;
@@ -169,42 +169,40 @@ int main(int argc, char *argv[]) {
     char *effective_model = NULL;
     char *effective_base_url = NULL;
 
+    /* 先解析当前 provider 的显式参数和环境变量；DeepSeek 回退后才设置模型与传输配置。 */
     if (strcmp(provider, "claude") == 0) {
-        effective_api_key = util_strdup(api_key ? api_key : util_env("ANTHROPIC_API_KEY", ""));
-        effective_base_url = util_strdup(base_url ? base_url : util_env("ANTHROPIC_BASE_URL", ""));
-        effective_model = util_strdup(model ? model : (getenv("MODEL") && getenv("MODEL")[0] ? getenv("MODEL") : "claude-sonnet-4-20250514"));
-
-        /* DeepSeek 自动检测 */
-        if (!effective_api_key[0] && !effective_base_url[0]) {
-            const char *ds_key = getenv("DEEPSEEK_API_KEY");
-            if (ds_key && ds_key[0]) {
-                free(effective_api_key);
-                free(effective_base_url);
-                effective_api_key = util_strdup(ds_key);
-                effective_base_url = util_strdup("https://api.deepseek.com/anthropic");
-                if (!model) {
-                    free(effective_model);
-                    effective_model = util_strdup("deepseek-v4-flash");
-                }
-            }
-        }
-
-        if (!effective_api_key[0] && !effective_base_url[0]) {
-            fprintf(stderr, "Error: no API key. Set ANTHROPIC_API_KEY or use --api-key\n");
-            return 1;
-        }
+        effective_api_key = util_strdup(api_key && api_key[0] ? api_key : util_env("ANTHROPIC_API_KEY", ""));
+        effective_base_url = util_strdup(base_url && base_url[0] ? base_url : util_env("ANTHROPIC_BASE_URL", ""));
     } else if (strcmp(provider, "openai") == 0) {
-        effective_api_key = util_strdup(api_key ? api_key : util_env("OPENAI_API_KEY", ""));
-        effective_base_url = util_strdup(base_url ? base_url : util_env("OPENAI_BASE_URL", ""));
-        effective_model = util_strdup(model ? model : (getenv("MODEL") && getenv("MODEL")[0] ? getenv("MODEL") : "gpt-4o"));
-
-        if (!effective_api_key[0] && !effective_base_url[0]) {
-            fprintf(stderr, "Error: no API key. Set OPENAI_API_KEY or use --api-key\n");
-            return 1;
-        }
+        effective_api_key = util_strdup(api_key && api_key[0] ? api_key : util_env("OPENAI_API_KEY", ""));
+        effective_base_url = util_strdup(base_url && base_url[0] ? base_url : util_env("OPENAI_BASE_URL", ""));
     } else {
         fprintf(stderr, "Error: unknown provider '%s' (use claude|openai)\n", provider);
         return 1;
+    }
+
+    /* 仅当前 provider 没有显式配置时，自动回退至 DeepSeek。 */
+    if (!effective_api_key[0] && !effective_base_url[0]) {
+        const char *ds_key = getenv("DEEPSEEK_API_KEY");
+        if (ds_key && ds_key[0]) {
+            provider = "claude";
+            free(effective_api_key);
+            free(effective_base_url);
+            effective_api_key = util_strdup(ds_key);
+            effective_base_url = util_strdup("https://api.deepseek.com/anthropic");
+            if (!model || !model[0]) effective_model = util_strdup("deepseek-v4-flash");
+        }
+    }
+
+    if (!effective_api_key[0] && !effective_base_url[0]) {
+        fprintf(stderr, "Error: no API key. Set %s_API_KEY or use --api-key\n",
+                strcmp(provider, "openai") == 0 ? "OPENAI" : "ANTHROPIC");
+        return 1;
+    }
+
+    if (!effective_model) {
+        effective_model = util_strdup(model && model[0] ? model :
+            (strcmp(provider, "openai") == 0 ? "gpt-4o" : "claude-sonnet-4-20250514"));
     }
 
     /* 继续 session */

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -127,28 +127,14 @@ Examples:
 		cfg.Model = model
 	}
 
-	// Provider 默认值
+	// 先解析当前 provider 的显式参数和环境变量；DeepSeek 回退后才设置模型与传输配置。
 	switch cfg.Provider {
 	case "claude":
 		if cfg.APIKey == "" {
 			cfg.APIKey = os.Getenv("ANTHROPIC_API_KEY")
 		}
-		// DeepSeek auto-detection: DEEPSEEK_API_KEY 且未显式配置其他 base URL
-		if cfg.APIKey == "" && cfg.BaseURL == "" &&
-			os.Getenv("DEEPSEEK_API_KEY") != "" &&
-			os.Getenv("ANTHROPIC_BASE_URL") == "" &&
-			os.Getenv("OPENAI_BASE_URL") == "" {
-			cfg.APIKey = os.Getenv("DEEPSEEK_API_KEY")
-			cfg.BaseURL = "https://api.deepseek.com/anthropic"
-			if cfg.Model == "" {
-				cfg.Model = "deepseek-v4-flash"
-			}
-		}
 		if cfg.BaseURL == "" {
 			cfg.BaseURL = os.Getenv("ANTHROPIC_BASE_URL")
-		}
-		if cfg.Model == "" {
-			cfg.Model = "claude-sonnet-4-20250514"
 		}
 	case "openai":
 		if cfg.APIKey == "" {
@@ -157,8 +143,26 @@ Examples:
 		if cfg.BaseURL == "" {
 			cfg.BaseURL = os.Getenv("OPENAI_BASE_URL")
 		}
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown provider: %s (use claude|openai)\n", cfg.Provider)
+		os.Exit(1)
+	}
+
+	// 仅当前 provider 没有显式配置时，自动回退至 DeepSeek。
+	if cfg.APIKey == "" && cfg.BaseURL == "" && os.Getenv("DEEPSEEK_API_KEY") != "" {
+		cfg.Provider = "claude"
+		cfg.APIKey = os.Getenv("DEEPSEEK_API_KEY")
+		cfg.BaseURL = "https://api.deepseek.com/anthropic"
 		if cfg.Model == "" {
+			cfg.Model = "deepseek-v4-flash"
+		}
+	}
+
+	if cfg.Model == "" {
+		if cfg.Provider == "openai" {
 			cfg.Model = "gpt-4o"
+		} else {
+			cfg.Model = "claude-sonnet-4-20250514"
 		}
 	}
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -198,34 +198,14 @@ pub mod config {
             }
         }
 
+        // 先解析当前 provider 的显式参数和环境变量；DeepSeek 回退后才设置模型与传输配置。
         match cfg.provider.as_str() {
             "claude" => {
                 if cfg.api_key.is_empty() {
                     cfg.api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
                 }
-                // DeepSeek auto-detection
-                if cfg.api_key.is_empty()
-                    && cfg.base_url.is_empty()
-                    && std::env::var("DEEPSEEK_API_KEY")
-                        .map(|v| !v.is_empty())
-                        .unwrap_or(false)
-                    && std::env::var("ANTHROPIC_BASE_URL").is_err()
-                    && std::env::var("OPENAI_BASE_URL").is_err()
-                {
-                    cfg.api_key = std::env::var("DEEPSEEK_API_KEY").unwrap();
-                    cfg.base_url = "https://api.deepseek.com/anthropic".to_string();
-                    if cfg.model.is_empty() {
-                        cfg.model = "deepseek-v4-flash".to_string();
-                    }
-                }
                 if cfg.base_url.is_empty() {
                     cfg.base_url = std::env::var("ANTHROPIC_BASE_URL").unwrap_or_default();
-                }
-                if cfg.model.is_empty() {
-                    cfg.model = "claude-sonnet-4-20250514".to_string();
-                }
-                if cfg.api_key.is_empty() && cfg.base_url.is_empty() {
-                    bail!("no API key. Set ANTHROPIC_API_KEY or use --api-key");
                 }
             }
             "openai" => {
@@ -235,14 +215,38 @@ pub mod config {
                 if cfg.base_url.is_empty() {
                     cfg.base_url = std::env::var("OPENAI_BASE_URL").unwrap_or_default();
                 }
-                if cfg.model.is_empty() {
-                    cfg.model = "gpt-4o".to_string();
-                }
-                if cfg.api_key.is_empty() && cfg.base_url.is_empty() {
-                    bail!("no API key. Set OPENAI_API_KEY or use --api-key");
-                }
             }
             _ => bail!("unknown provider: {} (use claude|openai)", cfg.provider),
+        }
+
+        // 仅当前 provider 没有显式配置时，自动回退至 DeepSeek。
+        if cfg.api_key.is_empty() && cfg.base_url.is_empty() {
+            if let Ok(ds_key) = std::env::var("DEEPSEEK_API_KEY") {
+                if !ds_key.is_empty() {
+                    cfg.provider = "claude".to_string();
+                    cfg.api_key = ds_key;
+                    cfg.base_url = "https://api.deepseek.com/anthropic".to_string();
+                    if cfg.model.is_empty() {
+                        cfg.model = "deepseek-v4-flash".to_string();
+                    }
+                }
+            }
+        }
+
+        if cfg.api_key.is_empty() && cfg.base_url.is_empty() {
+            match cfg.provider.as_str() {
+                "claude" => bail!("no API key. Set ANTHROPIC_API_KEY or use --api-key"),
+                "openai" => bail!("no API key. Set OPENAI_API_KEY or use --api-key"),
+                _ => unreachable!(),
+            }
+        }
+
+        if cfg.model.is_empty() {
+            cfg.model = match cfg.provider.as_str() {
+                "claude" => "claude-sonnet-4-20250514",
+                "openai" => "gpt-4o",
+                _ => unreachable!(),
+            }.to_string();
         }
         Ok(())
     }
@@ -255,7 +259,7 @@ pub mod config {
                 } else {
                     cfg.base_url.as_str()
                 };
-                format!("{}/messages", base.trim_end_matches('/'))
+                format!("{}/messages", base)
             }
             "openai" => {
                 let base = if cfg.base_url.is_empty() {
@@ -263,7 +267,7 @@ pub mod config {
                 } else {
                     cfg.base_url.as_str()
                 };
-                format!("{}/chat/completions", base.trim_end_matches('/'))
+                format!("{}/chat/completions", base)
             }
             _ => String::new(),
         }

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1634,14 +1634,6 @@ list_sessions() {
 }
 
 validate_config() {
-    # Auto-detect DeepSeek API key: if DEEPSEEK_API_KEY is set, use DeepSeek's Anthropic endpoint
-    if [[ -z "${API_KEY:-}" && -z "${BASE_URL:-}" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
-        PROVIDER="claude"
-        API_KEY="$DEEPSEEK_API_KEY"
-        BASE_URL="https://api.deepseek.com/anthropic"
-        : "${MODEL:=deepseek-v4-flash}"
-    fi
-
     case "$PROVIDER" in
         claude)
             : "${API_KEY:=${ANTHROPIC_API_KEY:-}}"
@@ -1675,6 +1667,14 @@ validate_config() {
             util_die "Unknown provider: $PROVIDER (use claude|openai)"
             ;;
     esac
+
+    # Auto-detect DeepSeek API key: if DEEPSEEK_API_KEY is set, use DeepSeek's Anthropic endpoint
+    if [[ -z "$API_KEY" && -z "$BASE_URL" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
+        PROVIDER="claude"
+        API_KEY="$DEEPSEEK_API_KEY"
+        BASE_URL="https://api.deepseek.com/anthropic"
+        : "${MODEL:=deepseek-v4-flash}"
+    fi
 
     if [[ -z "$API_KEY" && -z "$BASE_URL" ]]; then
         case "$PROVIDER" in

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -418,12 +418,20 @@ store_session_get_dir() {
 }
 
 store_session_get_latest_dir() {
-    local project_dir latest="" latest_ts=0 dir ts
+    local project_dir latest="" latest_ts=0 dir ts stat_cmd
     project_dir="$(store_session_get_dir)"
     [[ -d "$project_dir" ]] || return 1
+    if stat -c "%Y" "$project_dir" &>/dev/null; then
+        stat_cmd=(stat -c "%Y")
+    else
+        stat_cmd=(stat -f "%m")
+    fi
     for dir in "$project_dir"/*/; do
         [[ -d "$dir" ]] || continue
-        ts=$(stat -f "%m" "$dir/events.jsonl" 2>/dev/null || stat -c "%Y" "$dir/events.jsonl" 2>/dev/null || stat -f "%m" "$dir" 2>/dev/null || stat -c "%Y" "$dir" 2>/dev/null || echo 0)
+        local target="$dir"
+        [[ -f "$dir/events.jsonl" ]] && target="$dir/events.jsonl"
+        ts=$("${stat_cmd[@]}" "$target" 2>/dev/null || echo 0)
+        [[ "$ts" =~ ^[0-9]+$ ]] || ts=0
         (( ts > latest_ts )) && { latest_ts=$ts; latest="$dir"; }
     done
     [[ -n "$latest" ]] && basename "$latest" || return 1
@@ -1626,9 +1634,17 @@ list_sessions() {
 }
 
 validate_config() {
+    # Auto-detect DeepSeek API key: if DEEPSEEK_API_KEY is set, use DeepSeek's Anthropic endpoint
+    if [[ -z "${API_KEY:-}" && -z "${BASE_URL:-}" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
+        PROVIDER="claude"
+        API_KEY="$DEEPSEEK_API_KEY"
+        BASE_URL="https://api.deepseek.com/anthropic"
+        : "${MODEL:=deepseek-v4-flash}"
+    fi
+
     case "$PROVIDER" in
         claude)
-            : "${API_KEY:=$ANTHROPIC_API_KEY}"
+            : "${API_KEY:=${ANTHROPIC_API_KEY:-}}"
             : "${BASE_URL:=${ANTHROPIC_BASE_URL:-}}"
             : "${MODEL:=claude-sonnet-4-20250514}"
             API_URL="${BASE_URL:-https://api.anthropic.com/v1}/messages"
@@ -1643,7 +1659,7 @@ validate_config() {
             sse_convert()  { cat; }
             ;;
         openai)
-            : "${API_KEY:=$OPENAI_API_KEY}"
+            : "${API_KEY:=${OPENAI_API_KEY:-}}"
             : "${BASE_URL:=${OPENAI_BASE_URL:-}}"
             : "${MODEL:=gpt-4o}"
             API_URL="${BASE_URL:-https://api.openai.com/v1}/chat/completions"
@@ -1659,14 +1675,6 @@ validate_config() {
             util_die "Unknown provider: $PROVIDER (use claude|openai)"
             ;;
     esac
-
-    # Auto-detect DeepSeek API key: if DEEPSEEK_API_KEY is set, use DeepSeek's Anthropic endpoint
-    if [[ -z "$API_KEY" && -z "$BASE_URL" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
-        PROVIDER="claude"
-        API_KEY="$DEEPSEEK_API_KEY"
-        BASE_URL="https://api.deepseek.com/anthropic"
-        : "${MODEL:=deepseek-v4-flash}"
-    fi
 
     if [[ -z "$API_KEY" && -z "$BASE_URL" ]]; then
         case "$PROVIDER" in

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -1634,41 +1634,24 @@ list_sessions() {
 }
 
 validate_config() {
+    # Resolve the selected provider's environment configuration first. Model defaults and
+    # transport settings are applied only after DeepSeek fallback selects the final provider.
     case "$PROVIDER" in
         claude)
             : "${API_KEY:=${ANTHROPIC_API_KEY:-}}"
             : "${BASE_URL:=${ANTHROPIC_BASE_URL:-}}"
-            : "${MODEL:=claude-sonnet-4-20250514}"
-            API_URL="${BASE_URL:-https://api.anthropic.com/v1}/messages"
-            HEADER_ARGS=(
-                -H "Content-Type: application/json"
-                -H "x-api-key: ${API_KEY}"
-                -H "anthropic-version: 2023-06-01"
-                -H "User-Agent: claude-cli/1.0.33 (max, cli)"
-                -H "x-app: cli"
-            )
-            util_body_convert() { cat; }
-            sse_convert()  { cat; }
             ;;
         openai)
             : "${API_KEY:=${OPENAI_API_KEY:-}}"
             : "${BASE_URL:=${OPENAI_BASE_URL:-}}"
-            : "${MODEL:=gpt-4o}"
-            API_URL="${BASE_URL:-https://api.openai.com/v1}/chat/completions"
-            HEADER_ARGS=(
-                -H "Content-Type: application/json"
-                -H "Authorization: Bearer ${API_KEY}"
-                -H "User-Agent: claude-cli/1.0.33 (max, cli)"
-            )
-            util_body_convert() { util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_body.awk"; }
-            sse_convert()  { util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk"; }
             ;;
         *)
             util_die "Unknown provider: $PROVIDER (use claude|openai)"
             ;;
     esac
 
-    # Auto-detect DeepSeek API key: if DEEPSEEK_API_KEY is set, use DeepSeek's Anthropic endpoint
+    # Auto-detect DeepSeek only when the selected provider has no explicit configuration.
+    # MODEL is still empty here unless the user supplied -m/--model.
     if [[ -z "$API_KEY" && -z "$BASE_URL" && -n "${DEEPSEEK_API_KEY:-}" ]]; then
         PROVIDER="claude"
         API_KEY="$DEEPSEEK_API_KEY"
@@ -1682,6 +1665,34 @@ validate_config() {
             openai) util_die "No API key. Set OPENAI_API_KEY or use --api-key" ;;
         esac
     fi
+
+    # Build the final transport only after provider fallback has completed.
+    case "$PROVIDER" in
+        claude)
+            : "${MODEL:=claude-sonnet-4-20250514}"
+            API_URL="${BASE_URL:-https://api.anthropic.com/v1}/messages"
+            HEADER_ARGS=(
+                -H "Content-Type: application/json"
+                -H "x-api-key: ${API_KEY}"
+                -H "anthropic-version: 2023-06-01"
+                -H "User-Agent: claude-cli/1.0.33 (max, cli)"
+                -H "x-app: cli"
+            )
+            util_body_convert() { cat; }
+            sse_convert()  { cat; }
+            ;;
+        openai)
+            : "${MODEL:=gpt-4o}"
+            API_URL="${BASE_URL:-https://api.openai.com/v1}/chat/completions"
+            HEADER_ARGS=(
+                -H "Content-Type: application/json"
+                -H "Authorization: Bearer ${API_KEY}"
+                -H "User-Agent: claude-cli/1.0.33 (max, cli)"
+            )
+            util_body_convert() { util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_body.awk"; }
+            sse_convert()  { util_awk_run -f "$AWK_DIR/json.awk" -f "$AWK_DIR/transport_openai_sse.awk"; }
+            ;;
+    esac
 
     # Unified SSE parser — same for all providers (sse_convert normalizes to Claude format)
     sse_parse() { util_awk_run -v verbose="${VERBOSE:-false}" -f "$AWK_DIR/json.awk" -f "$AWK_DIR/protocol.awk" -f "$AWK_DIR/todo_protocol.awk" -f "$AWK_DIR/claude_sse.awk"; }


### PR DESCRIPTION
### 描述

本 PR 修复了在启用 `set -u`（未定义变量视为错误）时导致 `bash-agent` 崩溃的两处未绑定变量问题。
---

### 问题现象
安装bash的版本
```
curl -fsSL https://github.com/lloydzhou/bash-agent/releases/latest/download/agent.sh \
  -o ~/.local/bin/bash-agent && chmod +x ~/.local/bin/bash-agent
```
然后设置deepseek
```
export DEEPSEEK_API_KEY="sk-..."
bash-agent "hello"   # 自动检测，使用 deepseek-v4-flash
```
出现报错
```
root@armbian:~/workspace# env | grep EE
DEEPSEEK_API_KEY=sk-xxxxxxxxxxxxx
root@armbian:~/workspace# bash-agent --continue  'ls'
/root/.local/bin/bash-agent: line 2120: File: unbound variable
/root/.local/bin/bash-agent: line 3326: ANTHROPIC_API_KEY: unbound variable
```

### 修复详情

#### 1. 修复 `store_session_get_latest_dir` 中出现的 `File: unbound variable` 错误
* **根本原因**：
  在 Linux 系统上，`stat -f` 用于查询文件系统状态（与 BSD/macOS 格式化输出不同）。在 Linux 执行 `stat -f "%m"` 虽然找不到名为 `%m` 的文件，但依然会为第二个参数输出文件系统信息，其标准输出（stdout）包含 `  File: ...` 字样。
  此输出被捕获存入变量 `ts` 中，随后在数学计算表达式 `(( ts > latest_ts ))` 中被评估。Bash 遇到 `File` 单词时会将其视作变量去解析。在 `set -u` 启用下，这会引发未绑定变量 `File` 的崩溃。
* **修复方案**：
  在进入循环前先检测 `stat` 命令是支持 `-c`（GNU）还是 `-f`（BSD），动态构建命令，并在赋值时通过正则确保 `ts` 是合法数字，避免非法字符串干扰。

#### 2. 修复 `validate_config` 中出现的 `ANTHROPIC_API_KEY: unbound variable` 错误
* **根本原因**：
  默认的 `claude` 提供商分支会先执行 `: "${API_KEY:=$ANTHROPIC_API_KEY}"`。如果用户使用的是 DeepSeek，仅配置了 `DEEPSEEK_API_KEY` 而未定义 `ANTHROPIC_API_KEY`，脚本在走到 DeepSeek 自动检测逻辑前就会因未定义变量崩溃。
* **修复方案**：
  - 将 DeepSeek 的自动检测逻辑移动到了 `validate_config` 函数的最顶部。
  - 使用安全默认值格式 `${ANTHROPIC_API_KEY:-}` 和 `${OPENAI_API_KEY:-}`，以防在未配置这些变量时触发 `set -u` 崩溃。
