### PR TITLE
fix: handle interactive input while background tasks are pending

### DIFF
--- a/c/agent.c
+++ b/c/agent.c
@@ -38,9 +38,21 @@ typedef struct {
     char *cmd;
     char *task_id;
     MsgQueue *sub_result_queue;
+    MsgQueue *input_queue;
 } AsyncBashArgs;
 
 static void *async_bash_thread_fn(void *arg);
+
+static void agent_signal_notify(MsgQueue *input_queue) {
+    if (!input_queue) return;
+    InputMessage *wakeup = calloc(1, sizeof(InputMessage));
+    if (!wakeup) return;
+    wakeup->type = MSG_NOTIFY_PENDING;
+    if (mq_push(input_queue, wakeup) != 0) {
+        input_message_free(wakeup);
+        free(wakeup);
+    }
+}
 
 /* ============================================================
  * 图片占位符支持
@@ -234,6 +246,7 @@ typedef struct {
     int fork_mode;
     char *sub_session_id;
     MsgQueue *sub_result_queue;
+    MsgQueue *input_queue;
 } SubAgentArgs;
 
 /* ============================================================
@@ -1156,6 +1169,7 @@ int agent_loop(Agent *agent, const char *user_input, const char *turn_kind) {
                         args->cmd = util_strdup(cmd);
                         args->task_id = util_strdup(task_id);
                         args->sub_result_queue = agent->sub_result_queue;
+                        args->input_queue = agent->interactive ? agent->input_queue : NULL;
                         pthread_t thread;
                         int prc = pthread_create(&thread, NULL, async_bash_thread_fn, args);
                         if (prc != 0) {
@@ -1751,8 +1765,11 @@ int agent_main_loop(Agent *agent) {
 
                   agent->running = 0;
 
-                /* 等待所有异步任务完成，避免销毁仍被工作线程使用的队列。 */
-                agent_wait_for_sub_agents(agent);
+                /* 交互模式不等待后台任务，允许下一条普通输入立即触发新回合。
+                 * 非交互模式仍等待，确保销毁前回收使用队列的后台线程。 */
+                if (!agent->interactive) {
+                    agent_wait_for_sub_agents(agent);
+                }
 
                 /* 所有轮次完成：等待 display 队列写完 */
                 if (agent->interactive) {
@@ -1801,7 +1818,12 @@ static void *async_bash_thread_fn(void *arg) {
         msg->data.async_task_result.task_id = util_strdup(args->task_id);
         msg->data.async_task_result.exit_code = 1;
         msg->data.async_task_result.output = util_strdup("Failed to create temp file");
-        mq_push(args->sub_result_queue, msg);
+        if (mq_push(args->sub_result_queue, msg) == 0) {
+            agent_signal_notify(args->input_queue);
+        } else {
+            input_message_free(msg);
+            free(msg);
+        }
         free(args->cmd); free(args->task_id); free(args);
         return NULL;
     }
@@ -1873,7 +1895,12 @@ static void *async_bash_thread_fn(void *arg) {
     msg->data.async_task_result.exit_code = exit_code;
     msg->data.async_task_result.output = output ? output : util_strdup("");
 
-    mq_push(args->sub_result_queue, msg);
+    if (mq_push(args->sub_result_queue, msg) == 0) {
+        agent_signal_notify(args->input_queue);
+    } else {
+        input_message_free(msg);
+        free(msg);
+    }
 
     /* 清理 */
     free(args->cmd);
@@ -1905,7 +1932,12 @@ static void *sub_agent_thread_fn(void *arg) {
         msg->data.agent_result.session_id = util_strdup(args->sub_session_id);
         msg->data.agent_result.status = util_strdup("failed");
         msg->data.agent_result.text = util_strdup("Failed to create sub-agent");
-        mq_push(args->sub_result_queue, msg);
+        if (mq_push(args->sub_result_queue, msg) == 0) {
+            agent_signal_notify(args->input_queue);
+        } else {
+            input_message_free(msg);
+            free(msg);
+        }
         goto cleanup;
     }
 
@@ -1991,7 +2023,12 @@ static void *sub_agent_thread_fn(void *arg) {
     msg->data.agent_result.cache_read_tokens = sub->last_cache_read_tokens;
     msg->data.agent_result.cache_creation_tokens = sub->last_cache_creation_tokens;
     msg->data.agent_result.request_count = store_stats_get_file_int(sub->paths.stats, "agent_request_count");
-    mq_push(args->sub_result_queue, msg);
+    if (mq_push(args->sub_result_queue, msg) == 0) {
+        agent_signal_notify(args->input_queue);
+    } else {
+        input_message_free(msg);
+        free(msg);
+    }
 
     agent_destroy(sub);
 
@@ -2060,6 +2097,7 @@ char *agent_handle_sub_agent(Agent *agent, const char *prompt,
     args->fork_mode = 0;  /* fork 已在主线程完成 */
     args->sub_session_id = util_strdup(sub_session_id);
     args->sub_result_queue = agent->sub_result_queue;
+    args->input_queue = agent->interactive ? agent->input_queue : NULL;
 
     pthread_t thread;
     int prc = pthread_create(&thread, NULL, sub_agent_thread_fn, args);

--- a/c/cagent.c
+++ b/c/cagent.c
@@ -384,7 +384,10 @@ int main(int argc, char *argv[]) {
         /* 主循环 */
         agent_main_loop(agent);
 
-        /* 等待线程结束 */
+        /* 用户可能在后台任务运行时退出。销毁队列前必须回收所有后台线程。 */
+        agent_wait_for_sub_agents(agent);
+
+        /* 等待读取线程结束 */
         /* 注意：readline 线程可能已经 close 了 input_queue（Ctrl+D/exit），
          * 也可能没有（agent 出错退出）。安全起见再 close 一次（重复 close 无害）。 */
         mq_close(&input_queue);

--- a/go/agent.go
+++ b/go/agent.go
@@ -1020,7 +1020,7 @@ func (a *Agent) RunLoop(ctx context.Context, initialUserInput, initialTurnKind s
 		hasPending := a.pendingTasks > 0
 		a.subMu.Unlock()
 
-		if hasPending {
+		if hasPending && !a.cfg.Interactive {
 			select {
 			case r := <-a.subResultCh:
 				// 处理结果（events + stats + display），获取 context 和 turnKind
@@ -1035,6 +1035,7 @@ func (a *Agent) RunLoop(ctx context.Context, initialUserInput, initialTurnKind s
 			}
 		}
 
+		// 交互模式不等待后台任务；结果完成时由主循环唤醒并以 notify turn 注入。
 		// 无 pending 子 agent → 退出
 		if phaseFatalErr != nil {
 			a.display.SetTitle(a.store.FormatTitle(a.cfg.Model, "idle"))
@@ -1342,4 +1343,40 @@ func (a *Agent) handleUserNotify(text string) string {
 // EnqueueUserNotify 将用户 Ctrl+O 输入写入 notify/sub_result 通道。
 func (a *Agent) EnqueueUserNotify(text string) {
 	a.subResultCh <- SubAgentResult{Kind: "user_notify", Text: text}
+}
+
+// SetInteractive 更新运行模式；自动进入交互模式时必须在首个回合前调用。
+func (a *Agent) SetInteractive(interactive bool) {
+	a.cfg.Interactive = interactive
+}
+
+// SubResultReady 返回后台结果通知通道，供交互主循环统一调度。
+func (a *Agent) SubResultReady() <-chan SubAgentResult {
+	return a.subResultCh
+}
+
+// RunResult 处理一条已由交互主循环取出的后台结果，并触发对应回合。
+func (a *Agent) RunResult(ctx context.Context, result SubAgentResult) error {
+	context, turnKind := a.handleSubAgentResult(result)
+	return a.RunLoop(ctx, context, turnKind)
+}
+
+// WaitForBackgroundResults 在退出前同步回收所有后台任务。
+func (a *Agent) WaitForBackgroundResults(ctx context.Context) error {
+	for {
+		a.subMu.Lock()
+		pending := a.pendingTasks
+		a.subMu.Unlock()
+		if pending <= 0 {
+			return nil
+		}
+		select {
+		case result := <-a.subResultCh:
+			if err := a.RunResult(ctx, result); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }

--- a/go/cmd/goagent/main.go
+++ b/go/cmd/goagent/main.go
@@ -275,6 +275,7 @@ Examples:
 			// 无 prompt 且 stdin 是终端 → 自动进入交互模式（与 bash 版一致）
 			interactive = true
 			cfg.Interactive = true
+			a.SetInteractive(true)
 			runInteractive(ctx, a, store, display, home, cfg.Model, userInput)
 		}
 	}
@@ -308,12 +309,30 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 	})
 	rl.Start()
 
-	// 主循环：从 readline goroutine 接收输入，交给 agent 处理
-	for input := range rl.Input() {
-		turnKind := "user_input"
-		if input == notifyWakeupInput {
-			input = ""
-			turnKind = "notify"
+	// 主循环：统一调度普通输入和后台结果。单个 RunLoop 仍串行执行，
+	// 但不会在后台任务尚未完成时独占等待。
+	inputCh := rl.Input()
+	for inputCh != nil {
+		input := ""
+		turnKind := ""
+		select {
+		case line, ok := <-inputCh:
+			if !ok {
+				inputCh = nil
+				continue
+			}
+			input = line
+			turnKind = "user_input"
+			if input == notifyWakeupInput {
+				input = ""
+				turnKind = "notify"
+			}
+		case result := <-a.SubResultReady():
+			if err := a.RunResult(ctx, result); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
+			a.FlushDisplay()
+			continue
 		}
 		if err := a.RunLoop(ctx, input, turnKind); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -322,6 +341,9 @@ func runInteractive(ctx context.Context, a *agent.Agent, store agent.SessionStor
 		// 不再调用 rl.Done() — readline goroutine 立即开始下一轮 EditStart
 	}
 
+	if err := a.WaitForBackgroundResults(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	}
 	fmt.Printf("\033[36mGoodbye!\033[0m\n\033[90mResume with: --session %s  or  --continue\033[0m\n", store.SessionID())
 }
 

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -211,26 +211,8 @@ pub fn agent_run(cfg: Config, cwd: PathBuf, home: PathBuf) -> Result<()> {
         io::stdin().read_line(&mut input)?;
         rt.agent_loop(input)?;
     }
-    // 等待所有子 agent 完成（bash 版没有超时，Ctrl+C 可杀）
-    while rt.active_task_count > 0 {
-        match rt.sub_result_rx.recv() {
-            Ok(MainLoopMessage::AgentResult {
-                session_id,
-                status,
-                thinking,
-                text,
-                in_tokens,
-                out_tokens,
-                cache_read_tokens,
-                cache_creation_tokens,
-                request_count,
-            }) => {
-                rt.handle_sub_agent_result(&session_id, &status, &thinking, &text, in_tokens, out_tokens, cache_read_tokens, cache_creation_tokens, request_count)?;
-            }
-            _ => break,
-        }
-    }
-    Ok(())
+    // 等待所有后台任务完成（bash 版没有超时，Ctrl+C 可杀）
+    rt.wait_for_background_results()
 }
 
 // MainLoopMessage 主循环消息类型
@@ -752,6 +734,7 @@ impl Agent {
         let home = self.home.clone();
         let cfg = self.cfg.clone();
         let msg_tx_arc = self.sub_result_tx.clone(); // 子 agent 结果发送到专用通道
+        let wake_tx = if self.cfg.interactive { Some(self.msg_tx.clone()) } else { None };
         let sub_session_id_clone = sub_session_id.clone();
         let parent_paths = self.paths.clone();
         let fork = fields.get("fork").map(|s| s == "true" || s == "1").unwrap_or(false);
@@ -767,11 +750,23 @@ impl Agent {
         }
 
         std::thread::spawn(move || {
+            let send_result = |result| {
+                if msg_tx_arc.send(result).is_ok() {
+                    if let Some(tx) = &wake_tx {
+                        if let Ok(guard) = tx.lock() {
+                            if let Some(tx) = guard.as_ref() {
+                                let _ = tx.send(MainLoopMessage::NotifyPending);
+                            }
+                        }
+                    }
+                }
+            };
+
             // 1. 创建子 agent 的 conversation store
             let sub_conv = Store { path: sub_paths.conversation.clone() };
             if let Err(e) = sub_conv.ensure() {
                 // 早期失败时发送失败结果，让主进程减少 active_task_count
-                let _ = msg_tx_arc.send(MainLoopMessage::AgentResult {
+                send_result(MainLoopMessage::AgentResult {
                     session_id: sub_session_id_clone.clone(),
                     status: "failed".to_string(),
                     thinking: String::new(),
@@ -837,7 +832,7 @@ impl Agent {
                 Ok(l) => l,
                 Err(e) => {
                     // 通过消息队列发送失败结果，让主进程减少计数
-                    let _ = msg_tx_arc.send(MainLoopMessage::AgentResult {
+                    send_result(MainLoopMessage::AgentResult {
                         session_id: sub_session_id_clone,
                         status: "failed".to_string(),
                         thinking: String::new(),
@@ -896,7 +891,7 @@ impl Agent {
             let request_count = stats_get_f64(&stats, "agent_request_count") as usize;
 
             // 6. 通过消息队列发送结果
-            let _ = msg_tx_arc.send(MainLoopMessage::AgentResult {
+            send_result(MainLoopMessage::AgentResult {
                 session_id: sub_session_id_clone,
                 status: status.to_string(),
                 thinking: result_thinking,
@@ -1065,7 +1060,10 @@ impl Agent {
         // 在主线程中运行 main_loop
         self.main_loop()?;
 
-        // 等待 readline 线程结束
+        // 用户可能在后台任务运行时退出；销毁运行时前必须消费剩余结果。
+        self.wait_for_background_results()?;
+
+        // 等待读取线程结束
         let _ = readline_handle.join();
 
         self.info("Goodbye!");
@@ -1118,56 +1116,6 @@ impl Agent {
                     self.running.store(false, Ordering::SeqCst);
                     self.flush_display();
 
-                    // Go 版架构：agent_loop 结束后，如果有活跃子 agent，
-                    // main_loop 在内部循环等待所有 AgentResult 并处理，
-                    // 直到全部完成后再返回主循环（readline 已在下一轮 EditStart）。
-                    // display worker 的 hide/show 保证输出不会与 linenoise 冲突。
-                    while self.active_task_count > 0 {
-                        match self.sub_result_rx.recv() {
-                            Ok(MainLoopMessage::AgentResult {
-                                session_id,
-                                status,
-                                thinking,
-                                text,
-                                in_tokens,
-                                out_tokens,
-                                cache_read_tokens,
-                                cache_creation_tokens,
-                                request_count,
-                            }) => {
-                                self.handle_sub_agent_result(
-                                    &session_id, &status, &thinking, &text,
-                                    in_tokens, out_tokens, cache_read_tokens,
-                                    cache_creation_tokens, request_count,
-                                )?;
-                                self.flush_display();
-                            }
-                            Ok(MainLoopMessage::UserInput { .. }) => {
-                                // readline 已不再等 done，可能发来新的 UserInput。
-                                // 将其放回队列末尾，等当前子 agent 完成后再处理。
-                                // TODO: 暂时忽略，后续可改为队列缓存。
-                            }
-                            Ok(MainLoopMessage::NotifyPending) => {}
-                            Ok(MainLoopMessage::AsyncResult { task_id, exit_code, output }) => {
-                                let _ = self.emit_and_append_event(json!({"type":"async_task_result","task_id":&task_id,"exit_code":exit_code,"output":&output}));
-                                if self.active_task_count > 0 { self.active_task_count -= 1; }
-                                let ctx = format!("[bg-bash {}] exit_code={}\nOutput: {}", task_id, exit_code, output);
-                                let _ = self.queue_display_event(DisplayEvent::AsyncTaskResult { task_id, exit_code, output });
-                                let _ = self.agent_loop_with_kind(ctx, "async_task_result");
-                                self.flush_display();
-                            }
-                            Ok(MainLoopMessage::UserNotify { text }) => {
-                                let _ = self.queue_display_event(DisplayEvent::UserNotify { text: text.clone() });
-                                let _ = self.agent_loop_with_kind(text, "user_notify");
-                                self.flush_display();
-                            }
-                            Err(std::sync::mpsc::RecvError) => {
-                                // 所有发送端关闭
-                                return Ok(());
-                            }
-                        }
-                    }
-
                     // 不再通知 readline 线程 — 它已经在下一轮 EditStart
                 }
                 _ => {}
@@ -1176,6 +1124,54 @@ impl Agent {
             // 非交互模式且无活跃子 agent 时退出
             if !self.cfg.interactive && self.active_task_count == 0 {
                 break;
+            }
+        }
+        Ok(())
+    }
+
+    // 等待并处理所有后台结果；仅用于非交互退出和交互资源销毁前。
+    fn wait_for_background_results(&mut self) -> Result<()> {
+        while self.active_task_count > 0 {
+            match self.sub_result_rx.recv() {
+                Ok(MainLoopMessage::AgentResult {
+                    session_id,
+                    status,
+                    thinking,
+                    text,
+                    in_tokens,
+                    out_tokens,
+                    cache_read_tokens,
+                    cache_creation_tokens,
+                    request_count,
+                }) => {
+                    self.handle_sub_agent_result(
+                        &session_id,
+                        &status,
+                        &thinking,
+                        &text,
+                        in_tokens,
+                        out_tokens,
+                        cache_read_tokens,
+                        cache_creation_tokens,
+                        request_count,
+                    )?;
+                    self.flush_display();
+                }
+                Ok(MainLoopMessage::AsyncResult { task_id, exit_code, output }) => {
+                    let _ = self.emit_and_append_event(json!({"type":"async_task_result","task_id":&task_id,"exit_code":exit_code,"output":&output}));
+                    if self.active_task_count > 0 { self.active_task_count -= 1; }
+                    let ctx = format!("[bg-bash {}] exit_code={}\nOutput: {}", task_id, exit_code, output);
+                    let _ = self.queue_display_event(DisplayEvent::AsyncTaskResult { task_id, exit_code, output });
+                    self.agent_loop_with_kind(ctx, "async_task_result")?;
+                    self.flush_display();
+                }
+                Ok(MainLoopMessage::UserNotify { text }) => {
+                    let _ = self.queue_display_event(DisplayEvent::UserNotify { text: text.clone() });
+                    self.agent_loop_with_kind(text, "user_notify")?;
+                    self.flush_display();
+                }
+                Ok(MainLoopMessage::NotifyPending) | Ok(MainLoopMessage::UserInput { .. }) => {}
+                Err(_) => return Err(anyhow!("后台结果通道已断开")),
             }
         }
         Ok(())
@@ -1482,6 +1478,7 @@ impl Agent {
                                 let task_id = format!("task_{}", chrono_like_now());
                                 self.active_task_count += 1;
                                 let tx = self.sub_result_tx.clone();
+                                let wake_tx = if self.cfg.interactive { Some(self.msg_tx.clone()) } else { None };
                                 let tid = task_id.clone();
                                 thread::spawn(move || {
                                     let output = Command::new("bash")
@@ -1496,7 +1493,15 @@ impl Agent {
                                         Ok(o) => (o.status.code().unwrap_or(-1), String::from_utf8_lossy(&o.stdout).to_string() + &String::from_utf8_lossy(&o.stderr)),
                                         Err(e) => (127, e.to_string()),
                                     };
-                                    let _ = tx.send(MainLoopMessage::AsyncResult { task_id: tid, exit_code, output: stdout });
+                                    if tx.send(MainLoopMessage::AsyncResult { task_id: tid, exit_code, output: stdout }).is_ok() {
+                                        if let Some(wake_tx) = wake_tx {
+                                            if let Ok(guard) = wake_tx.lock() {
+                                                if let Some(tx) = guard.as_ref() {
+                                                    let _ = tx.send(MainLoopMessage::NotifyPending);
+                                                }
+                                            }
+                                        }
+                                    }
                                 });
                                 format!("Async task started: task_id={}", task_id)
                             } else {

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -956,7 +956,7 @@ tool_bash() {
             bash -lc "$cmd" > "$tmpout" 2>&1
             _rc=$?; _out=$(util_awk_run -f "$AWK_DIR/sanitize_utf8.awk" "$tmpout"); rm -f "$tmpout"
             util_write_msg "ASYNC_TASK_RESULT" "$task_id" "$_rc" "$_out" >> "$NOTIFY_FIFO" 2>/dev/null || true
-        ) &
+        ) </dev/null >/dev/null 2>&1 &
         printf 'Async task started: task_id=%s, pid=%s' "$task_id" "$!"
         return 0
     fi

--- a/tests/fixtures/mock_server.py
+++ b/tests/fixtures/mock_server.py
@@ -751,6 +751,47 @@ class H(http.server.BaseHTTPRequestHandler):
                     'data: [DONE]\n\n',
                 ]: w.write(c.encode()); w.flush()
             return
+        # --- Interactive pending input: ordinary input must run before delayed background result ---
+        if b'INTERACTIVE_PENDING_MARKER' in body:
+            if path.startswith('/v1/messages'):
+                if b'[bg-bash ' in body and b'Output: pending-bg-ok' in body:
+                    chunks = [
+                        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_interactive_bg_done","role":"assistant","content":[],"model":"test","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+                        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+                        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Background result handled."}}\n\n',
+                        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n\n',
+                        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                    ]
+                elif b'INTERACTIVE_SECOND_INPUT' in body:
+                    chunks = [
+                        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_interactive_second","role":"assistant","content":[],"model":"test","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+                        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+                        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Second input handled."}}\n\n',
+                        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n\n',
+                        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                    ]
+                elif b'"tool_result"' in body or b'"role":"tool"' in body:
+                    chunks = [
+                        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_interactive_started","role":"assistant","content":[],"model":"test","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+                        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+                        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Background started."}}\n\n',
+                        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n\n',
+                        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                    ]
+                else:
+                    chunks = [
+                        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_interactive_start","role":"assistant","content":[],"model":"test","usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+                        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_interactive_bg","name":"Bash","input":{}}}\n\n',
+                        'event: content_block_delta\ndata: ' + json.dumps({'type':'content_block_delta','index':0,'delta':{'type':'input_json_delta','partial_json': json.dumps({'command':'sleep 12; echo pending-bg-ok','background':True})}}) + '\n\n',
+                        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}\n\n',
+                        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                    ]
+                for c in chunks: w.write(c.encode()); w.flush()
+            return
         # --- Async Bash: model calls Bash(background=true), then end_turn, then async result arrives ---
         if b'ASYNC_BASH_MARKER' in body and b'"tool_result"' not in body and b'"role":"tool"' not in body:
             if path.startswith('/v1/messages'):

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -552,6 +552,108 @@ test_agent_async_bash() {
     fi
 }
 
+test_agent_interactive_pending_input() {
+    info "Test 11f: Interactive input runs before delayed background result"
+    local output_file plain_file rc second_line bg_line done_line
+    output_file=$(mktemp)
+    plain_file=$(mktemp)
+
+    AGENT_PATH="$AGENT" BASE_URL="$BASE/v1" OUTPUT_FILE="$output_file" python3 <<'PY'
+import fcntl, os, pty, select, subprocess, sys, termios, time
+
+agent = os.environ["AGENT_PATH"]
+base = os.environ["BASE_URL"]
+out_path = os.environ["OUTPUT_FILE"]
+master, slave = pty.openpty()
+env = os.environ.copy()
+env["LINENOISE_COLS"] = "80"
+
+def child_setup():
+    os.setsid()
+    fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+
+proc = subprocess.Popen(
+    [agent, "-i", "-p", "claude", "--base-url", base, "-m", "test", "--api-key", "test"],
+    stdin=slave, stdout=slave, stderr=slave, close_fds=True, env=env,
+    preexec_fn=child_setup,
+)
+os.close(slave)
+data = bytearray()
+
+def drain(timeout):
+    end = time.time() + timeout
+    while time.time() < end:
+        ready, _, _ = select.select([master], [], [], min(0.1, end - time.time()))
+        if not ready:
+            continue
+        try:
+            chunk = os.read(master, 65536)
+        except OSError:
+            return
+        if not chunk:
+            return
+        data.extend(chunk)
+
+def wait_for(needle, timeout):
+    end = time.time() + timeout
+    target = needle.encode()
+    while time.time() < end:
+        if target in data:
+            return True
+        drain(0.2)
+    return target in data
+
+rc = 0
+try:
+    if not wait_for("bash-agent interactive mode", 5):
+        raise RuntimeError("interactive mode did not start")
+    drain(0.2)
+    os.write(master, b"INTERACTIVE_PENDING_MARKER\r")
+    if not wait_for("Background started.", 8):
+        raise RuntimeError("background task start turn did not finish")
+    os.write(master, b"INTERACTIVE_SECOND_INPUT\r")
+    if not wait_for("T:2 R:3", 4):
+        raise RuntimeError("ordinary input was delayed while background task was pending")
+    if not wait_for("[bg-bash ", 15):
+        raise RuntimeError("background result was not injected")
+    if not wait_for("R:4", 5):
+        raise RuntimeError("background result turn did not finish")
+    os.write(master, b"exit\r")
+    if not wait_for("Goodbye!", 10):
+        raise RuntimeError("interactive process did not exit cleanly")
+except Exception as exc:
+    data.extend(("\nTEST_ERROR: " + str(exc) + "\n").encode())
+    rc = 1
+finally:
+    if proc.poll() is None:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+    drain(0.2)
+    os.close(master)
+    with open(out_path, "wb") as f:
+        f.write(data)
+sys.exit(rc)
+PY
+    rc=$?
+    LC_ALL=C sed 's/\x1B\[[0-9;?]*[ -\/]*[@-~]//g; s/\r//g' "$output_file" > "$plain_file"
+    second_line=$(grep -n -m1 'T:2 R:3' "$plain_file" | cut -d: -f1)
+    bg_line=$(grep -n -m1 '\[bg-bash ' "$plain_file" | cut -d: -f1)
+    done_line=$(grep -n -m1 'R:4' "$plain_file" | cut -d: -f1)
+    if [[ $rc -eq 0 && -n "$second_line" && -n "$bg_line" && -n "$done_line" && \
+          $second_line -lt $bg_line && $bg_line -le $done_line ]]; then
+        green "Agent interactive pending input"; ((PASS++)) || true
+    else
+        red "Agent interactive pending input"; cat "$plain_file"; ((FAIL++)) || true
+    fi
+    rm -f "$output_file" "$plain_file"
+}
+
 test_agent_tool_result_persist_order() {
     info "Test 11c: assistant tool_use persisted before following tool_result"
     local output session_id conv_file
@@ -2658,6 +2760,7 @@ test_agent_openai_request_body
 test_agent_openai_tool_write
 test_agent_openai_sensenova_style
 test_agent_async_bash
+test_agent_interactive_pending_input
 test_agent_tool_result_persist_order
 test_agent_skill_injection
 test_agent_skill_injection_from_repo_skills_dir


### PR DESCRIPTION
## 概要

- 允许交互模式在后台任务运行期间立即处理普通输入
- 后台结果完成后继续按原语义注入新回合
- 保持非交互模式退出前等待后台任务
- 修复 Bash 后台进程继承回合输出管道导致的隐式阻塞
- 增加四运行时共用的伪终端时序回归测试

## 验证

- `make test-bash`：205 通过，0 失败
- `make test-go-e2e`：205 通过，0 失败
- `make test-rust-e2e`：205 通过，0 失败
- `make build-c && AGENT=./dist/cagent bash tests/test.sh`：205 通过，0 失败
- `git diff --check`：通过