### PR TITLE
feat: APT 源聚合 mcpc/oapi，新增手动 republish workflow

### DIFF
--- a/.github/workflows/apt-republish.yml
+++ b/.github/workflows/apt-republish.yml
@@ -1,0 +1,61 @@
+name: APT Republish
+
+# 手动重发 apt 源：聚合 bash-agent / mcpc / oapi 三个仓库最新 release 的
+# deb，全量重建 APT 仓库并部署到 GitHub Pages（lloydzhou.github.io/bash-agent）。
+#
+# 使用场景：mcpc / oapi 发新版本后，手动跑一次本 workflow 即可刷新源内
+# 对应包（bash-agent 自身发版走 ci.yml release job，已含聚合逻辑）。
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 与 ci.yml release job 的 Pages 部署互斥，避免互相覆盖
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  republish:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch latest debs from all repos
+        run: bash scripts/apt/fetch-debs.sh dist
+
+      - name: Build APT repository and site
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gnupg 2>&1 | tail -1
+          # 版本号仅作 control 缺 Version 字段时的兜底，实际以 deb 内 control 为准
+          version="$(git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)"
+          bash scripts/apt/build-apt-repo.sh "$version" dist apt-repo
+          # 组装 Pages 站点根：官网（site/）+ apt 仓库（debian/）+ install.sh
+          cp -r site/. apt-repo/
+          cp scripts/install-apt.sh apt-repo/install.sh
+          find apt-repo -maxdepth 2 | sort
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apt-repo
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,9 @@ jobs:
             dist/bash-agent_*_amd64.deb
             dist/bash-agent_*_arm64.deb
 
+      - name: Fetch mcpc/oapi debs for aggregate apt repo
+        run: bash scripts/apt/fetch-debs.sh dist lloydzhou/mcpc lloydzhou/oapi
+
       - name: Build APT repository and site
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -540,7 +543,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y -qq gnupg 2>&1 | tail -1
-          bash scripts/build-apt-repo.sh "${{ github.ref_name }}" dist apt-repo
+          bash scripts/apt/build-apt-repo.sh "${{ github.ref_name }}" dist apt-repo
           # 组装 Pages 站点根：官网（site/）+ apt 仓库（debian/）+ install.sh
           cp -r site/. apt-repo/
           cp scripts/install-apt.sh apt-repo/install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@
 ## [Unreleased]
 
 > **conversation 归档**：compact 裁剪的对话行落盘 `conversation-archive.jsonl`，SubAgent fork 一并继承；四个运行时同步实现。
+>
+> **APT 源聚合**：源内新增 mcpc / oapi 两个包（deb 由各自仓库发布），新增手动 republish workflow。
 
 ### Added
+
+- **APT 源聚合三仓库**：`scripts/build-apt-repo.sh` 迁移至 `scripts/apt/build-apt-repo.sh` 并泛化为收集目录下全部 `*_{amd64,arm64}.deb`；新增 `scripts/apt/fetch-debs.sh` 从 lloydzhou/{bash-agent,mcpc,oapi} 最新 release 下载 deb（公开仓库匿名 API，任一仓库缺 deb 资产即中止，防止发布缺包的源）。ci.yml release job 构建源前先拉取 mcpc/oapi deb；新增 `.github/workflows/apt-republish.yml`（仅 `workflow_dispatch`），聚合三仓库全量重建并部署 Pages——mcpc/oapi 发新版后手动跑一次即可刷新源。
 
 - **conversation 归档**（PR #90）：`store_conv_trim_tail` 在裁剪前把被丢弃的 conversation 行追加到 `session_dir/conversation-archive.jsonl`；session 初始化时 touch 归档文件，SubAgent fork 时随 conversation/summary/plan 一并拷贝。Bash / C / Go / Rust 四版本同步。
 - **测试**：bash e2e 新增 fork 归档继承与 compact 归档内容断言；C `test-continue` 扩展至 9 例（重复 trim 追加、CRLF/空行字节保真、>64KiB 大记录不拆行、fork 拷贝）；Go 单测扩展归档场景。

--- a/scripts/apt/build-apt-repo.sh
+++ b/scripts/apt/build-apt-repo.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# 从 dist/ 目录中的 .deb 构建标准 apt 仓库，输出到 apt-repo/。
-# 用法：scripts/build-apt-repo.sh <version> [deb_dir] [out_dir] [repo_slug]
+# 从 deb_dir 中的 .deb 构建标准 apt 仓库，输出到 out_dir。
+# 用法：scripts/apt/build-apt-repo.sh <version> [deb_dir] [out_dir] [repo_slug]
+#
+# 聚合模式：收集目录下所有 *_amd64.deb / *_arm64.deb（bash-agent + mcpc +
+# oapi，由 scripts/apt/fetch-debs.sh 下载或 CI 本地构建产物提供）。
 #
 # .deb 文件存放于仓库内 pool/ 目录（部署走 Pages artifact，不进任何 git 分支）。
 # Packages 索引的 Filename 字段使用相对路径（apt 所有版本均不支持绝对 URL，
@@ -32,9 +35,9 @@ REPO_DIR="$OUT_DIR/debian"
 rm -rf "$OUT_DIR"
 mkdir -p "$REPO_DIR/dists/stable"
 
-# 收集 .deb 文件名（只收架构包）
+# 收集 .deb 文件名（只收架构包，任意来源：bash-agent / mcpc / oapi）
 shopt -s nullglob
-debs=( "$DEB_DIR"/bash-agent_*_amd64.deb "$DEB_DIR"/bash-agent_*_arm64.deb )
+debs=( "$DEB_DIR"/*_amd64.deb "$DEB_DIR"/*_arm64.deb )
 shopt -u nullglob
 if (( ${#debs[@]} == 0 ));then
   echo "错误：$DEB_DIR 中没有架构 .deb 文件（*_amd64.deb / *_arm64.deb）" >&2

--- a/scripts/apt/fetch-debs.sh
+++ b/scripts/apt/fetch-debs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# 从各仓库 GitHub Releases 下载最新版本的 .deb 到指定目录（聚合 apt 源用）。
+# 用法：scripts/apt/fetch-debs.sh <out_dir> [repo_slug ...]
+#
+# 默认聚合三个仓库：bash-agent / mcpc / oapi；也可显式传仓库列表，
+# 例如 release job 本地已有 bash-agent deb 时只拉另外两个：
+#   scripts/apt/fetch-debs.sh dist lloydzhou/mcpc lloydzhou/oapi
+#
+# 公开仓库匿名 API 即可读取（CI 中无需 PAT）；可选设置 GITHUB_TOKEN（PAT）
+# 提升 API 限流。任一指定仓库的 latest release 缺少 deb 资产时报错退出，
+# 防止发布缺包的源。
+
+set -euo pipefail
+
+OUT_DIR="${1:-dist}"
+shift || true
+REPOS=("$@")
+(( ${#REPOS[@]} > 0 )) || REPOS=(lloydzhou/bash-agent lloydzhou/mcpc lloydzhou/oapi)
+
+mkdir -p "$OUT_DIR"
+
+api_curl() {
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$@"
+  else
+    curl -fsSL "$@"
+  fi
+}
+
+total=0
+for repo in "${REPOS[@]}"; do
+  echo "==> $repo 最新 release 的 deb"
+  urls="$(api_curl "https://api.github.com/repos/$repo/releases/latest" \
+    | grep -o '"browser_download_url": *"[^"]*"' \
+    | sed 's/"browser_download_url": *"//; s/"$//' \
+    | grep -E '_(amd64|arm64)\.deb$' || true)"
+  if [[ -z "$urls" ]]; then
+    echo "错误：$repo 的 latest release 没有 amd64/arm64 deb 资产，中止（防止发布缺包的源）" >&2
+    exit 1
+  fi
+  count=0
+  for url in $urls; do
+    name="$(basename "$url")"
+    curl -fsSL -o "$OUT_DIR/$name" "$url"
+    echo "    下载 $name"
+    count=$((count + 1))
+  done
+  total=$((total + count))
+done
+
+echo "==> 共下载 $total 个 deb 到 $OUT_DIR"


### PR DESCRIPTION
## 概述

APT 源（`lloydzhou.github.io/bash-agent/debian`）从单包（bash-agent）升级为聚合三仓库：**bash-agent + mcpc + oapi**。源地址不变，已配置的老机器零感知，`apt install mcpc oapi` 直接可用。

## 改动

| 文件 | 说明 |
|------|------|
| `scripts/apt/build-apt-repo.sh` | 原 `scripts/build-apt-repo.sh\} 迁移；deb 收集从 `bash-agent_*_{amd64,arm64}.deb` 泛化为 `*_{amd64,arm64}.deb` |
| `scripts/apt/fetch-debs.sh` | 新增。从 `lloydzhou/{bash-agent,mcpc,oapi}` 最新 release 下载 deb（公开仓库匿名 API 即可，无需 PAT）；支持显式传仓库列表；任一仓库缺 deb 资产即报错中止，**防止发布缺包的源** |
| `.github/workflows/ci.yml` | release job 建源前先 `fetch-debs.sh dist lloydzhou/mcpc lloydzhou/oapi`（bash-agent 用本地刚构建的 deb，避免 latest API 延迟导致版本回退） |
| `.github/workflows/apt-republish.yml` | 新增，仅 `workflow_dispatch`：聚合三仓库 → 全量重建源（GPG 签名沿用现有 secrets）→ 部署 Pages。`mcpc`/`oapi` 发新版后手动跑一次即刷新源内对应包 |

## 设计要点

- **幂等全量重建**：源每次从 dist 全量生成（pool 无历史版本），聚合 = 扩 glob + 下载，无增量合并复杂度
- **双写路径一致**：tag 发版（ci.yml）与手动 republish 走同一套脚本，源内永远三包齐全，不存在覆盖竞争
- **concurrency `group: pages`**：与 release job 的 Pages 部署互斥排队
- **GPG secrets 无需复制**：republish 在 bash-agent 仓库内运行，直接用现有 secrets

## 依赖

mcpc / oapi 侧需先合入各自 deb 打包 PR 并发 v0.1.1（deb 加入 release assets），否则 `fetch-debs.sh` 会按设计中止。

## 本地验证

- `fetch-debs.sh .apt-test lloydzhou/bash-agent`：成功下载 4.3.7 双架构 deb
- `fetch-debs.sh` 对无 deb 资产的 mcpc：正确报错退出（exit 1）
- 泛化后 `build-apt-repo.sh` 用真实 bash-agent deb 干跑：Packages/Release/pool/cnf 结构与线上源一致