### PR TITLE
feat: add Debian package release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,9 +236,61 @@ jobs:
           name: tcode
           path: dist/tcode
 
+  deb-package:
+    needs: [bash-agent, goagent, rustagent, cagent, tcode]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Install Debian packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binutils binutils-aarch64-linux-gnu
+
+      - name: Build Debian packages
+        id: build-deb
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="0.0.0+git${GITHUB_SHA:0:7}"
+          fi
+          make build-deb VERSION="$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Debian packages
+        env:
+          DEB_VERSION: ${{ steps.build-deb.outputs.version }}
+        run: |
+          all_deb="dist/bash-agent_${DEB_VERSION}_all.deb"
+          amd64_deb="dist/bash-agent_${DEB_VERSION}_amd64.deb"
+          arm64_deb="dist/bash-agent_${DEB_VERSION}_arm64.deb"
+          test "$(dpkg-deb -f "$all_deb" Architecture)" = all
+          test "$(dpkg-deb -f "$amd64_deb" Architecture)" = amd64
+          test "$(dpkg-deb -f "$arm64_deb" Architecture)" = arm64
+          dpkg-deb --contents "$all_deb" | grep -q './usr/bin/bash-agent$'
+          ! dpkg-deb --contents "$all_deb" | grep -q './usr/bin/goagent$'
+          sudo apt-get install -y "./$amd64_deb"
+          for command_name in bash-agent goagent rustagent cagent tcode; do
+            test -x "/usr/bin/$command_name"
+          done
+
+      - name: Upload Debian packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-packages
+          path: dist/bash-agent_*.deb
+
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [bash-agent, goagent, rustagent, cagent, tcode]
+    needs: [bash-agent, goagent, rustagent, cagent, tcode, deb-package]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -259,7 +311,7 @@ jobs:
           curl -fsSL "$ARCHIVE_URL" -o "dist/${{ github.ref_name }}.tar.gz"
           (
             cd dist
-            shasum -a 256 \
+            sha256sum \
               "${{ github.ref_name }}.tar.gz" \
               agent.sh \
               goagent-linux-amd64 \
@@ -274,7 +326,10 @@ jobs:
               cagent-linux-arm64 \
               cagent-darwin-amd64 \
               cagent-darwin-arm64 \
-              tcode > checksums.txt
+              tcode \
+              bash-agent_*_all.deb \
+              bash-agent_*_amd64.deb \
+              bash-agent_*_arm64.deb > checksums.txt
           )
 
       - name: Publish release assets
@@ -296,3 +351,6 @@ jobs:
             dist/cagent-darwin-amd64
             dist/cagent-darwin-arm64
             dist/tcode
+            dist/bash-agent_*_all.deb
+            dist/bash-agent_*_amd64.deb
+            dist/bash-agent_*_arm64.deb

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 SHELL := /bin/bash
 
-.PHONY: build build-bash build-go build-rust build-tcode build-c test test-bash test-go test-rust test-go-e2e test-rust-e2e test-c-e2e test-c-classify update-system-prompt-golden clean
+.PHONY: build build-bash build-go build-rust build-tcode build-c build-deb test test-bash test-go test-rust test-go-e2e test-rust-e2e test-c-e2e test-c-classify update-system-prompt-golden clean
+
+VERSION ?=
+DEB_DIST_DIR ?= dist
+DEB_OUTPUT_DIR ?= dist
 
 build: build-bash build-go build-rust build-tcode build-c
 
@@ -28,6 +32,10 @@ build-tcode:
 
 build-c:
 	$(MAKE) -C c
+
+build-deb:
+	@test -n "$(VERSION)" || { echo "用法：make build-deb VERSION=4.3.0 [DEB_DIST_DIR=dist] [DEB_OUTPUT_DIR=dist]" >&2; exit 2; }
+	bash scripts/build-deb.sh "$(VERSION)" "$(DEB_DIST_DIR)" "$(DEB_OUTPUT_DIR)"
 
 test: test-bash test-go test-rust test-c-e2e
 

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,0 +1,24 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: bash-agent
+Source: https://github.com/lloydzhou/bash-agent
+
+Files: *
+Copyright: 2026 Lloyd Zhou and bash-agent contributors
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -67,10 +67,6 @@ for artifact in "${required[@]}"; do
     echo "错误：缺少必需产物：$DIST_DIR/$artifact" >&2
     exit 1
   }
-  [[ -x "$DIST_DIR/$artifact" ]] || {
-    echo "错误：产物不可执行：$DIST_DIR/$artifact" >&2
-    exit 1
-  }
 done
 
 mkdir -p "$OUTPUT_DIR"

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# 从持续集成生成的 Linux 产物构建 Debian 软件包。
+# 用法：scripts/build-deb.sh <版本> [产物目录] [输出目录]
+
+set -euo pipefail
+
+PACKAGE="bash-agent"
+MAINTAINER="Lloyd Zhou <lloydzhou@qq.com>"
+HOMEPAGE="https://github.com/lloydzhou/bash-agent"
+VERSION_INPUT="${1:-}"
+DIST_DIR="${2:-dist}"
+OUTPUT_DIR="${3:-dist}"
+
+if [[ -z "$VERSION_INPUT" ]]; then
+  echo "用法：$0 <版本> [产物目录] [输出目录]" >&2
+  exit 2
+fi
+
+VERSION="${VERSION_INPUT#v}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+command -v dpkg-deb >/dev/null 2>&1 || {
+  echo "错误：需要 dpkg-deb。" >&2
+  exit 1
+}
+command -v strip >/dev/null 2>&1 || {
+  echo "错误：需要 strip。" >&2
+  exit 1
+}
+command -v aarch64-linux-gnu-strip >/dev/null 2>&1 || {
+  echo "错误：需要 aarch64-linux-gnu-strip（Ubuntu 软件包：binutils-aarch64-linux-gnu）。" >&2
+  exit 1
+}
+
+if command -v dpkg >/dev/null 2>&1; then
+  dpkg --validate-version "$VERSION" >/dev/null 2>&1 || {
+    echo "错误：不是合法的 Debian 版本：$VERSION" >&2
+    exit 1
+  }
+elif [[ ! "$VERSION" =~ ^[0-9][0-9A-Za-z.+:~_-]*$ ]]; then
+  echo "错误：不是合法的 Debian 版本：$VERSION" >&2
+  exit 1
+fi
+
+[[ -d "$DIST_DIR" ]] || {
+  echo "错误：产物目录不存在：$DIST_DIR" >&2
+  exit 1
+}
+[[ -f "$ROOT_DIR/packaging/debian/copyright" ]] || {
+  echo "错误：缺少 packaging/debian/copyright。" >&2
+  exit 1
+}
+
+required=(
+  agent.sh
+  tcode
+  goagent-linux-amd64
+  goagent-linux-arm64
+  rustagent-linux-amd64
+  rustagent-linux-arm64
+  cagent-linux-amd64
+  cagent-linux-arm64
+)
+for artifact in "${required[@]}"; do
+  [[ -f "$DIST_DIR/$artifact" ]] || {
+    echo "错误：缺少必需产物：$DIST_DIR/$artifact" >&2
+    exit 1
+  }
+  [[ -x "$DIST_DIR/$artifact" ]] || {
+    echo "错误：产物不可执行：$DIST_DIR/$artifact" >&2
+    exit 1
+  }
+done
+
+mkdir -p "$OUTPUT_DIR"
+DIST_DIR="$(cd "$DIST_DIR" && pwd)"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+if [[ -z "${SOURCE_DATE_EPOCH:-}" ]]; then
+  if command -v git >/dev/null 2>&1 && git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    SOURCE_DATE_EPOCH="$(git -C "$ROOT_DIR" log -1 --format=%ct)"
+  else
+    SOURCE_DATE_EPOCH=0
+  fi
+fi
+# Debian 规范检查将 1980 年以前的时间视为异常；无版本库时使用安全基线。
+if (( SOURCE_DATE_EPOCH < 315532800 )); then
+  SOURCE_DATE_EPOCH=315532800
+fi
+export SOURCE_DATE_EPOCH
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bash-agent-deb.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT INT TERM
+
+write_control() {
+  local pkg_dir="$1"
+  local arch="$2"
+  local description="$3"
+  local dependencies="bash (>= 4.0), gawk, curl, ca-certificates, ripgrep"
+
+  if [[ "$arch" != "all" ]]; then
+    dependencies+=", tmux, procps, libc6, libgcc-s1, libcurl4t64 | libcurl4"
+  fi
+
+  cat > "$pkg_dir/DEBIAN/control" <<EOF
+Package: $PACKAGE
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: $arch
+Maintainer: $MAINTAINER
+Depends: $dependencies
+Homepage: $HOMEPAGE
+Description: minimal AI coding agent runtime
+ $description
+ Supports Claude, OpenAI-compatible providers, persistent sessions,
+ skills, context compression and sub-agent orchestration.
+EOF
+}
+
+install_docs() {
+  local pkg_dir="$1"
+  local doc_dir="$pkg_dir/usr/share/doc/$PACKAGE"
+  mkdir -p "$doc_dir"
+  install -m 0644 "$ROOT_DIR/packaging/debian/copyright" "$doc_dir/copyright"
+
+  if [[ -f "$ROOT_DIR/README.md" ]]; then
+    gzip -9n < "$ROOT_DIR/README.md" > "$doc_dir/README.md.gz"
+    chmod 0644 "$doc_dir/README.md.gz"
+  fi
+  {
+    printf '%s (%s) unstable; urgency=medium\n\n' "$PACKAGE" "$VERSION"
+    printf '  * Upstream release %s.\n\n' "$VERSION"
+    printf ' -- %s  %s\n' "$MAINTAINER" "$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" -R)"
+  } | gzip -9n > "$doc_dir/changelog.gz"
+  chmod 0644 "$doc_dir/changelog.gz"
+
+  if [[ -f "$ROOT_DIR/CHANGELOG.md" ]]; then
+    gzip -9n < "$ROOT_DIR/CHANGELOG.md" > "$doc_dir/changelog.md.gz"
+    chmod 0644 "$doc_dir/changelog.md.gz"
+  fi
+}
+
+write_md5sums() {
+  local pkg_dir="$1"
+  (
+    cd "$pkg_dir"
+    find usr -type f -print0 | LC_ALL=C sort -z | xargs -0 md5sum
+  ) > "$pkg_dir/DEBIAN/md5sums"
+  chmod 0644 "$pkg_dir/DEBIAN/md5sums"
+}
+
+normalize_timestamps() {
+  local pkg_dir="$1"
+  find "$pkg_dir" -print0 | xargs -0 touch -h -d "@$SOURCE_DATE_EPOCH"
+}
+
+build_package() {
+  local arch="$1"
+  local pkg_dir="$WORK_DIR/$arch"
+  local bin_dir="$pkg_dir/usr/bin"
+  local output="$OUTPUT_DIR/${PACKAGE}_${VERSION}_${arch}.deb"
+
+  mkdir -p "$pkg_dir/DEBIAN" "$bin_dir"
+  chmod 0755 "$pkg_dir/DEBIAN"
+  install -m 0755 "$DIST_DIR/agent.sh" "$bin_dir/bash-agent"
+
+  if [[ "$arch" == "all" ]]; then
+    write_control "$pkg_dir" "$arch" \
+      "This architecture-independent package contains the Bash implementation."
+  else
+    install -m 0755 "$DIST_DIR/goagent-linux-$arch" "$bin_dir/goagent"
+    install -m 0755 "$DIST_DIR/rustagent-linux-$arch" "$bin_dir/rustagent"
+    install -m 0755 "$DIST_DIR/cagent-linux-$arch" "$bin_dir/cagent"
+    if [[ "$arch" == "arm64" ]]; then
+      aarch64-linux-gnu-strip --strip-unneeded "$bin_dir/cagent"
+    else
+      strip --strip-unneeded "$bin_dir/cagent"
+    fi
+    install -m 0755 "$DIST_DIR/tcode" "$bin_dir/tcode"
+    write_control "$pkg_dir" "$arch" \
+      "This package contains the Bash, Go, Rust and C implementations plus tcode."
+  fi
+
+  install_docs "$pkg_dir"
+  chmod 0644 "$pkg_dir/DEBIAN/control"
+  write_md5sums "$pkg_dir"
+  normalize_timestamps "$pkg_dir"
+  rm -f "$output"
+  dpkg-deb --root-owner-group -Zxz -z9 --build "$pkg_dir" "$output"
+  echo "已生成：$output"
+}
+
+build_package all
+build_package amd64
+build_package arm64


### PR DESCRIPTION
## 改动概述

- 新增 Debian 打包脚本，生成 `all`、`amd64`、`arm64` 三种软件包
- 架构无关包提供 Bash 实现；架构包提供 Bash、Go、Rust、C 实现和 `tcode`
- 补齐依赖、版权、变更日志、校验文件、可复现时间戳和文件所有权
- 新增普通推送及合并请求可运行的 Debian 软件包持续集成任务
- 标签发布复用已验证的软件包产物，并将三个软件包纳入校验和及发布附件

## 验证结果

- `bash -n scripts/build-deb.sh`
- `git diff --check`
- 持续集成工作流语法解析通过
- Ubuntu 24.04 容器构建三个软件包通过
- `lintian --display-info --pedantic` 通过
- `amd64` 软件包实际安装并验证 `bash-agent`、`goagent`、`rustagent`、`cagent`、`tcode`
- `all` 软件包实际安装并验证 `bash-agent`
