### PR TITLE
fix(rust): Android 交叉编译兼容（errno 分支 + Makefile 目标）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: build build-bash build-go build-rust build-tcode build-c build-webagent build-webagent-android build-deb test test-bash test-go test-rust test-go-e2e test-rust-e2e test-c-e2e test-c-classify test-c-transport update-system-prompt-golden clean
+.PHONY: build build-bash build-go build-rust build-tcode build-c build-webagent build-webagent-android build-rustagent-android build-deb test test-bash test-go test-rust test-go-e2e test-rust-e2e test-c-e2e test-c-classify test-c-transport update-system-prompt-golden clean
 
 VERSION ?=
 DEB_DIST_DIR ?= dist
@@ -21,11 +21,6 @@ build-rust:
 	cp rust/target/release/rustagent dist/rustagent
 	strip -x dist/rustagent
 
-build-rust2:
-	cd rust2 && cargo build --release -j 10
-	cp rust2/target/release/rust2agent dist/rust2agent
-	strip -x dist/rust2agent
-
 build-tcode:
 	cp scripts/tcode dist/tcode
 	chmod +x dist/tcode
@@ -36,10 +31,21 @@ build-webagent:
 	cp webagent/target/release/webagent dist/webagent
 	strip -x dist/webagent
 
+# 交叉编译 rustagent 到 Android (Termux) — 需要 NDK
+# 说明：NDK 只有带 API level 的 clang，cc-rs（ring）探测不到
+# aarch64-linux-android-clang 通用名，必须用 env 显式指定 CC/AR
+# （变量名含 '-'，bash 无法直接赋值，需经 env 命令传入）
+NDK_TOOLCHAIN = $(NDK)/toolchains/llvm/prebuilt/darwin-x86_64/bin
+ANDROID_CC = $(NDK_TOOLCHAIN)/aarch64-linux-android27-clang
+ANDROID_ENV = env 'CC_aarch64-linux-android=$(ANDROID_CC)' 'AR_aarch64-linux-android=$(NDK_TOOLCHAIN)/llvm-ar' CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER='$(ANDROID_CC)'
+build-rustagent-android:
+	@test -n "$(NDK)" || { echo "用法：make build-rustagent-android NDK=/path/to/android-ndk" >&2; exit 2; }
+	cd rust && $(ANDROID_ENV) cargo build --release --target aarch64-linux-android -j 10
+	cp rust/target/aarch64-linux-android/release/rustagent dist/rustagent-android
+
 # 交叉编译 webagent 到 Android (Termux) — 需要 NDK
-build-webagent-android:
-	@test -n "$(NDK)" || { echo "用法：make build-webagent-android NDK=/path/to/android-ndk" >&2; exit 2; }
-	cd webagent && CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$(NDK)/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android27-clang" cargo build --release --target aarch64-linux-android -j 10
+build-webagent-android: build-rustagent-android
+	cd webagent && $(ANDROID_ENV) cargo build --release --target aarch64-linux-android -j 10
 	cp webagent/target/aarch64-linux-android/release/webagent dist/webagent-android
 
 build-c:

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -1023,6 +1023,10 @@ impl Agent {
                     unsafe {
                         *libc::__error() = 0
                     };
+                    #[cfg(target_os = "android")]
+                    unsafe {
+                        *libc::__errno() = 0
+                    };
                     #[cfg(target_os = "linux")]
                     unsafe {
                         *libc::__errno_location() = 0
@@ -1075,6 +1079,8 @@ impl Agent {
                             let err = unsafe { *libc::__error() };
                             #[cfg(target_os = "linux")]
                             let err = unsafe { *libc::__errno_location() };
+                            #[cfg(target_os = "android")]
+                            let err = unsafe { *libc::__errno() };
                             if err == libc::EAGAIN {
                                 break Err(ffi::LineError::Interrupted);
                             }

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -202,6 +202,10 @@ pub fn line(prompt: &str) -> Result<String, LineError> {
     unsafe {
         *libc::__error() = 0
     };
+    #[cfg(target_os = "android")]
+    unsafe {
+        *libc::__errno() = 0
+    };
     #[cfg(target_os = "linux")]
     unsafe {
         *libc::__errno_location() = 0
@@ -214,6 +218,8 @@ pub fn line(prompt: &str) -> Result<String, LineError> {
         let err = unsafe { *libc::__error() };
         #[cfg(target_os = "linux")]
         let err = unsafe { *libc::__errno_location() };
+        #[cfg(target_os = "android")]
+        let err = unsafe { *libc::__errno() };
         if err == libc::EAGAIN {
             Err(LineError::Interrupted)
         } else if err == libc::ENOENT || err == 0 {


### PR DESCRIPTION
## 问题

`make build-rustagent-android`（aarch64-linux-android 交叉编译）失败，两层原因：

### 1. errno 代码缺少 android 分支（编译错误 ×5）

`rust/src/ffi/mod.rs` 与 `rust/src/agent.rs` 中 errno 读取/重置只有 macos/linux 两个 cfg 分支，android（bionic）下全部不命中：

```rust
#[cfg(target_os = "macos")]
let err = unsafe { *libc::__error() };
#[cfg(target_os = "linux")]
let err = unsafe { *libc::__errno_location() };
// android: err 未定义 → error[E0425] cannot find value `err` ×5
```

修法与 `feat/rust-serve` 分支 `b4a39e9` 当时一致（android 用 `libc::__errno()`），并补齐其漏掉的 agent.rs clear errno 处，共 4 处。

### 2. cc-rs（ring 0.17.14）探测不到 NDK 编译器

```
error occurred in cc-rs: failed to find tool "aarch64-linux-android-clang"
```

- NDK r27d 只提供带 API level 的 `aarch64-linux-android27-clang`，无通用名
- `CARGO_TARGET_AARCH64_LINUX_ANDROID_CC` 变量名格式 cc-rs 不识别，需用 `CC_aarch64-linux-android`（target 横线转下划线）
- 变量名含 `-`，bash 无法直接赋值，须经 `env` 命令注入

## 改动

| 文件 | 内容 |
|---|---|
| `rust/src/ffi/mod.rs` | errno 读取/重置 + android 分支（`libc::__errno()`）×2 |
| `rust/src/agent.rs` | 同上 ×2（含 b4a39e9 漏掉的 clear 处） |
| `Makefile` | 新增独立目标 `build-rustagent-android`；`build-webagent-android` 依赖之；`ANDROID_ENV` 统一注入 CC/AR/LINKER；移除失效的 `build-rust2` |

## 验证

- `make build-rustagent-android NDK=~/android-sdk/android-ndk-r27d` ✅
- 产物 `dist/rustagent-android`（3.4M）：ELF aarch64 PIE，interpreter `/system/bin/linker64`，仅依赖 bionic libc/libm/libdl
- 宿主 `cargo check --release` 不受影响 ✅

## 使用

```bash
make build-rustagent-android NDK=/path/to/android-ndk
```

> Draft：待 Termux 实机验证后再合并。

> 说明：不含 `feat/rust-serve` 的 --serve 功能（b4a39e9 提交里混在一起，本 PR 只提取 android 兼容部分）。