### PR TITLE
fix: request stream usage for OpenAI-compatible providers

### DIFF
--- a/c/transport.c
+++ b/c/transport.c
@@ -1281,7 +1281,7 @@ char *convert_to_openai(const char *claude_body) {
     sb_append_json_string(&result, model ? model : "");
     sb_append(&result, ",\"max_tokens\":");
     sb_appendf(&result, "%d", max_tokens);
-    sb_append(&result, ",\"stream\":true");
+    sb_append(&result, ",\"stream\":true,\"stream_options\":{\"include_usage\":true}");
 
     if (system_val.type != JSON_NULL) {
         char *sys = json_as_string(system_val);

--- a/go/transport.go
+++ b/go/transport.go
@@ -862,7 +862,10 @@ func (t *HTTPTransport) buildOpenAIBody(messages, systemPrompt, toolDefs string,
 		"model":      t.cfg.Model,
 		"max_tokens": maxTokens,
 		"stream":     true,
-		"messages":   converted,
+		"stream_options": map[string]interface{}{
+			"include_usage": true,
+		},
+		"messages": converted,
 	}
 	if thinking == "adaptive" || thinking == "enabled" {
 		body["thinking"] = map[string]interface{}{

--- a/rust/src/transport.rs
+++ b/rust/src/transport.rs
@@ -98,6 +98,7 @@ impl Transport for OpenAITransport {
             "model": model,
             "max_tokens": max_tokens,
             "stream": true,
+            "stream_options": {"include_usage": true},
             "messages": openai_messages,
         });
 

--- a/src/awk/transport_openai_body.awk
+++ b/src/awk/transport_openai_body.awk
@@ -35,7 +35,7 @@ END {
     }
 
     # 4. Build output JSON
-    result = "{\"model\":\"" model "\",\"max_tokens\":" max_tokens ",\"stream\":true"
+    result = "{\"model\":\"" model "\",\"max_tokens\":" max_tokens ",\"stream\":true,\"stream_options\":{\"include_usage\":true}"
 
     # thinking adaptive/enabled -> OpenAI enabled + reasoning_effort
     thinking_type = ""


### PR DESCRIPTION
## 问题

使用 Kimi（Moonshot）等 OpenAI 兼容 chat completions **流式**接口时，所有 usage/token 事件解析全为 0。

根因：按 OpenAI 规范，流式响应默认**不在**最后的 SSE chunk 中返回 usage，必须由客户端显式请求：

```json
{"stream": true, "stream_options": {"include_usage": true}}
```

此前请求体未携带该字段，服务端不回 usage，导致四个运行时的 token 统计、compact 预算决策全部失效。

## 修改

四运行时同步修改，在 OpenAI 请求体 `"stream": true` 之后**无条件**追加 `"stream_options": {"include_usage": true}`：

| 文件 | 运行时 |
|------|--------|
| `src/awk/transport_openai_body.awk` | Bash（基准） |
| `go/transport.go` | Go |
| `rust/src/transport.rs` | Rust |
| `c/transport.c` | C |

字段位置四端逐字对齐（`stream` 之后），符合项目"请求体一致性"原则。

## 兼容性

`stream_options.include_usage` 是 **OpenAI 官方规范字段**：

- DeepSeek / Kimi / GLM / DashScope / Ark / OpenRouter / vLLM / Ollama 等均支持，或宽松忽略未知字段
- 最坏情况：服务端仍不回 usage —— 与修改前行为完全一致，**无回归**
- 因此不加条件开关，无条件添加

## 验证

**e2e（mock server，串行执行）**：

| 版本 | 结果 |
|------|------|
| Go | 221 passed / 0 failed |
| Rust | 221 passed / 0 failed |
| C | 221 passed / 0 failed |
| Bash | awk body 转换用例随 test.sh 通过 |

**真实 Kimi 端点实测**（`kimi-k3`，改动前 usage 全 0）：

| 版本 | usage 事件 |
|------|-----------|
| Bash | `input_tokens=6245, output_tokens=44` ✅ |
| Go | `input_tokens=6809, output_tokens=65` ✅ |
| Rust | `input_tokens=6247, output_tokens=96` ✅ |
| C | `input_tokens=6170, output_tokens=60` ✅ |
