### PR TITLE
fix(c): preserve long JSONL conversation records during trim

### DIFF
--- a/c/store.c
+++ b/c/store.c
@@ -419,31 +419,52 @@ int store_conv_add_tool_results(const char *path, int count, const char **tool_u
 }
 
 int store_conv_line_count(const char *path, char ***out, int *out_count) {
+    *out = NULL;
+    *out_count = 0;
+
     FILE *f = fopen(path, "r");
-    if (!f) { *out = NULL; *out_count = 0; return -1; }
+    if (!f) return -1;
 
     int cap = 64;
     int count = 0;
-    char **lines = malloc(cap * sizeof(char*));
-    char linebuf[65536];
+    char **lines = malloc(cap * sizeof(char *));
+    char *line = NULL;
+    size_t line_cap = 0;
+    ssize_t read_len;
+    if (!lines) goto fail;
 
-    while (fgets(linebuf, sizeof(linebuf), f)) {
+    /* getline 会按真实换行符扩容，不能将超长 JSONL 记录误当成多行。 */
+    while ((read_len = getline(&line, &line_cap, f)) != -1) {
         /* 去除尾部换行 */
-        size_t len = strlen(linebuf);
-        while (len > 0 && (linebuf[len-1] == '\n' || linebuf[len-1] == '\r'))
-            linebuf[--len] = '\0';
+        size_t len = (size_t)read_len;
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+            line[--len] = '\0';
         if (len == 0) continue;
 
         if (count >= cap) {
-            cap *= 2;
-            lines = realloc(lines, cap * sizeof(char*));
+            int new_cap = cap * 2;
+            char **new_lines = realloc(lines, new_cap * sizeof(char *));
+            if (!new_lines) goto fail;
+            lines = new_lines;
+            cap = new_cap;
         }
-        lines[count++] = util_strdup(linebuf);
+        lines[count] = util_strdup(line);
+        if (!lines[count]) goto fail;
+        count++;
     }
+
+    free(line);
     fclose(f);
     *out = lines;
     *out_count = count;
     return 0;
+
+fail:
+    free(line);
+    fclose(f);
+    for (int i = 0; i < count; i++) free(lines[i]);
+    free(lines);
+    return -1;
 }
 
 int store_conv_trim_tail(const char *path, int keep_lines) {

--- a/c/test_continue.c
+++ b/c/test_continue.c
@@ -107,9 +107,61 @@ static void test_explicit_sub_session_paths_remain_available(void) {
     free(home);
 }
 
+static void test_conv_long_line_survives_trim(void) {
+    char *dir = make_temp_dir("conv-long-line");
+    char *path = util_path_join(dir, "conversation.jsonl");
+    StrBuf long_line;
+    sb_init(&long_line);
+    sb_append(&long_line, "{\"role\":\"user\",\"content\":\"");
+    for (int i = 0; i < 70000; i++) sb_append_char(&long_line, 'x');
+    sb_append(&long_line, "-long-record\"}");
+
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        check(0, "create long conversation fixture");
+        sb_free(&long_line);
+        free(path);
+        rmdir(dir);
+        free(dir);
+        return;
+    }
+    fprintf(f, "{\"role\":\"user\",\"content\":\"first\"}\n");
+    fprintf(f, "%s\n", long_line.data);
+    fprintf(f, "{\"role\":\"assistant\",\"content\":\"last\"}\n");
+    fclose(f);
+
+    char **lines = NULL;
+    int count = 0;
+    int read_ok = store_conv_line_count(path, &lines, &count) == 0 && count == 3
+        && strlen(lines[1]) == long_line.len
+        && json_parse_root(lines[1]).error == NULL;
+    check(read_ok, "read a JSONL record larger than 64 KiB as one line");
+    for (int i = 0; i < count; i++) free(lines[i]);
+    free(lines);
+
+    int trim_ok = store_conv_trim_tail(path, 2) == 0;
+    lines = NULL;
+    count = 0;
+    trim_ok = trim_ok && store_conv_line_count(path, &lines, &count) == 0 && count == 2
+        && strlen(lines[0]) == long_line.len
+        && strstr(lines[0], "-long-record\"}") != NULL
+        && json_parse_root(lines[0]).error == NULL
+        && json_parse_root(lines[1]).error == NULL;
+    check(trim_ok, "trim rewrites a JSONL record larger than 64 KiB without splitting it");
+    for (int i = 0; i < count; i++) free(lines[i]);
+    free(lines);
+
+    sb_free(&long_line);
+    unlink(path);
+    free(path);
+    rmdir(dir);
+    free(dir);
+}
+
 int main(void) {
     test_continue_skips_sub_sessions();
     test_continue_rejects_only_sub_sessions();
     test_explicit_sub_session_paths_remain_available();
+    test_conv_long_line_survives_trim();
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## 问题

C 版会话压缩通过固定 64 KiB 缓冲读取 `conversation.jsonl`。单条记录超过该长度时，会被误识别为多条物理记录，并在重写时插入换行，破坏 JSONL。

## 修复

- 改用可动态扩容、按真实换行符读取的 `getline()`。
- 补充分配失败时的清理路径。
- 新增超过 70,000 字节记录的读取与压缩重写回归测试。

## 验证

- `make -C c test-continue`
- `make build-c`
- `make test-c-e2e`（208 通过，0 失败）
- `git diff --check`