### PR TITLE
feat(webagent): 行号块整块滚动 / mobile 统计精简 / 图片上传

### DIFF
--- a/webagent/src/index.html
+++ b/webagent/src/index.html
@@ -237,33 +237,44 @@ details.row[open] > summary .chev { transform: rotate(45deg); }
 .diffhead .path { color: var(--label-secondary); overflow: hidden;
   text-overflow: ellipsis; }
 .diffhead .add { color: var(--ok-400); } .diffhead .del { color: var(--red-400); }
-.diff { margin: 0 10px; border-radius: 8px; overflow: hidden;
+.diff { margin: 0 10px; border-radius: 8px; overflow-x: auto; overflow-y: hidden;
   border: 1px solid var(--border-l1); font-family: var(--font-code);
   font-size: 12px; line-height: 18px; }
 .diff .dl { display: grid; grid-template-columns: 3.5ch 3.5ch minmax(0,1fr);
-  white-space: pre; }
+  white-space: pre; width: max-content; min-width: 100%; }
 .diff .ln { color: var(--label-caption); text-align: right; padding: 0 6px 0 4px;
-  user-select: none; }
-.diff .txt { padding-right: 12px; overflow-x: auto; overflow-y: hidden;
+  user-select: none; position: sticky; background: var(--code-block); }
+.diff .ln.a { left: 0; } .diff .ln.b { left: calc(3.5ch + 10px); }
+.diff .txt { padding-right: 12px;
   white-space: pre; overflow-wrap: normal; }
 .diff .dl.ctx .txt { color: var(--label-secondary); }
 .diff .dl.add { background: rgba(90,200,120,.12); }
 .diff .dl.add .txt { color: var(--label-primary); }
+.diff .dl.add .ln { background:
+  linear-gradient(rgba(90,200,120,.12), rgba(90,200,120,.12)), var(--code-block); }
 .diff .dl.del { background: rgba(242,90,90,.12); }
 .diff .dl.del .txt { color: var(--label-primary); }
+.diff .dl.del .ln { background:
+  linear-gradient(rgba(242,90,90,.12), rgba(242,90,90,.12)), var(--code-block); }
 .diff .dl.hunk { background: var(--hover); }
 .diff .dl.hunk .txt { color: var(--label-tertiary); }
 .diff .dl.meta .txt { color: var(--label-caption); }
 html[data-theme=light] .diff .dl.add { background: rgba(66,176,98,.12); }
+html[data-theme=light] .diff .dl.add .ln { background:
+  linear-gradient(rgba(66,176,98,.12), rgba(66,176,98,.12)), var(--code-block); }
 html[data-theme=light] .diff .dl.del { background: rgba(236,19,19,.08); }
+html[data-theme=light] .diff .dl.del .ln { background:
+  linear-gradient(rgba(236,19,19,.08), rgba(236,19,19,.08)), var(--code-block); }
 
 /* 带行号的代码块（Read / Write 展示，对齐 CLI 行号 display） */
-.codelines { padding: 8px 0; min-width: 0; }
+.codelines { padding: 8px 0; min-width: 0; overflow-x: auto; }
 .codelines .dl { display: grid; grid-template-columns: 5ch minmax(0,1fr);
-  font-family: var(--font-code); font-size: 12px; line-height: 18px; }
+  font-family: var(--font-code); font-size: 12px; line-height: 18px;
+  width: max-content; min-width: 100%; }
 .codelines .ln { color: var(--label-caption); text-align: right;
-  padding: 0 8px 0 4px; user-select: none; }
-.codelines .txt { padding-right: 12px; overflow-x: auto; overflow-y: hidden;
+  padding: 0 8px 0 4px; user-select: none; position: sticky; left: 0;
+  background: var(--code-block); }
+.codelines .txt { padding-right: 12px;
   white-space: pre; color: var(--label-secondary); overflow-wrap: normal; }
 .codelines.add .txt { color: var(--label-primary); }
 .codelines.add .ln { color: var(--ok-400); }
@@ -309,6 +320,16 @@ html[data-theme=light] .diff .dl.del { background: rgba(236,19,19,.08); }
   overflow: hidden; flex: none; }
 #ctxbar i { display: block; height: 100%; width: 0%;
   background: var(--brand); border-radius: 2px; transition: width .3s; }
+#statsline .hud-full { display: inline; }
+#statsline .hud-short { display: none; }
+@media (max-width: 640px) {
+  #statsline { gap: 8px; padding: 0 10px; }
+  #statsline .seg[data-k=model], #statsline .seg[data-k=in],
+  #statsline .seg[data-k=out], #statsline .seg[data-k=cc] { display: none; }
+  #statsline .hud-full { display: none; }
+  #statsline .hud-short { display: inline; }
+  #ctxbar { width: 44px; }
+}
 #ctxbar.warn i { background: var(--warn); }
 #ctxbar.full i { background: var(--error); }
 
@@ -364,8 +385,17 @@ html[data-theme=light] .diff .dl.del { background: rgba(236,19,19,.08); }
   padding: 0; }
 #input::placeholder { color: var(--label-caption); user-select: none; }
 .composer-row { display: flex; align-items: center; gap: 10px; margin-top: 8px; }
+#attach { flex: none; width: 30px; height: 30px; border-radius: 50%; border: none;
+  background: transparent; color: var(--label-caption); cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; padding: 0; }
+#attach:hover { background: var(--hover); color: var(--label-secondary); }
+#attach:disabled { opacity: .5; cursor: wait; }
+#attach svg { width: 16px; height: 16px; }
+#attach.spin svg { animation: attachspin 1s linear infinite; }
+@keyframes attachspin { to { transform: rotate(360deg); } }
 .hint { flex: 1; font-size: 12px; line-height: 18px; color: var(--label-caption);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hint.err { color: var(--error); }
 #send { flex: none; width: 34px; height: 34px; border-radius: 50%; border: none;
   background: var(--brand-fill); color: #fff; cursor: pointer;
   display: inline-flex; align-items: center; justify-content: center; padding: 0; }
@@ -421,6 +451,10 @@ html[data-theme=light] .diff .dl.del { background: rgba(236,19,19,.08); }
     <div class="composer">
       <textarea id="input" placeholder="给 bash-agent 发送消息…" rows="1" autofocus></textarea>
       <div class="composer-row">
+        <input type="file" id="filepick" accept="image/png,image/jpeg,image/webp" hidden>
+        <button id="attach" aria-label="上传图片" title="上传图片">
+          <svg viewBox="0 0 24 24" fill="none"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
         <span class="hint" id="hint">Enter 发送 · Shift+Enter 换行</span>
         <button id="send" aria-label="发送">
           <svg viewBox="0 0 16 16" fill="none"><path d="M8 13V3M4 7l4-4 4 4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -498,28 +532,37 @@ var CFG = __WEBAGENT_CONFIG__;
     if (n >= 1000) return (n / 1000).toFixed(n % 1000 === 0 ? 0 : 1) + 'K';
     return '' + n;
   }
-  function hudSeg(text, cls) {
+  function hudSeg(text, cls, key, full, short) {
     var s = document.createElement('span'); s.className = 'seg' + (cls ? ' ' + cls : '');
-    s.textContent = text; return s;
+    if (key) s.setAttribute('data-k', key);
+    if (full !== undefined) {
+      var f = document.createElement('span'); f.className = 'hud-full'; f.textContent = full;
+      var h = document.createElement('span'); h.className = 'hud-short'; h.textContent = short;
+      s.appendChild(f); s.appendChild(h);
+    } else s.textContent = text;
+    return s;
   }
   function renderHud() {
     var ie = H.tin + H.cr;
     var pct = ie > 0 ? Math.round(H.cr / ie * 100) + '%' : '—';
     statsline.textContent = '';
-    if (MODEL) statsline.appendChild(hudSeg(MODEL, 'model'));
+    if (MODEL) statsline.appendChild(hudSeg(MODEL, 'model', 'model'));
     // 上下文占用 = 最近一次请求的 input+cache_read+cache_creation+output
-    var seg = hudSeg('上下文 ' + fmtK(H.ctx) + '/' + fmtK(MAXCTX) + ' · ' +
-      (H.ctx > 0 ? Math.round(H.ctx / MAXCTX * 100) + '%' : '—'));
+    var seg = hudSeg('', '', 'ctx',
+      '上下文 ' + fmtK(H.ctx) + '/' + fmtK(MAXCTX) + ' · ' +
+        (H.ctx > 0 ? Math.round(H.ctx / MAXCTX * 100) + '%' : '—'),
+      fmtK(H.ctx) + ' · ' + (H.ctx > 0 ? Math.round(H.ctx / MAXCTX * 100) + '%' : '—'));
     var bar = document.createElement('span'); bar.id = 'ctxbar';
     var fill = document.createElement('i'); bar.appendChild(fill);
     var ratio = H.ctx / MAXCTX;
     fill.style.width = Math.min(100, Math.round(ratio * 100)) + '%';
     if (ratio >= 0.9) bar.className = 'full'; else if (ratio >= 0.8) bar.className = 'warn';
     seg.appendChild(bar); statsline.appendChild(seg);
-    statsline.appendChild(hudSeg('输入 ' + fmtK(ie) + '（缓存 ' + pct + '）'));
-    statsline.appendChild(hudSeg('输出 ' + fmtK(H.tout)));
-    statsline.appendChild(hudSeg('对话 ' + H.turn + ' 轮 · ' + H.req + ' 请求'));
-    if (H.cc > 0) statsline.appendChild(hudSeg('压缩 ' + fmtK(H.cc)));
+    statsline.appendChild(hudSeg('输入 ' + fmtK(ie) + '（缓存 ' + pct + '）', '', 'in'));
+    statsline.appendChild(hudSeg('输出 ' + fmtK(H.tout), '', 'out'));
+    statsline.appendChild(hudSeg('', '', 'turn',
+      '对话 ' + H.turn + ' 轮 · ' + H.req + ' 请求', H.turn + '轮·' + H.req + 'req'));
+    if (H.cc > 0) statsline.appendChild(hudSeg('压缩 ' + fmtK(H.cc), '', 'cc'));
   }
   function hudReset() { H.turn = 0; H.req = 0; H.tin = 0; H.tout = 0; H.cr = 0; H.cc = 0; H.ctx = 0; renderHud(); }
 
@@ -1142,23 +1185,23 @@ var CFG = __WEBAGENT_CONFIG__;
       if (hunk) {
         oldNo = +hunk[1]; newNo = +hunk[2];
         row = el('div', 'dl hunk');
-        o = el('span', 'ln'); n = el('span', 'ln');
+        o = el('span', 'ln a'); n = el('span', 'ln b');
         t = el('span', 'txt'); t.textContent = '  ' + ln;
       } else if (/^(--- |\+\+\+ )/.test(ln)) {
         row = el('div', 'dl meta');
-        o = el('span', 'ln'); n = el('span', 'ln');
+        o = el('span', 'ln a'); n = el('span', 'ln b');
         t = el('span', 'txt'); t.textContent = ln;
       } else if (ln.charAt(0) === '+') {
         row = el('div', 'dl add');
-        o = el('span', 'ln'); n = el('span', 'ln'); n.textContent = newNo++;
+        o = el('span', 'ln a'); n = el('span', 'ln b'); n.textContent = newNo++;
         t = el('span', 'txt'); t.textContent = ln;
       } else if (ln.charAt(0) === '-') {
         row = el('div', 'dl del');
-        o = el('span', 'ln'); o.textContent = oldNo++; n = el('span', 'ln');
+        o = el('span', 'ln a'); o.textContent = oldNo++; n = el('span', 'ln b');
         t = el('span', 'txt'); t.textContent = ln;
       } else {
         row = el('div', 'dl ctx');
-        o = el('span', 'ln'); o.textContent = oldNo++; n = el('span', 'ln'); n.textContent = newNo++;
+        o = el('span', 'ln a'); o.textContent = oldNo++; n = el('span', 'ln b'); n.textContent = newNo++;
         t = el('span', 'txt'); t.textContent = ln;
       }
       row.appendChild(o); row.appendChild(n); row.appendChild(t);
@@ -1396,6 +1439,57 @@ var CFG = __WEBAGENT_CONFIG__;
   }
   sendBtn.addEventListener('click', sendMsg);
   ta.addEventListener('input', grow);
+
+  /* ------------------------------------------------------------ 图片上传（对齐 CLI [Image #N] 机制） */
+  var attachBtn = document.getElementById('attach');
+  var filepick = document.getElementById('filepick');
+  var hintEl = document.getElementById('hint');
+  var HINT_DEFAULT = hintEl.textContent;
+  function insertAtCursor(text) {
+    var s = ta.selectionStart, e = ta.selectionEnd, v = ta.value;
+    ta.value = v.slice(0, s) + text + v.slice(e);
+    ta.selectionStart = ta.selectionEnd = s + text.length;
+    grow(); ta.focus();
+  }
+  function uploadImage(file) {
+    if (!file) return;
+    if (!/^image\//.test(file.type)) { addErrorRow('上传失败', '仅支持 PNG / JPEG / WebP 图片'); return; }
+    if (file.size > 8 * 1024 * 1024) { addErrorRow('上传失败', '图片超过 8MB 限制'); return; }
+    attachBtn.disabled = true; attachBtn.classList.add('spin');
+    hintEl.textContent = '上传 ' + (file.name || '图片') + '…';
+    fetch('/upload', { method: 'POST', body: file })
+      .then(function (r) {
+        return r.text().then(function (t) {
+          if (!r.ok) throw new Error(t.replace(/^"|"$/g, '') || ('HTTP ' + r.status));
+          try { return JSON.parse(t).placeholder; } catch (e) { throw new Error('bad response'); }
+        });
+      })
+      .then(function (ph) { insertAtCursor(ph + ' '); })
+      .catch(function (e) { addErrorRow('上传失败', String(e.message || e)); })
+      .finally(function () {
+        attachBtn.disabled = false; attachBtn.classList.remove('spin');
+        hintEl.textContent = HINT_DEFAULT;
+      });
+  }
+  attachBtn.addEventListener('click', function () { filepick.click(); });
+  filepick.addEventListener('change', function () {
+    uploadImage(filepick.files && filepick.files[0]);
+    filepick.value = '';
+  });
+  ta.addEventListener('paste', function (e) {
+    var files = e.clipboardData && e.clipboardData.files;
+    if (files && files.length && /^image\//.test(files[0].type)) {
+      e.preventDefault();
+      uploadImage(files[0]);
+    }
+  });
+  ta.addEventListener('dragover', function (e) { e.preventDefault(); });
+  ta.addEventListener('drop', function (e) {
+    e.preventDefault();
+    var files = e.dataTransfer && e.dataTransfer.files;
+    if (files && files.length) uploadImage(files[0]);
+  });
+
   ta.addEventListener('keydown', function (e) {
     if (e.key === 'Enter') {
       if (e.shiftKey || e.ctrlKey || e.metaKey) { return; } // allow newline

--- a/webagent/src/index.html
+++ b/webagent/src/index.html
@@ -239,12 +239,13 @@ details.row[open] > summary .chev { transform: rotate(45deg); }
 .diffhead .add { color: var(--ok-400); } .diffhead .del { color: var(--red-400); }
 .diff { margin: 0 10px; border-radius: 8px; overflow-x: auto; overflow-y: hidden;
   border: 1px solid var(--border-l1); font-family: var(--font-code);
-  font-size: 12px; line-height: 18px; }
-.diff .dl { display: grid; grid-template-columns: 3.5ch 3.5ch minmax(0,1fr);
+  font-size: 12px; line-height: 18px; --diff-ln: 3.5ch; }
+.diff .dl { display: grid; grid-template-columns: var(--diff-ln) var(--diff-ln) minmax(0,1fr);
   white-space: pre; width: max-content; min-width: 100%; }
 .diff .ln { color: var(--label-caption); text-align: right; padding: 0 6px 0 4px;
   user-select: none; position: sticky; background: var(--code-block); }
-.diff .ln.a { left: 0; } .diff .ln.b { left: calc(3.5ch + 10px); }
+/* border-box 下 grid item 宽 = track 宽，.ln.b 偏移即 --diff-ln（padding 已含在 track 内，多算会漏缝） */
+.diff .ln.a { left: 0; } .diff .ln.b { left: var(--diff-ln); }
 .diff .txt { padding-right: 12px;
   white-space: pre; overflow-wrap: normal; }
 .diff .dl.ctx .txt { color: var(--label-secondary); }

--- a/webagent/src/index.html
+++ b/webagent/src/index.html
@@ -257,6 +257,7 @@ details.row[open] > summary .chev { transform: rotate(45deg); }
 .diff .dl.del .ln { background:
   linear-gradient(rgba(242,90,90,.12), rgba(242,90,90,.12)), var(--code-block); }
 .diff .dl.hunk { background: var(--hover); }
+.diff .dl.hunk .ln { background: var(--hover); }
 .diff .dl.hunk .txt { color: var(--label-tertiary); }
 .diff .dl.meta .txt { color: var(--label-caption); }
 html[data-theme=light] .diff .dl.add { background: rgba(66,176,98,.12); }

--- a/webagent/src/index.html
+++ b/webagent/src/index.html
@@ -364,11 +364,15 @@ html[data-theme=light] .diff .dl.del .ln { background:
   max-height: 180px; overflow-y: auto; }
 #todoPanel .tpli { display: flex; align-items: center; gap: 10px; min-width: 0;
   font-size: 13px; line-height: 20px; color: var(--label-secondary); }
-#todoPanel .glyph { display: inline-grid; flex: none; place-items: center;
+#todoPanel .glyph { display: inline-flex; flex: none; align-items: center; justify-content: center;
   width: 16px; height: 16px; }
 #todoPanel .g-done { color: var(--ok-400); }
 #todoPanel .g-pend { color: var(--label-caption); }
-#todoPanel .g-prog { color: var(--brand); animation: tp-spin 1s linear infinite; }
+#todoPanel .g-prog { display: inline-flex; align-items: center; justify-content: center;
+  width: 14px; height: 14px; color: var(--brand); }
+#todoPanel .g-prog svg { display: block; width: 14px; height: 14px;
+  transform-box: fill-box; transform-origin: center center;
+  animation: tp-spin 1s linear infinite; }
 @keyframes tp-spin { to { transform: rotate(360deg); } }
 #todoPanel .tpct { min-width: 0; overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; }

--- a/webagent/src/index.html
+++ b/webagent/src/index.html
@@ -240,8 +240,10 @@ details.row[open] > summary .chev { transform: rotate(45deg); }
 .diff { margin: 0 10px; border-radius: 8px; overflow-x: auto; overflow-y: hidden;
   border: 1px solid var(--border-l1); font-family: var(--font-code);
   font-size: 12px; line-height: 18px; --diff-ln: 3.5ch; }
+/* 所有行共享一条统一宽度的轨道；否则短行自身宽度较小，sticky 行号会受短行边界限制 */
+.diffbody { display: grid; width: max-content; min-width: 100%; }
 .diff .dl { display: grid; grid-template-columns: var(--diff-ln) var(--diff-ln) minmax(0,1fr);
-  white-space: pre; width: max-content; min-width: 100%; }
+  white-space: pre; width: 100%; min-width: 0; }
 .diff .ln { color: var(--label-caption); text-align: right; padding: 0 6px 0 4px;
   user-select: none; position: sticky; background: var(--code-block); }
 /* border-box 下 grid item 宽 = track 宽，.ln.b 偏移即 --diff-ln（padding 已含在 track 内，多算会漏缝） */
@@ -1175,7 +1177,8 @@ var CFG = __WEBAGENT_CONFIG__;
       head.appendChild(pl); head.appendChild(pa); head.appendChild(pd);
     }
     wrap.appendChild(head);
-    var tbl = el('div', 'diff');
+    var tbl = el('div', 'diffbody');
+    var scroll = el('div', 'diff'); scroll.appendChild(tbl);
     var lines = text.split('\n');
     var oldNo = 0, newNo = 0;
     var start = m ? 1 : 0; // 命中摘要则跳过首行
@@ -1209,7 +1212,7 @@ var CFG = __WEBAGENT_CONFIG__;
       row.appendChild(o); row.appendChild(n); row.appendChild(t);
       tbl.appendChild(row);
     }
-    wrap.appendChild(tbl);
+    wrap.appendChild(scroll);
     return wrap;
   }
 

--- a/webagent/src/server.rs
+++ b/webagent/src/server.rs
@@ -447,12 +447,27 @@ fn handle_upload(
             .open(&cand)
         {
             Ok(mut f) => {
-                f.write_all(&body)?;
+                if let Err(e) = f.write_all(&body) {
+                    // IO 失败兜底 500：不让连接静默断掉，前端 errorrow 能显示具体原因
+                    return serve_status(
+                        stream,
+                        500,
+                        &serde_json::json!({"error": format!("write image: {e}")}).to_string(),
+                        "application/json",
+                    );
+                }
                 path = cand;
                 break;
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => n += 1,
-            Err(e) => return Err(anyhow::anyhow!("create image: {e}")),
+            Err(e) => {
+                return serve_status(
+                    stream,
+                    500,
+                    &serde_json::json!({"error": format!("create image: {e}")}).to_string(),
+                    "application/json",
+                )
+            }
         }
     }
     let resp = serde_json::json!({

--- a/webagent/src/server.rs
+++ b/webagent/src/server.rs
@@ -85,6 +85,7 @@ impl WsHub {
 ///   GET /              -> index.html（内嵌单页 UI）
 ///   GET /manifest.json -> PWA manifest
 ///   GET /icon.svg      -> logo
+///   POST /upload       -> 图片二进制落盘 <session_dir>/images/{n}.png（对齐 CLI [Image #N]）
 ///   GET /ws            -> WebSocket 升级（交给 tungstenite 完成握手，避免预读丢帧）
 fn handle_connection(
     mut stream: TcpStream,
@@ -140,6 +141,10 @@ fn handle_connection(
     }
     if path == "/icon.svg" {
         serve_static(&mut stream, ICON_SVG.as_bytes(), "image/svg+xml")?;
+        return Ok(());
+    }
+    if path == "/upload" {
+        handle_upload(&mut stream, &request_head, &events_path)?;
         return Ok(());
     }
 
@@ -334,6 +339,127 @@ fn serve_static(stream: &mut TcpStream, body: &[u8], ctype: &str) -> Result<()> 
     stream.write_all(body)?;
     stream.flush()?;
     Ok(())
+}
+
+/// 带状态码的纯文本/JSON 响应。
+fn serve_status(stream: &mut TcpStream, code: u16, body: &str, ctype: &str) -> Result<()> {
+    let reason = match code {
+        200 => "OK",
+        400 => "Bad Request",
+        405 => "Method Not Allowed",
+        409 => "Conflict",
+        411 => "Length Required",
+        413 => "Payload Too Large",
+        _ => "Error",
+    };
+    let headers = format!(
+        "HTTP/1.1 {code} {reason}\r\nContent-Type: {ctype}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(headers.as_bytes())?;
+    stream.write_all(body.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+
+/// POST /upload：把请求 body（图片二进制）写入 <session_dir>/images/{n}.png，
+/// 返回 {"placeholder":"[Image #n]","path":...}。
+/// 与 CLI 侧 agent_image_next_name / expand_image_placeholders 同一约定：
+/// 用户输入含 [Image #n] 时 agent 自动展开为绝对路径映射，agent 零改动。
+fn handle_upload(
+    stream: &mut TcpStream,
+    request_head: &[u8],
+    events_path: &EventsPath,
+) -> Result<()> {
+    const MAX_UPLOAD: usize = 8 * 1024 * 1024;
+    let head = String::from_utf8_lossy(request_head);
+    let method = head
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().next())
+        .unwrap_or("");
+    if method != "POST" {
+        return serve_status(stream, 405, "method not allowed", "text/plain");
+    }
+    let content_length = head.lines().find_map(|l| {
+        let (k, v) = l.split_once(':')?;
+        k.trim()
+            .eq_ignore_ascii_case("content-length")
+            .then(|| v.trim().parse::<usize>().ok())
+            .flatten()
+    });
+    let Some(len) = content_length else {
+        return serve_status(stream, 411, "length required", "text/plain");
+    };
+    if len > MAX_UPLOAD {
+        return serve_status(stream, 413, "payload too large", "text/plain");
+    }
+    // 请求头已读到 \r\n\r\n；body 可能已有前缀被一并读进 request_head
+    let head_end = request_head
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|i| i + 4)
+        .unwrap_or(request_head.len());
+    let mut body = request_head[head_end..].to_vec();
+    body.truncate(len);
+    let mut buf = [0u8; 8192];
+    while body.len() < len {
+        let n = stream
+            .read(&mut buf)
+            .map_err(|e| anyhow::anyhow!("read body: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        let take = (len - body.len()).min(n);
+        body.extend_from_slice(&buf[..take]);
+    }
+    if body.len() != len || body.is_empty() {
+        return serve_status(stream, 400, "bad request", "text/plain");
+    }
+    // session 目录由 events.jsonl 路径派生（同一 session_dir 下的 images/）
+    let dir = events_path
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|p| p.parent())
+        .map(|d| d.join("images"));
+    let Some(dir) = dir else {
+        return serve_status(
+            stream,
+            409,
+            r#"{"error":"session not started"}"#,
+            "application/json",
+        );
+    };
+    fs::create_dir_all(&dir).ok();
+    // 起始序号对齐 agent_image_next_name（现有 png 数 + 1）；
+    // create_new 原子占名，并发上传时冲突自动递增，天然不撞名
+    let mut n: usize = fs::read_dir(&dir)
+        .map(|it| it.filter_map(|e| e.ok()).count())
+        .unwrap_or(0)
+        + 1;
+    let path;
+    loop {
+        let cand = dir.join(format!("{n}.png"));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&cand)
+        {
+            Ok(mut f) => {
+                f.write_all(&body)?;
+                path = cand;
+                break;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => n += 1,
+            Err(e) => return Err(anyhow::anyhow!("create image: {e}")),
+        }
+    }
+    let resp = serde_json::json!({
+        "placeholder": format!("[Image #{n}]"),
+        "path": path.display().to_string(),
+    });
+    serve_status(stream, 200, &resp.to_string(), "application/json")
 }
 
 /// serve 服务器句柄：hub 用于广播，input_rx 接收用户输入行。


### PR DESCRIPTION
## 概要

webagent 三项体验改进，仅动 `webagent/` crate，agent 侧（bash/go/rust/c）零改动。

### 1. 行号块整块横向滚动

**问题**：Edit diff / Write·Read 行号块里每行 `.txt` 自带 `overflow-x: auto`，超宽时逐行各自滚动（行与行错位），行号还会被滚走。

**方案**：
- `.diff` / `.codelines` 容器承担 `overflow-x: auto`；行 `.dl` 改 `width: max-content; min-width: 100%`，删 `.txt` 的行内滚动
- 行号列 `position: sticky` 钉在左缘：diff 双行号列 `.ln.a { left: 0 }`、`.ln.b { left: calc(3.5ch + 10px) }`（第二列偏移 = 第一列 track 宽 + padding，与 grid 列定义保持同步）
- add/del 行号背景改为 `linear-gradient(行tint色), var(--code-block)` 双层背景，滚动时遮住穿透的内容且行色一致；light 主题同步

### 2. mobile 统计行精简

**问题**：≤640px 视口下统计行（`model · 上下文 x/200K · 输入… · 输出… · 对话… · 压缩…`）塞不下，被 `overflow: hidden` 截断看不全。

**方案**：
- `hudSeg` 输出段加 `data-k`（model/ctx/in/out/turn/cc）；ctx 与 turn 段渲染 `hud-full` / `hud-short` 双文案
- `@media (max-width: 640px)`：隐藏 model / in / out / cc 段；ctx 显示短文案 `32.2K · 16%`（+44px 进度条）；turn 显示 `5轮·5req`
- desktop（>640px）文案与现状完全一致，无回归

### 3. 图片上传（对齐 CLI `[Image #N]` 机制）

**目标**：手机浏览器贴图给 agent，与 CLI 剪贴板粘贴 `[Image #N]` 同一通路，agent 零改动（`expand_image_placeholders` 照常展开为 `<attached-images>` 绝对路径映射）。

**服务端** `POST /upload`：
- 目录从 `events.jsonl` 路径派生（`<session_dir>/images/`），复用现有 `EventsPath` 状态，**零新增参数**，`--session`/`--continue`/动态 session_start 三种来源自动跟随
- 序号 `create_new` 原子占名 + 冲突自动递增，并发上传不撞名（起始号对齐 `agent_image_next_name`：现有 png 数 + 1）
- 返回 `{"placeholder":"[Image #n]","path":...}`；限制：>8MB→413、非 POST→405、session 未建立→409

**前端**三入口：📎 按钮（file picker）、输入框粘贴、拖拽。上传中回形针转圈 + hint 文案提示；成功在光标处插入 `[Image #N] `；失败显示既有 errorrow。前端限制 `image/png|jpeg|webp` + 8MB 预检。

## 验证

| 套件 | 结果 |
|------|------|
| 新增 check_features.py（滚动/desktop 统计/mobile 统计/上传成功/409 失败路径） | 23/23 ✓ |
| 旧 check_ui.py（mock WS 全 UI 断言） | 24/24 ✓ |
| 旧 check_replay.py（真实 webagent + events 回放） | 15/15 ✓ |
| 真实 /upload curl：落盘字节 cmp 一致、编号递增、413/405/409 | ✓ |

## 截图

- mobile 统计行：`feat-mobile-stats.png`（见 comment）
- desktop diff 滚动：`feat-desktop-diff.png`（见 comment）
