### PR TITLE
feat(store): conversation 归档——trim 裁剪行落盘 conversation-archive.jsonl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@ c/build/
 c/tools_embed.h
 c/test_classify
 c/test_classify.dSYM/
+c/test_continue
+c/test_continue.dSYM/
+c/test_transport
+c/test_transport.dSYM/
 .bash-agent/
+.worktree/

--- a/c/store.c
+++ b/c/store.c
@@ -17,6 +17,7 @@ void store_session_paths_free(SessionPaths *p) {
     FREE_PTR(p->base_dir);
     FREE_PTR(p->session_dir);
     FREE_PTR(p->conversation);
+    FREE_PTR(p->archive);
     FREE_PTR(p->events);
     FREE_PTR(p->stats);
     FREE_PTR(p->summary);
@@ -95,6 +96,10 @@ SessionPaths store_session_paths_for(const char *home, const char *cwd, const ch
     p.conversation = util_strdup(buf.data);
 
     sb_truncate(&buf, 0);
+    sb_appendf(&buf, "%s/conversation-archive.jsonl", p.session_dir);
+    p.archive = util_strdup(buf.data);
+
+    sb_truncate(&buf, 0);
     sb_appendf(&buf, "%s/events.jsonl", p.session_dir);
     p.events = util_strdup(buf.data);
 
@@ -138,6 +143,7 @@ int store_session_init(const SessionPaths *p, int is_new) {
     if (util_mkdirs(p->session_dir, 0755) != 0) return -1;
     mkdir(store_session_image_dir(p), 0755);
     touch_file(p->conversation);
+    touch_file(p->archive);
     touch_file(p->events);
     touch_file(p->summary);
     touch_file(p->plan);
@@ -186,6 +192,9 @@ int store_session_fork(const SessionPaths *parent, const SessionPaths *child) {
     char *parent_conv = util_read_file(parent->conversation);
     if (parent_conv && strlen(parent_conv) > 0) util_write_file(child->conversation, parent_conv);
     free(parent_conv);
+    char *parent_archive = util_read_file(parent->archive);
+    if (parent_archive && strlen(parent_archive) > 0) util_write_file(child->archive, parent_archive);
+    free(parent_archive);
     char *parent_summary = util_read_file(parent->summary);
     if (parent_summary && strlen(parent_summary) > 0) util_write_file(child->summary, parent_summary);
     free(parent_summary);
@@ -433,13 +442,11 @@ int store_conv_line_count(const char *path, char ***out, int *out_count) {
     ssize_t read_len;
     if (!lines) goto fail;
 
-    /* getline 会按真实换行符扩容，不能将超长 JSONL 记录误当成多行。 */
+    /* 与 Bash 的 wc -l 对齐：每个以 LF 结尾的物理行都是一条记录。
+     * 保留 CR，避免 CRLF 会话在后续裁剪前被规范化。 */
     while ((read_len = getline(&line, &line_cap, f)) != -1) {
-        /* 去除尾部换行 */
-        size_t len = (size_t)read_len;
-        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
-            line[--len] = '\0';
-        if (len == 0) continue;
+        if (read_len == 0 || line[read_len - 1] != '\n') continue;
+        line[read_len - 1] = '\0';
 
         if (count >= cap) {
             int new_cap = cap * 2;
@@ -467,30 +474,59 @@ fail:
     return -1;
 }
 
+static size_t conv_line_end_offset(const char *data, size_t len, int lines) {
+    if (lines <= 0) return 0;
+    int seen = 0;
+    for (size_t i = 0; i < len; i++) {
+        if (data[i] == '\n' && ++seen == lines) return i + 1;
+    }
+    return len;
+}
+
 int store_conv_trim_tail(const char *path, int keep_lines) {
-    char **lines = NULL;
-    int count = 0;
-    if (store_conv_line_count(path, &lines, &count) != 0) return -1;
-    if (keep_lines >= count) {
-        for (int i = 0; i < count; i++) free(lines[i]);
-        free(lines);
+    char *data = util_read_file(path);
+    if (!data) return -1;
+
+    size_t len = strlen(data);
+    int total_lines = 0;
+    for (size_t i = 0; i < len; i++) {
+        if (data[i] == '\n') total_lines++;
+    }
+    if (keep_lines >= total_lines) {
+        free(data);
         return 0;
     }
 
-    /* 重写文件，只保留最后 keep_lines 行 */
-    FILE *f = fopen(path, "w");
+    size_t split_at = conv_line_end_offset(data, len, total_lines - keep_lines);
+
+    /* 先按原始字节追加被裁剪的物理行；归档失败不阻止 Bash 同样会执行的裁剪。 */
+    char *session_dir = util_strdup(path);
+    char *slash = strrchr(session_dir, '/');
+    if (slash) {
+        *slash = '\0';
+        char *archive = util_path_join(session_dir, "conversation-archive.jsonl");
+        FILE *archive_file = fopen(archive, "ab");
+        if (archive_file) {
+            (void)fwrite(data, 1, split_at, archive_file);
+            fclose(archive_file);
+        }
+        free(archive);
+    }
+    free(session_dir);
+
+    FILE *f = fopen(path, "wb");
     if (!f) {
-        for (int i = 0; i < count; i++) free(lines[i]);
-        free(lines);
+        free(data);
         return -1;
     }
-    int start = count - keep_lines;
-    for (int i = start; i < count; i++) {
-        fprintf(f, "%s\n", lines[i]);
+    size_t kept = len - split_at;
+    if (kept > 0 && fwrite(data + split_at, 1, kept, f) != kept) {
+        fclose(f);
+        free(data);
+        return -1;
     }
     fclose(f);
-    for (int i = 0; i < count; i++) free(lines[i]);
-    free(lines);
+    free(data);
     return 0;
 }
 

--- a/c/store.h
+++ b/c/store.h
@@ -22,6 +22,7 @@ typedef struct {
     char *base_dir;         /* ~/.bash-agent/projects/<key>/ */
     char *session_dir;      /* base_dir/<session-id>/ */
     char *conversation;     /* session_dir/conversation.jsonl */
+    char *archive;          /* session_dir/conversation-archive.jsonl */
     char *events;           /* session_dir/events.jsonl */
     char *stats;            /* session_dir/stats.json */
     char *summary;          /* session_dir/summary.md */

--- a/c/test_continue.c
+++ b/c/test_continue.c
@@ -107,6 +107,112 @@ static void test_explicit_sub_session_paths_remain_available(void) {
     free(home);
 }
 
+static void test_conv_trim_archives_and_appends(void) {
+    char *dir = make_temp_dir("conv-archive");
+    char *conversation = util_path_join(dir, "conversation.jsonl");
+    char *archive = util_path_join(dir, "conversation-archive.jsonl");
+    util_write_file(conversation,
+                    "{\"role\":\"user\",\"content\":\"first\"}\n"
+                    "{\"role\":\"assistant\",\"content\":\"second\"}\n"
+                    "{\"role\":\"user\",\"content\":\"third\"}\n");
+
+    int first_trim = store_conv_trim_tail(conversation, 2) == 0;
+    char *archive_data = util_read_file(archive);
+    char *conversation_data = util_read_file(conversation);
+    check(first_trim && archive_data && strstr(archive_data, "first")
+          && !strstr(archive_data, "second") && conversation_data
+          && !strstr(conversation_data, "first") && strstr(conversation_data, "second")
+          && strstr(conversation_data, "third"),
+          "trim archives dropped JSONL before retaining the tail");
+    free(archive_data);
+    free(conversation_data);
+
+    FILE *f = fopen(conversation, "a");
+    if (f) {
+        fprintf(f, "{\"role\":\"assistant\",\"content\":\"fourth\"}\n");
+        fclose(f);
+    }
+    int second_trim = f && store_conv_trim_tail(conversation, 2) == 0;
+    archive_data = util_read_file(archive);
+    check(second_trim && archive_data
+          && strcmp(archive_data,
+                    "{\"role\":\"user\",\"content\":\"first\"}\n"
+                    "{\"role\":\"assistant\",\"content\":\"second\"}\n") == 0,
+          "repeated trims append newly dropped JSONL to the archive");
+
+    free(archive_data);
+    unlink(archive);
+    unlink(conversation);
+    free(archive);
+    free(conversation);
+    rmdir(dir);
+    free(dir);
+}
+
+static void test_conv_trim_preserves_raw_bytes(void) {
+    char *dir = make_temp_dir("conv-archive-raw");
+    char *conversation = util_path_join(dir, "conversation.jsonl");
+    char *archive = util_path_join(dir, "conversation-archive.jsonl");
+    const char *input = "{\"role\":\"user\",\"content\":\"first\"}\r\n\r\n"
+                        "{\"role\":\"assistant\",\"content\":\"second\"}\r\n"
+                        "{\"role\":\"user\",\"content\":\"third\"}\r\n";
+    const char *dropped = "{\"role\":\"user\",\"content\":\"first\"}\r\n\r\n";
+    const char *kept = "{\"role\":\"assistant\",\"content\":\"second\"}\r\n"
+                       "{\"role\":\"user\",\"content\":\"third\"}\r\n";
+    util_write_file(conversation, input);
+
+    int trimmed = store_conv_trim_tail(conversation, 2) == 0;
+    char *archive_data = util_read_file(archive);
+    char *conversation_data = util_read_file(conversation);
+    check(trimmed && archive_data && conversation_data
+          && strcmp(archive_data, dropped) == 0 && strcmp(conversation_data, kept) == 0,
+          "trim preserves dropped and retained JSONL bytes including CRLF and blank lines");
+
+    free(conversation_data);
+    free(archive_data);
+    unlink(archive);
+    unlink(conversation);
+    free(archive);
+    free(conversation);
+    rmdir(dir);
+    free(dir);
+}
+
+static void test_session_fork_copies_archive(void) {
+    char *home = make_temp_dir("fork-archive");
+    char *cwd = util_path_join(home, "project");
+    util_mkdirs(cwd, 0755);
+    SessionPaths parent = store_session_paths_for(home, cwd, "parent");
+    SessionPaths child = store_session_paths_for(home, cwd, "child");
+
+    int initialized = store_session_init(&parent, 1) == 0;
+    int archive_created = initialized && access(parent.archive, F_OK) == 0;
+    util_write_file(parent.conversation, "conversation\n");
+    util_write_file(parent.archive, "archive\n");
+    util_write_file(parent.summary, "summary\n");
+    util_write_file(parent.plan, "plan\n");
+
+    int forked = initialized && store_session_fork(&parent, &child) == 0;
+    char *conversation = util_read_file(child.conversation);
+    char *archive = util_read_file(child.archive);
+    char *summary = util_read_file(child.summary);
+    char *plan = util_read_file(child.plan);
+    check(archive_created && forked && conversation && archive && summary && plan
+          && strcmp(conversation, "conversation\n") == 0
+          && strcmp(archive, "archive\n") == 0
+          && strcmp(summary, "summary\n") == 0 && strcmp(plan, "plan\n") == 0,
+          "session fork copies archive with conversation, summary, and plan");
+
+    free(plan);
+    free(summary);
+    free(archive);
+    free(conversation);
+    store_session_paths_free(&child);
+    store_session_paths_free(&parent);
+    free(cwd);
+    free(home);
+}
+
 static void test_conv_long_line_survives_trim(void) {
     char *dir = make_temp_dir("conv-long-line");
     char *path = util_path_join(dir, "conversation.jsonl");
@@ -162,6 +268,9 @@ int main(void) {
     test_continue_skips_sub_sessions();
     test_continue_rejects_only_sub_sessions();
     test_explicit_sub_session_paths_remain_available();
+    test_conv_trim_archives_and_appends();
+    test_conv_trim_preserves_raw_bytes();
+    test_session_fork_copies_archive();
     test_conv_long_line_survives_trim();
     return failures == 0 ? 0 : 1;
 }

--- a/c/transport.c
+++ b/c/transport.c
@@ -1099,11 +1099,14 @@ char *build_claude_request(const char *model, const char *system_prompt,
     sb_append(&buf, "{\"max_tokens\":");
     sb_appendf(&buf, "%d", max_tokens);
 
-    /* messages */
+    /* messages：与 Bash store_conv_get_messages 对齐，跳过空物理行。 */
     sb_append(&buf, ",\"messages\":[");
+    int first_message = 1;
     for (int i = 0; i < conv_line_count; i++) {
-        if (i > 0) sb_append(&buf, ",");
+        if (!conv_lines[i] || conv_lines[i][0] == '\0') continue;
+        if (!first_message) sb_append(&buf, ",");
         sb_append(&buf, conv_lines[i]);
+        first_message = 0;
     }
     sb_append(&buf, "]");
 

--- a/go/agent_test.go
+++ b/go/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -416,6 +417,9 @@ func TestFileStoreInit(t *testing.T) {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		t.Error("session dir should exist")
 	}
+	if _, err := os.Stat(filepath.Join(store.sessionDir, "conversation-archive.jsonl")); err != nil {
+		t.Errorf("archive file should be pre-created: %v", err)
+	}
 }
 
 func TestFileStoreResolveContinueSkipsSubSessions(t *testing.T) {
@@ -594,10 +598,73 @@ func TestFileStorePlan(t *testing.T) {
 	}
 }
 
+func TestFileStoreConvTrimTailArchivesDroppedMessages(t *testing.T) {
+	store := newTestStore(t)
+	first := `{"role":"user","content":"first"}`
+	second := `{"role":"assistant","content":"answer"}`
+	third := `{"role":"user","content":"second"}`
+	if err := os.WriteFile(store.convFile, []byte(first+"\n"+second+"\n"+third+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(store.archiveFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.ConvTrimTail(2); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ConvTrimTail(1); err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := os.ReadFile(store.archiveFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := first + "\n" + second + "\n"; string(archive) != want {
+		t.Fatalf("archive = %q, want %q", archive, want)
+	}
+	conversation, err := os.ReadFile(store.convFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := third + "\n"; string(conversation) != want {
+		t.Fatalf("conversation = %q, want %q", conversation, want)
+	}
+}
+
+func TestFileStoreConvTrimTailPreservesRawBytes(t *testing.T) {
+	store := newTestStore(t)
+	input := []byte("{\"role\":\"user\",\"content\":\"first\"}\r\n\r\n{\"role\":\"assistant\",\"content\":\"second\"}\r\n{\"role\":\"user\",\"content\":\"third\"}\r\n")
+	dropped := []byte("{\"role\":\"user\",\"content\":\"first\"}\r\n\r\n")
+	kept := []byte("{\"role\":\"assistant\",\"content\":\"second\"}\r\n{\"role\":\"user\",\"content\":\"third\"}\r\n")
+	if err := os.WriteFile(store.convFile, input, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ConvTrimTail(2); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := os.ReadFile(store.archiveFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := os.ReadFile(store.convFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(archive, dropped) || !bytes.Equal(conversation, kept) {
+		t.Fatalf("archive = %q, conversation = %q", archive, conversation)
+	}
+}
+
 func TestFileStoreFork(t *testing.T) {
 	store := newTestStore(t)
 	_ = store.AddUserMessage("parent message")
 	_ = store.SetSummary("parent summary")
+	archive := `{"role":"user","content":"archived"}` + "\n"
+	if err := os.WriteFile(store.archiveFile, []byte(archive), 0644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
 
 	// parent session 目录
 	parentSessionDir := filepath.Join(store.GetDir(), store.SessionID())
@@ -626,6 +693,11 @@ func TestFileStoreFork(t *testing.T) {
 	summary, _ := childStore.GetSummary()
 	if strings.TrimSpace(summary) != "parent summary" {
 		t.Errorf("child summary = %q, want 'parent summary'", summary)
+	}
+
+	copied, err := os.ReadFile(filepath.Join(childSessionDir, "conversation-archive.jsonl"))
+	if err != nil || string(copied) != archive {
+		t.Fatalf("child archive = %q, want %q (err=%v)", copied, archive, err)
 	}
 }
 

--- a/go/store.go
+++ b/go/store.go
@@ -26,6 +26,7 @@ type FileStore struct {
 
 	// 文件路径（Init 后填充）
 	convFile      string
+	archiveFile   string
 	eventFile     string
 	summaryFile   string
 	planFile      string
@@ -171,6 +172,7 @@ func (s *FileStore) Init(sessionID string) error {
 	}
 
 	s.convFile = filepath.Join(dir, "conversation.jsonl")
+	s.archiveFile = filepath.Join(dir, "conversation-archive.jsonl")
 	s.eventFile = filepath.Join(dir, "events.jsonl")
 	s.summaryFile = filepath.Join(dir, "summary.txt")
 	s.planFile = filepath.Join(dir, "plan.md")
@@ -182,7 +184,7 @@ func (s *FileStore) Init(sessionID string) error {
 	if fi, err := os.Stat(s.eventFile); err != nil || fi.Size() == 0 {
 		newSession = true
 	}
-	for _, f := range []string{s.convFile, s.eventFile, s.summaryFile, s.planFile, s.planDraftFile} {
+	for _, f := range []string{s.convFile, s.archiveFile, s.eventFile, s.summaryFile, s.planFile, s.planDraftFile} {
 		file, err := os.OpenFile(f, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 		if err != nil {
 			return fmt.Errorf("touch %s: %w", f, err)
@@ -212,7 +214,7 @@ func (s *FileStore) Init(sessionID string) error {
 
 func (s *FileStore) Fork(parentDir, childDir string) error {
 	os.MkdirAll(childDir, 0755)
-	for _, name := range []string{"conversation.jsonl", "summary.txt", "plan.md"} {
+	for _, name := range []string{"conversation.jsonl", "conversation-archive.jsonl", "summary.txt", "plan.md"} {
 		src := filepath.Join(parentDir, name)
 		dst := filepath.Join(childDir, name)
 		data, err := os.ReadFile(src)
@@ -418,7 +420,7 @@ func (s *FileStore) ConvLineCount() (int, error) {
 	if err != nil {
 		return 0, nil
 	}
-	return len(splitNonEmpty(string(data))), nil
+	return strings.Count(string(data), "\n"), nil
 }
 
 func (s *FileStore) ConvHeadTo(n int) (string, error) {
@@ -426,11 +428,7 @@ func (s *FileStore) ConvHeadTo(n int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	lines := splitNonEmpty(string(data))
-	if n > len(lines) {
-		n = len(lines)
-	}
-	return strings.Join(lines[:n], "\n") + "\n", nil
+	return string(data[:lineEndOffset(data, n)]), nil
 }
 
 func (s *FileStore) ConvTrimTail(n int) error {
@@ -438,12 +436,19 @@ func (s *FileStore) ConvTrimTail(n int) error {
 	if err != nil {
 		return err
 	}
-	lines := splitNonEmpty(string(data))
-	if n > len(lines) {
-		n = len(lines)
+	totalLines := strings.Count(string(data), "\n")
+	if n >= totalLines {
+		return nil
 	}
-	keep := lines[len(lines)-n:]
-	return os.WriteFile(s.convFile, []byte(strings.Join(keep, "\n")+"\n"), 0644)
+
+	splitAt := lineEndOffset(data, totalLines-n)
+	archive, err := os.OpenFile(s.archiveFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err == nil {
+		_, _ = archive.Write(data[:splitAt])
+		_ = archive.Close()
+	}
+
+	return os.WriteFile(s.convFile, data[splitAt:], 0644)
 }
 
 func (s *FileStore) ConvUserTurnCount() (int, error) {
@@ -1041,6 +1046,22 @@ func splitNonEmpty(s string) []string {
 		}
 	}
 	return result
+}
+
+func lineEndOffset(data []byte, lines int) int {
+	if lines <= 0 {
+		return 0
+	}
+	seen := 0
+	for i, b := range data {
+		if b == '\n' {
+			seen++
+			if seen == lines {
+				return i + 1
+			}
+		}
+	}
+	return len(data)
 }
 
 func pathToProjectKey(absPath string) string {

--- a/rust/src/agent.rs
+++ b/rust/src/agent.rs
@@ -673,6 +673,7 @@ impl Agent {
             .unwrap_or(true);
         for f in [
             &paths.conversation,
+            &paths.archive,
             &paths.events,
             &paths.summary,
             &paths.plan,

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -255,6 +255,7 @@ pub fn store_session_init(paths: &Paths, new_session: bool) -> Result<()> {
     fs::create_dir_all(&img_dir)?;
     for path in [
         &paths.conversation,
+        &paths.archive,
         &paths.events,
         &paths.summary,
         &paths.plan,
@@ -272,8 +273,9 @@ pub fn store_session_init(paths: &Paths, new_session: bool) -> Result<()> {
 
 pub fn store_session_fork(parent: &Paths, child: &Paths) -> Result<()> {
     fs::create_dir_all(&child.session_dir)?; // 先建目录（对齐 Bash mkdir -p）
-    let files_to_copy: [(&Path, &Path); 3] = [
+    let files_to_copy: [(&Path, &Path); 4] = [
         (&parent.conversation, &child.conversation),
+        (&parent.archive, &child.archive),
         (&parent.summary, &child.summary),
         (&parent.plan, &child.plan),
     ];
@@ -353,7 +355,7 @@ pub fn store_conv_total_bytes(path: &Path) -> Result<usize> {
 }
 
 pub fn store_conv_total_lines(path: &Path) -> Result<usize> {
-    Ok(store_conv_lines(path)?.len())
+    Ok(fs::read(path)?.iter().filter(|&&b| b == b'\n').count())
 }
 
 pub fn store_conv_count_user_inputs(path: &Path) -> Result<usize> {
@@ -368,19 +370,44 @@ pub fn store_conv_count_user_inputs(path: &Path) -> Result<usize> {
 }
 
 pub fn store_conv_trim_keep_last(path: &Path, keep_lines: usize) -> Result<()> {
-    let data = fs::read_to_string(path)?;
-    let raw_lines: Vec<&str> = data.lines().filter(|l| !l.trim().is_empty()).collect();
-    if keep_lines >= raw_lines.len() {
+    let data = fs::read(path)?;
+    let total_lines = data.iter().filter(|&&b| b == b'\n').count();
+    if keep_lines >= total_lines {
         return Ok(());
     }
-    let kept = &raw_lines[raw_lines.len() - keep_lines..];
-    let mut out = String::new();
-    for line in kept {
-        out.push_str(line);
-        out.push('\n');
+
+    let split_at = line_end_offset(&data, total_lines - keep_lines);
+    let archive = path
+        .parent()
+        .expect("conversation path must have a parent")
+        .join("conversation-archive.jsonl");
+    if let Ok(mut archive_file) = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(archive)
+    {
+        use std::io::Write;
+        let _ = archive_file.write_all(&data[..split_at]);
     }
-    fs::write(path, out)?;
+
+    fs::write(path, &data[split_at..])?;
     Ok(())
+}
+
+fn line_end_offset(data: &[u8], lines: usize) -> usize {
+    if lines == 0 {
+        return 0;
+    }
+    let mut seen = 0;
+    for (idx, byte) in data.iter().enumerate() {
+        if *byte == b'\n' {
+            seen += 1;
+            if seen == lines {
+                return idx + 1;
+            }
+        }
+    }
+    data.len()
 }
 
 pub fn store_conv_keep_line_count(path: &Path, target_bytes: usize) -> Result<usize> {
@@ -565,6 +592,7 @@ pub struct Paths {
     pub base_dir: PathBuf,
     pub session_dir: PathBuf,
     pub conversation: PathBuf,
+    pub archive: PathBuf,
     pub events: PathBuf,
     pub summary: PathBuf,
     pub plan: PathBuf,
@@ -601,6 +629,7 @@ pub fn paths_for(home: &std::path::Path, cwd: &std::path::Path, session_id: &str
         base_dir: project_dir,
         session_dir: session_dir.clone(),
         conversation: session_dir.join("conversation.jsonl"),
+        archive: session_dir.join("conversation-archive.jsonl"),
         events: session_dir.join("events.jsonl"),
         summary: session_dir.join("summary.txt"),
         plan: session_dir.join("plan.md"),
@@ -650,6 +679,109 @@ fn session_activity_mod_time(session_dir: &std::path::Path) -> Result<std::time:
         return Ok(meta.modified()?);
     }
     Ok(fs::metadata(session_dir)?.modified()?)
+}
+
+#[cfg(test)]
+mod archive_tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_paths() -> (PathBuf, Paths) {
+        let home = std::env::temp_dir().join(format!(
+            "rustagent-archive-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let paths = paths_for(&home, &home.join("project"), "session");
+        (home, paths)
+    }
+
+    #[test]
+    fn trim_archives_dropped_lines_and_appends_on_repeat() {
+        let (home, paths) = test_paths();
+        store_session_init(&paths, true).unwrap();
+        assert!(paths.archive.exists());
+        fs::write(
+            &paths.conversation,
+            "{\"role\":\"user\",\"content\":\"first\"}\n{\"role\":\"assistant\",\"content\":\"second\"}\n{\"role\":\"user\",\"content\":\"third\"}\n",
+        )
+        .unwrap();
+
+        store_conv_trim_keep_last(&paths.conversation, 2).unwrap();
+        assert!(paths.archive.exists());
+        assert_eq!(
+            fs::read_to_string(&paths.archive).unwrap(),
+            "{\"role\":\"user\",\"content\":\"first\"}\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&paths.conversation).unwrap(),
+            "{\"role\":\"assistant\",\"content\":\"second\"}\n{\"role\":\"user\",\"content\":\"third\"}\n"
+        );
+
+        store_conv_trim_keep_last(&paths.conversation, 1).unwrap();
+        assert_eq!(
+            fs::read_to_string(&paths.archive).unwrap(),
+            "{\"role\":\"user\",\"content\":\"first\"}\n{\"role\":\"assistant\",\"content\":\"second\"}\n"
+        );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn trim_preserves_raw_bytes_in_archive_and_conversation() {
+        let (home, paths) = test_paths();
+        fs::create_dir_all(&paths.session_dir).unwrap();
+        let input = b"{\"role\":\"user\",\"content\":\"first\"}\r\n\r\n{\"role\":\"assistant\",\"content\":\"second\"}\r\n{\"role\":\"user\",\"content\":\"third\"}\r\n";
+        let dropped = b"{\"role\":\"user\",\"content\":\"first\"}\r\n\r\n";
+        let kept = b"{\"role\":\"assistant\",\"content\":\"second\"}\r\n{\"role\":\"user\",\"content\":\"third\"}\r\n";
+        fs::write(&paths.conversation, input).unwrap();
+
+        store_conv_trim_keep_last(&paths.conversation, 2).unwrap();
+
+        assert_eq!(fs::read(&paths.archive).unwrap(), dropped);
+        assert_eq!(fs::read(&paths.conversation).unwrap(), kept);
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn trim_creates_missing_archive_for_legacy_session() {
+        let (home, paths) = test_paths();
+        fs::create_dir_all(&paths.session_dir).unwrap();
+        fs::write(
+            &paths.conversation,
+            "{\"role\":\"user\"}\n{\"role\":\"assistant\"}\n",
+        )
+        .unwrap();
+
+        store_conv_trim_keep_last(&paths.conversation, 1).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&paths.archive).unwrap(),
+            "{\"role\":\"user\"}\n"
+        );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn fork_copies_archive() {
+        let (home, parent) = test_paths();
+        let child = paths_for(&home, &home.join("project"), "child");
+        store_session_init(&parent, true).unwrap();
+        fs::write(
+            &parent.archive,
+            "{\"role\":\"user\",\"content\":\"archived\"}\n",
+        )
+        .unwrap();
+
+        store_session_fork(&parent, &child).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(child.archive).unwrap(),
+            "{\"role\":\"user\",\"content\":\"archived\"}\n"
+        );
+        let _ = fs::remove_dir_all(home);
+    }
 }
 
 #[cfg(test)]

--- a/src/agent.sh
+++ b/src/agent.sh
@@ -354,7 +354,7 @@ store_session_init() {
     PLAN_DRAFT_FILE="${session_dir}/plan.draft"
     STATS_FILE="${session_dir}/stats.json"
     [[ ! -s "$SESSION_EVENT_FILE" ]] && new_session=true
-    touch "$CONV_FILE" "$SESSION_EVENT_FILE" "$CONTEXT_SUMMARY_FILE" "$PLAN_FILE" "$PLAN_DRAFT_FILE" "$STATS_FILE"
+    touch "$CONV_FILE" "$SESSION_EVENT_FILE" "$CONTEXT_SUMMARY_FILE" "$PLAN_FILE" "$PLAN_DRAFT_FILE" "$STATS_FILE" "${session_dir}/conversation-archive.jsonl"
     mkdir -p "${session_dir}/images" 2>/dev/null || true
     if [[ "$new_session" == true ]]; then
         store_event_append "{\"type\":\"session_start\",\"session_id\":\"$(util_json_escape "$SESSION_ID")\"}"
@@ -371,7 +371,7 @@ store_session_init() {
 store_session_fork() {
     local parent_dir="$1" child_dir="$2"
     mkdir -p "$child_dir"
-    cp "$parent_dir"/{conversation.jsonl,summary.txt,plan.md} "$child_dir/" 2>/dev/null || true
+    cp "$parent_dir"/{conversation.jsonl,conversation-archive.jsonl,summary.txt,plan.md} "$child_dir/" 2>/dev/null || true
 }
 
 store_session_get_dir() {
@@ -489,6 +489,7 @@ store_conv_head_to() { head -n "$1" "$CONV_FILE" > "$2"; } # $1=lines, $2=outfil
 store_conv_trim_tail() {
     # $1=lines to keep from tail
     local tmp; tmp=$(mktemp "${TMPDIR:-/tmp}/conv_trim.XXXXXX")
+    head -n "$(( $(store_conv_line_count) - $1 ))" "$CONV_FILE" >> "${CONV_FILE%/*}/conversation-archive.jsonl"
     tail -n "$1" "$CONV_FILE" > "$tmp"
     mv "$tmp" "$CONV_FILE"
 }

--- a/tests/fixtures/mock_server.py
+++ b/tests/fixtures/mock_server.py
@@ -1703,5 +1703,5 @@ t = threading.Thread(target=httpd.serve_forever)
 t.daemon = True
 t.start()
 import time
-time.sleep(120)
+time.sleep(600)
 httpd.shutdown()

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2011,6 +2011,7 @@ test_agent_fork_session() {
     mkdir -p "$src_dir/images"
     printf '{"role":"user","content":"original question"}\n{"role":"assistant","content":"original answer"}\n' > "$src_dir/conversation.jsonl"
     printf 'original summary' > "$src_dir/summary.txt"
+    printf '{"role":"user","content":"archived message"}\n' > "$src_dir/conversation-archive.jsonl"
     printf '# original plan' > "$src_dir/plan.md"
     printf '{"type":"session_start","session_id":"%s"}\n' "$src_id" > "$src_dir/events.jsonl"
 
@@ -2045,6 +2046,13 @@ test_agent_fork_session() {
         green "fork: events.jsonl is fresh (no source events leaked)"; ((PASS++)) || true
     else
         red "fork: source events leaked into forked session"; ((FAIL++)) || true
+    fi
+
+    # 验证：归档文件继承
+    if grep -q "archived message" "$proj_dir/$new_id/conversation-archive.jsonl" 2>/dev/null; then
+        green "fork: conversation archive inherited"; ((PASS++)) || true
+    else
+        red "fork: conversation archive NOT inherited"; ((FAIL++)) || true
     fi
 
     # 验证：源 session conversation 未被修改
@@ -2473,6 +2481,14 @@ test_agent_compact_context() {
         green "agent_compact_context: conv trimmed ($original_lines -> $post_lines lines)"; ((PASS++)) || true
     else
         red "agent_compact_context: conv NOT trimmed ($original_lines -> $post_lines lines)"; echo "  Output: $output"; ((FAIL++)) || true
+    fi
+
+    # Verify: archive contains exactly the dropped original messages
+    local archive_file="${session_dir}/conversation-archive.jsonl"
+    if [[ -s "$archive_file" ]] && grep -q '"step 1 of compact test' "$archive_file" && ! grep -q '"step 20 of compact test' "$archive_file"; then
+        green "agent_compact_context: archive contains dropped messages"; ((PASS++)) || true
+    else
+        red "agent_compact_context: archive missing or contains wrong messages"; echo "  Archive: $(cat "$archive_file" 2>/dev/null || echo 'N/A')"; ((FAIL++)) || true
     fi
 
     # Verify: summary file created with expected content


### PR DESCRIPTION
## 概要

compact 裁剪掉的 conversation 行不再丢弃，归档到 `session_dir/conversation-archive.jsonl`；SubAgent fork 继承归档文件。

## 改动（Bash/C/Go/Rust 四版本同步）

- **session init**：touch `conversation-archive.jsonl`
- **SubAgent fork**：归档随 `conversation.jsonl / summary / plan` 一并拷贝
- **`store_conv_trim_tail`**：trim 前把被裁剪行追加进归档（Bash `head -n $((total-keep)) >> archive`）
- **C `build_claude_request`**：跳过空物理行，与 Bash `store_conv_get_messages` 对齐（请求体一致性）
- **Rust `store_conv_total_lines`**：改字节扫描计数；trim 重写避免 >64KiB 的 JSONL 记录被拆行

## 测试

- bash e2e：226/226（新增 fork 归档继承、compact 归档内容断言）
- Go：单测全过 + e2e 226/226
- Rust：e2e 226/226
- C：e2e 226/226 + test-continue 9/9 + test-transport 37/37

## 顺带修复

- `go/agent_test.go` 缺 `bytes` import（编译失败）
- `tests/fixtures/mock_server.py` 存活 120s→600s：bash 版全套约 4 分钟，server 中途自杀导致后半段 10 个 mock 依赖测试连坐失败
