### PR TITLE
fix(c,go): 修复 cagent SIGSEGV 崩溃 + 崩溃后终端 raw mode 恢复

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -2033,7 +2033,7 @@ char *agent_handle_sub_agent(Agent *agent, const char *prompt,
     /* 显示启动通知（事件已手动写入，只推显示队列不重复写事件） */
     DisplayMessage *dm = malloc(sizeof(DisplayMessage));
     *dm = display_msg_sub_agent_start(sub_session_id, description);
-    if (!store_event_stream_json_enabled()) {
+    if (!store_event_stream_json_enabled() && agent->display_queue) {
         mq_push(agent->display_queue, dm);
     } else {
         display_message_free(dm);
@@ -2160,7 +2160,7 @@ int agent_handle_sub_agent_result(Agent *agent, const char *session_id,
     DisplayMessage *dm = malloc(sizeof(DisplayMessage));
     *dm = display_msg_sub_agent_result(session_id, status, thinking,
                                        text, in_tokens, out_tokens);
-    if (!store_event_stream_json_enabled()) {
+    if (!store_event_stream_json_enabled() && agent->display_queue) {
         mq_push(agent->display_queue, dm);
     } else {
         display_message_free(dm);

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -55,6 +55,19 @@ static void image_paste_wrapper(char **out, size_t *outlen) {
     agent_image_clipboard_paste(g_paste_session_dir, out, outlen);
 }
 
+/* 崩溃信号处理：恢复终端 raw mode 后重新发出信号以生成 core dump。
+ * 仅使用 async-signal-safe 函数。 */
+static void crash_handler(int sig) {
+    linenoiseRestoreTerminal();
+    /* 输出换行，避免终端残留 prompt 行 */
+    const char msg[] = "\n\rcagent: fatal signal received, terminal restored.\n\r";
+    write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    /* 恢复默认 handler 并重新发送信号，让 OS 生成 core dump */
+    signal(sig, SIG_DFL);
+    raise(sig);
+    _exit(128 + sig); /* 理论上不会到达 */
+}
+
 int main(int argc, char *argv[]) {
     srand((unsigned int)time(NULL) ^ (unsigned int)getpid());
     /* 默认值 */
@@ -234,6 +247,19 @@ int main(int argc, char *argv[]) {
     /* 忽略 SIGPIPE：多线程中 SubAgent/bg-bash 线程的 HTTP 或 pipe 写入
      * 可能触发 SIGPIPE，默认行为是终止整个进程 */
     signal(SIGPIPE, SIG_IGN);
+
+    /* SIGSEGV / SIGABRT handler：进程崩溃时恢复终端 raw mode，避免
+     * linenoise 设置的 raw mode 残留导致终端排版错乱。
+     * handler 内仅调用 async-signal-safe 函数（tcsetattr / write / _exit）。 */
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = crash_handler;
+    sa.sa_flags = SA_RESETHAND; /* 恢复默认行为，允许 core dump */
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGSEGV, &sa, NULL);
+    sigaction(SIGABRT, &sa, NULL);
+    sigaction(SIGBUS, &sa, NULL);
+    sigaction(SIGFPE, &sa, NULL);
 
     /* 初始化 curl */
     curl_global_init(CURL_GLOBAL_DEFAULT);

--- a/c/json.c
+++ b/c/json.c
@@ -139,6 +139,7 @@ JsonParse json_parse(const char *src, size_t *pos) {
 }
 
 JsonParse json_parse_root(const char *src) {
+    if (!src) return make_err("null input");
     size_t pos = 0;
     JsonParse p = json_parse_internal(src, &pos);
     if (p.error) return p;

--- a/c/msgqueue.c
+++ b/c/msgqueue.c
@@ -38,6 +38,7 @@ void mq_destroy(MsgQueue *q) {
 }
 
 int mq_push(MsgQueue *q, void *data) {
+    if (!q || !data) return -1;
     MQNode *node = malloc(sizeof(MQNode));
     if (!node) return -1;
     node->data = data;
@@ -62,6 +63,7 @@ int mq_push(MsgQueue *q, void *data) {
 }
 
 int mq_pop(MsgQueue *q, void **data_out) {
+    if (!q || !data_out) return -1;
     pthread_mutex_lock(&q->mutex);
     while (!q->head && !q->closed) {
         pthread_cond_wait(&q->cond, &q->mutex);
@@ -83,6 +85,7 @@ int mq_pop(MsgQueue *q, void **data_out) {
 }
 
 int mq_try_pop(MsgQueue *q, void **data_out) {
+    if (!q || !data_out) return -1;
     pthread_mutex_lock(&q->mutex);
     if (!q->head) {
         pthread_mutex_unlock(&q->mutex);

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -6,13 +6,38 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	agent "github.com/lloyd/claude-code/bash-agent/go2"
+	"github.com/lloyd/claude-code/bash-agent/go2/linenoise"
 )
 
 func main() {
+	// Crash recovery: linenoise readline runs the terminal in raw mode.
+	// A panic or fatal signal (e.g. NULL deref in cgo) would leave the
+	// terminal in raw mode — no echo, no newline processing. These handlers
+	// restore the terminal before the process dies.
+	defer func() {
+		if r := recover(); r != nil {
+			linenoise.RestoreTerminal()
+			fmt.Fprintf(os.Stderr, "\ngoagent panic: %v\n", r)
+			os.Exit(1)
+		}
+	}()
+	crashSigCh := make(chan os.Signal, 1)
+	signal.Notify(crashSigCh, syscall.SIGSEGV, syscall.SIGABRT, syscall.SIGBUS, syscall.SIGFPE)
+	go func() {
+		sig := <-crashSigCh
+		linenoise.RestoreTerminal()
+		signal.Reset(sig)
+		p, _ := os.FindProcess(os.Getpid())
+		_ = p.Signal(sig.(syscall.Signal))
+		os.Exit(1)
+	}()
+
 	// 参数定义
 	var (
 		provider     string

--- a/go/cmd/goagent/readline.go
+++ b/go/cmd/goagent/readline.go
@@ -72,6 +72,13 @@ func (r *Readline) SetInterruptCallback(fn func()) {
 const promptStr = "\x1b[32m> \x1b[0m"
 
 func (r *Readline) loop() {
+	defer func() {
+		if rec := recover(); rec != nil {
+			linenoise.RestoreTerminal()
+			fmt.Fprintf(os.Stderr, "\nreadline panic: %v\n", rec)
+			os.Exit(1)
+		}
+	}()
 	buf := make([]byte, 65536)
 	stdinFd := int(os.Stdin.Fd())
 

--- a/go/linenoise/linenoise.go
+++ b/go/linenoise/linenoise.go
@@ -189,6 +189,13 @@ func SetMultiLine(ml bool) {
 	}
 }
 
+// RestoreTerminal restores the terminal from raw mode. Safe to call from a
+// signal handler or panic recovery — internally only uses async-signal-safe
+// C functions (tcsetattr, write).
+func RestoreTerminal() {
+	C.linenoiseRestoreTerminal()
+}
+
 // EditStart initializes a non-blocking line editing session.
 // Returns a LinenoiseState pointer for subsequent EditFeed/EditStop/Hide/Show calls.
 func EditStart(stdinFd, stdoutFd int, buf []byte, prompt string) (*LinenoiseState, error) {

--- a/vendor/linenoise/linenoise.c
+++ b/vendor/linenoise/linenoise.c
@@ -2324,6 +2324,13 @@ static void linenoiseAtExit(void) {
     freeHistory();
 }
 
+/* Public wrapper to restore terminal from a crash signal handler.
+ * disableRawMode only calls tcsetattr (async-signal-safe) and write
+ * (async-signal-safe), so this is safe to call from a signal handler. */
+void linenoiseRestoreTerminal(void) {
+    disableRawMode(STDIN_FILENO);
+}
+
 /* This is the API call to add a new entry in the linenoise history.
  * It uses a fixed array of char pointers that are shifted (memmoved)
  * when the history max length is reached in order to remove the older

--- a/vendor/linenoise/linenoise.h
+++ b/vendor/linenoise/linenoise.h
@@ -136,6 +136,10 @@ void linenoisePrintf(const char *fmt, ...);
 void linenoiseRegisterState(struct linenoiseState *ls);
 void linenoiseSetActive(int active);
 
+/* Restore terminal to pre-raw-mode state. Async-signal-safe wrapper
+ * around disableRawMode for use in crash signal handlers. */
+void linenoiseRestoreTerminal(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## 问题

cagent 在 SubAgent 嵌套调用场景下发生 SIGSEGV 崩溃（4 份 macOS crash log），
崩溃后终端残留在 raw mode，输出完全错乱，需手动 `stty sane` 恢复。

### Bug 1: SubAgent NULL display_queue → SIGSEGV (addr=0x18) — C 版本

**触发条件**: SubAgent（display_queue=NULL）内部 LLM 调用 SubAgent 工具（嵌套），
主 agent 为 human 输出模式。

**根因**: `agent_handle_sub_agent` / `agent_process_sub_result` 直接调 `mq_push`，
绕过了已有 NULL 检查的 `push_display` 辅助函数。SubAgent display_queue=NULL →
`mq_push` 解引用 NULL 偏移 0x18（pthread_mutex_t.mutex）→ 段错误。

### Bug 2: json_parse_root(NULL) → SIGSEGV (addr=0x0) — C 版本

**根因**: tool call 的 `input_json.data` 为 NULL 时，`json_parse_root` 未做 NULL 检查，
`skip_ws(NULL, &pos)` 解引用空指针。

### 终端排版错乱 — C + Go 版本

linenoise readline 线程将终端设为 raw mode（禁用 OPOST/ONLCR）。进程崩溃后
`atexit` 不触发，raw mode 残留。

## 修复

### Commit 1: C 版本（2 bugs + 终端恢复）

| 文件 | 改动 |
|------|------|
| `c/agent.c` | `agent_handle_sub_agent` / `agent_process_sub_result` 的 `mq_push` 前增加 `display_queue != NULL` 条件 |
| `c/json.c` | `json_parse_root` 入口增加 `if (!src) return make_err` |
| `c/msgqueue.c` | `mq_push` / `mq_pop` / `mq_try_pop` 防御性 NULL 检查 |
| `c/cagent.c` | `SIGSEGV`/`SIGABRT`/`SIGBUS`/`SIGFPE` signal handler，恢复终端后重新发出信号 |
| `vendor/linenoise/linenoise.{c,h}` | 公开 `linenoiseRestoreTerminal()` 函数 |

### Commit 2: Go 版本（终端恢复加固）

Go 版本**不存在** Bug 1 和 Bug 2（语言层面天然保护：nil channel send 会 block 而非 crash；
`encoding/json` 对空输入返回 error 而非 panic）。但 Go 同样使用 CGo linenoise 进入 raw mode，
缺少崩溃恢复机制。

| 文件 | 改动 |
|------|------|
| `go/cmd/goagent/main.go` | `defer recover()` + `signal.Notify(SIGSEGV/SIGABRT/SIGBUS/SIGFPE)` 恢复终端 |
| `go/cmd/goagent/readline.go` | readline goroutine `defer recover()` 恢复终端 |
| `go/linenoise/linenoise.go` | `RestoreTerminal()` Go 绑定，调用 C 版 `linenoiseRestoreTerminal()` |

### Rust 版本

已有 `std::panic::set_hook` → `crossterm::terminal::disable_raw_mode()`，无需修改。

## 测试

- C: `make build-c` + `AGENT=./dist/cagent bash tests/test.sh` — **201 passed, 0 failed**
- Go: `make build-go` + `AGENT=./dist/goagent bash tests/test.sh` — **201 passed, 0 failed**